### PR TITLE
Add Helm chart

### DIFF
--- a/deployments/helm/.helmignore
+++ b/deployments/helm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/deployments/helm/Chart.yaml
+++ b/deployments/helm/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1alpha1
+name: onos-config-manager
+version: 0.0.1
+kubeVersion: ">=1.12.0"
+appVersion: 0.0.1
+description: ONOS Config Manager
+keywords:
+  - onos
+  - sdn
+home: https://onosproject.org
+maintainers:
+  - name: tomakazi
+    email: tom@opennetworking.org
+  - name: kuujo
+    email: jordan@opennetworking.org

--- a/deployments/helm/files/changeStore-sample.json
+++ b/deployments/helm/files/changeStore-sample.json
@@ -1,0 +1,124 @@
+{
+  "Version": "1.0.0",
+  "Storetype": "change",
+  "Store": {
+    "DCuMG07l01g2BvMdEta+7DyxMxk=": {
+      "ID": "DCuMG07l01g2BvMdEta+7DyxMxk=",
+      "Description": "Original Config for test switch",
+      "Created": "2019-04-25T16:07:24.623647371+01:00",
+      "Config": [
+        {
+          "Path": "/test1:cont1a",
+          "Value": "",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/cont2a",
+          "Value": "",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/cont2a/leaf2a",
+          "Value": "13",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/cont2a/leaf2b",
+          "Value": "1.579",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/cont2a/leaf2c",
+          "Value": "abc",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/leaf1a",
+          "Value": "abcdef",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout1",
+          "Value": "",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout1/tx-power",
+          "Value": "8",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout2",
+          "Value": "",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout2/tx-power",
+          "Value": "10",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:leafAtTopLevel",
+          "Value": "WXY-1234",
+          "Remove": false
+        }
+      ]
+    },
+    "LsDuwm2XJjdOq+u9QEcUJo/HxaM=": {
+      "ID": "LsDuwm2XJjdOq+u9QEcUJo/HxaM=",
+      "Description": "Remove txout 2",
+      "Created": "2019-04-25T16:07:24.623932408+01:00",
+      "Config": [
+        {
+          "Path": "/test1:cont1a/cont2a/leaf2c",
+          "Value": "def",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout2",
+          "Value": "",
+          "Remove": true
+        }
+      ]
+    },
+    "ccrCK+iDpgjBvlkG/HQ57yzOPzU=": {
+      "ID": "ccrCK+iDpgjBvlkG/HQ57yzOPzU=",
+      "Description": "Trim power level",
+      "Created": "2019-04-25T16:07:24.623888041+01:00",
+      "Config": [
+        {
+          "Path": "/test1:cont1a/cont2a/leaf2b",
+          "Value": "3.14159",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout3",
+          "Value": "",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout3/tx-power",
+          "Value": "16",
+          "Remove": false
+        }
+      ]
+    },
+    "oJ5GSd9a4aBzgYRlCcFqyNdPzL0=": {
+      "ID": "oJ5GSd9a4aBzgYRlCcFqyNdPzL0=",
+      "Description": "Remove txout 1",
+      "Created": "2019-04-25T16:07:24.623984111+01:00",
+      "Config": [
+        {
+          "Path": "/test1:cont1a/cont2a/leaf2c",
+          "Value": "ghi",
+          "Remove": false
+        },
+        {
+          "Path": "/test1:cont1a/list2a=txout1",
+          "Value": "",
+          "Remove": true
+        }
+      ]
+    }
+  }
+}

--- a/deployments/helm/files/configStore-sample.json
+++ b/deployments/helm/files/configStore-sample.json
@@ -1,0 +1,43 @@
+{
+  "Version": "1.0.0",
+  "Storetype": "config",
+  "Store": {
+    "Device1Version": {
+      "Name": "Device1Version",
+      "Device": "localhost:10161",
+      "Created": "2019-04-25T16:07:24.623962132+01:00",
+      "Updated": "2019-04-25T16:07:24.623962362+01:00",
+      "User": "onos",
+      "Description": "Configuration for Device 1",
+      "Changes": [
+        "DCuMG07l01g2BvMdEta+7DyxMxk=",
+        "ccrCK+iDpgjBvlkG/HQ57yzOPzU=",
+        "LsDuwm2XJjdOq+u9QEcUJo/HxaM="
+      ]
+    },
+    "Device2VersionMain": {
+      "Name": "Device2VersionMain",
+      "Device": "localhost:10162",
+      "Created": "2019-04-25T16:07:24.623995634+01:00",
+      "Updated": "2019-04-25T16:07:24.623995815+01:00",
+      "User": "onos",
+      "Description": "Main Configuration for Device 2",
+      "Changes": [
+        "DCuMG07l01g2BvMdEta+7DyxMxk=",
+        "ccrCK+iDpgjBvlkG/HQ57yzOPzU=",
+        "oJ5GSd9a4aBzgYRlCcFqyNdPzL0="
+      ]
+    },
+    "devicesim1": {
+      "Name": "devicesim1",
+      "Device": "localhost:10163",
+      "Created": "2019-05-02T12:37:24+01:00",
+      "Updated": "2019-05-02T12:37:24+01:00",
+      "User": "onos",
+      "Description": "Sample configuration for devicesim1",
+      "Changes": [
+        "DCuMG07l01g2BvMdEta+7DyxMxk="
+      ]
+    }
+  }
+}

--- a/deployments/helm/files/deviceStore-sample.json
+++ b/deployments/helm/files/deviceStore-sample.json
@@ -1,0 +1,20 @@
+{
+  "Version": "1.0.0",
+  "Storetype": "device",
+  "Store": {
+    "localhost:10161": {
+      "Addr": "localhost:10161",
+      "User": "devicesim",
+      "Pwd": "notused",
+      "Timeout": 10000000000
+    },
+    "localhost:10162": {
+      "Addr": "localhost:10162",
+      "Timeout": 10000000000
+    },
+    "localhost:10163": {
+      "Addr": "localhost:10163",
+      "Timeout": 10000000000
+    }
+  }
+}

--- a/deployments/helm/files/networkStore-sample.json
+++ b/deployments/helm/files/networkStore-sample.json
@@ -1,0 +1,21 @@
+{
+  "Version": "1.0.0",
+  "Storetype": "network",
+  "Store": [
+    {
+      "Name": "Change1",
+      "User": "onos",
+      "ConfigurationChanges": {
+        "Device1Version": "DCuMG07l01g2BvMdEta+7DyxMxk=",
+        "Device2VersionMain": "DCuMG07l01g2BvMdEta+7DyxMxk="
+      }
+    },
+    {
+      "Name": "Change2",
+      "User": "onos",
+      "ConfigurationChanges": {
+        "Device2VersionMain": "DCuMG07l01g2BvMdEta+7DyxMxk="
+      }
+    }
+  ]
+}

--- a/deployments/helm/templates/_helpers.tpl
+++ b/deployments/helm/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 59 chars because some Kubernetes name fields are limited to 63 characters (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 59 | trimSuffix "-" -}}
+{{- end -}}

--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-config
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+data:
+  changeStore-sample.json: {{ (.Files.Glob "files/changeStore-sample.json").AsConfig | indent 2 }}
+  configStore-sample.json: {{ (.Files.Glob "files/configStore-sample.json").AsConfig | indent 2 }}
+  deviceStore-sample.json: {{ (.Files.Glob "files/deviceStore-sample.json").AsConfig | indent 2 }}
+  networkStore-sample.json: {{ (.Files.Glob "files/networkStore-sample.json").AsConfig | indent 2 }}

--- a/deployments/helm/templates/configmap.yaml
+++ b/deployments/helm/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  changeStore-sample.json: {{ (.Files.Glob "files/changeStore-sample.json").AsConfig | indent 2 }}
-  configStore-sample.json: {{ (.Files.Glob "files/configStore-sample.json").AsConfig | indent 2 }}
-  deviceStore-sample.json: {{ (.Files.Glob "files/deviceStore-sample.json").AsConfig | indent 2 }}
-  networkStore-sample.json: {{ (.Files.Glob "files/networkStore-sample.json").AsConfig | indent 2 }}
+  {{ $root := . }}
+  {{ range $path, $bytes := .Files.Glob "files/*" }}
+  {{ base $path }}: '{{ $root.Files.Get $path }}'
+  {{ end }}

--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  release: "{{ .Release.Name }}"
+  heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      name: {{ template "fullname" . }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "fullname" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HTTP_PROXY
+              value: $(NODE_NAME):4140
+          command:
+            - onos-config-manager
+          args:
+            - "-restconfPort=8080"
+            - "-configStore=/etc/onos-config-manager/test-configs/configStore-sample.json"
+            - "-changeStore=/etc/onos-config-manager/test-configs/changeStore-sample.json"
+            - "-deviceStore=/etc/onos-config-manager/test-configs/deviceStore-sample.json"
+            - "-networkStore=/etc/onos-config-manager/test-configs/networkStore-sample.json"
+          readinessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          # Mount the test configuration
+          # TODO: This should be removed when stores are added!
+          volumeMounts:
+            - name: test-config
+              mountPath: /etc/onos-config-manager/test-configs
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.image.pullSecrets }}
+        - name: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      # Mount test volumes
+      # TODO: This should be removed when stores are added!
+      volumes:
+        - name: test-config
+          configMap:
+            name: {{ template "fullname" . }}-config

--- a/deployments/helm/templates/ingress.yaml
+++ b/deployments/helm/templates/ingress.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "fullname" . }}-ingress
+spec:
+  rules:
+    - http:
+        paths:
+        - path: /onos-config
+          backend:
+            serviceName: {{ template "fullname" . }}
+            servicePort: 5150
+{{- end }}

--- a/deployments/helm/templates/service.yaml
+++ b/deployments/helm/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  selector:
+    app: {{ template "fullname" . }}
+  clusterIP: None
+  ports:
+    - name: h2
+      port: 5150
+    - name: restconf
+      port: 8080

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -1,0 +1,12 @@
+nameOverride: ""
+
+replicas: 1
+image:
+  repository: onosproject/onos-config
+  tag: latest
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+resources:
+  requests:
+    cpu: 0.5
+    memory: 512Mi

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -1,12 +1,17 @@
 nameOverride: ""
 
 replicas: 1
+
 image:
   repository: onosproject/onos-config
   tag: latest
   pullPolicy: IfNotPresent
   pullSecrets: []
+
 resources:
   requests:
     cpu: 0.5
     memory: 512Mi
+
+ingress:
+  enabled: false


### PR DESCRIPTION
This PR adds a basic Helm chart to deploy the onos-config Docker image in k8s. To install the chart, run:
```
helm install deployments/helm
```

You can optionally set the number of replicas to run by overriding the `replicas` value:
```
helm install deployments/helm --set replicas=2
```