### PR TITLE
Ensure make build works correctly inside Docker containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,16 @@ export CGO_ENABLED=0
 
 .PHONY: build
 
-build:
+deps:
+	dep ensure -v
+
+build: deps
 	export GOOS=linux
 	export GOARCH=amd64
-	dep ensure -v
 	go build -o build/_output/onos-config-manager ./cmd/onos-config-manager
 
-run:
-	dep ensure -v
+test: deps
+	go test github.com/onosproject/onos-config/...
+
+run: deps
 	go run cmd/onos-config-manager/config-manager.go

--- a/cmd/profiling/profile-config.go
+++ b/cmd/profiling/profile-config.go
@@ -26,7 +26,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/opennetworkinglab/onos-config/pkg"
+	"github.com/onosproject/onos-config/pkg/store/change"
 	"os"
 	"runtime/pprof"
 	"strconv"
@@ -42,16 +42,16 @@ func main() {
 	defer pprof.StopCPUProfile()
 
 
-	changeValues := pkg.ValueCollections{}
+	changeValues := change.ValueCollections{}
 	iterations := 50000
 
 	for i := 0; i < iterations; i++ {
 		path := fmt.Sprintf("/test%d", i)
-		cv, _ := pkg.CreateChangeValue(path, strconv.Itoa(i), false)
+		cv, _ := change.CreateChangeValue(path, strconv.Itoa(i), false)
 		changeValues = append(changeValues, cv)
 	}
 
-	change, err := pkg.CreateChange(changeValues, "Benchmarked Change")
+	change, err := change.CreateChange(changeValues, "Benchmarked Change")
 
 	err = change.IsValid()
 	if err != nil {


### PR DESCRIPTION
To build the Docker image:
```
docker build -t onos-config:0.1 build/dev-docker
```
To run the Docker image:
```
docker run -it -v `pwd`:/go/src/github.com/opennetworkinglab/onos-config onos-config:0.1 ...
```
The arguments to the image are:
* `build` - build an executable
* `test` - run tests
* `run` - run the config manager