### PR TITLE
Gnmi subscribe Improvements

### DIFF
--- a/docs/run.md
+++ b/docs/run.md
@@ -82,7 +82,27 @@ gnmi_cli -address localhost:5150 -set \
 > southbound layer
 
 ## Northbound Subscribe Once Request via gNMI
-Similarly, to make a gNMI Subscribe Once request, use the `gnmi_cli` command as in the example below:
+Similarly, to make a gNMI Subscribe Once request, use the `gnmi_cli` command as in the example below, 
+please note the `1` as subscription mode to indicate to send the response once:
+
+```bash
+gnmi_cli -address localhost:5150 \
+    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost:10161', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -timeout 5s \
+    -client_crt tools/test/devicesim/certs/client1.crt \
+    -client_key tools/test/devicesim/certs/client1.key \
+    -ca_crt tools/test/devicesim/certs/onfca.crt \
+    -alsologtostderr
+```
+
+> Currently no checking of the contents is enforced and the config is not forwarded down to the 
+> southbound layer
+
+**Note** This command will fail if no value is set at that specific path. This is due to limitations of the gnmi_cli.
+
+## Northbound Subscribe Request for Stream Notifications via gNMI
+Similarly, to make a gNMI Subscribe request for streaming, use the `gnmi_cli` command as in the example below, 
+please note the `0` as subscription mode to indicate streaming:
 
 ```bash
 gnmi_cli -address localhost:5150 \
@@ -97,7 +117,7 @@ gnmi_cli -address localhost:5150 \
 > Currently no checking of the contents is enforced and the config is not forwarded down to the 
 > southbound layer
 
-**Note** This command will fail if no value is set at that specific path. This is due to limitations of the gnmi_cli.
+**Note** This command will block until there is a change at the requested value that gets propagated to the underlying stream.
 
 ## Administrative Tools
 The project provides a number of administrative tools for remotely accessing the enhanced northbound

--- a/docs/run.md
+++ b/docs/run.md
@@ -86,7 +86,7 @@ Similarly, to make a gNMI Subscribe Once request, use the `gnmi_cli` command as 
 
 ```bash
 gnmi_cli -address localhost:5150 \
-    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost:10161', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'localhost:10161', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
     -timeout 5s \
     -client_crt tools/test/devicesim/certs/client1.crt \
     -client_key tools/test/devicesim/certs/client1.key \

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -47,15 +47,15 @@ func Listen(changeChannel <-chan events.Event) {
 	log.Println("Event listener initialized")
 
 	for configEvent := range changeChannel {
-		log.Println("Event", configEvent)
+		log.Println("Listener: Event", configEvent)
 		for device, deviceChan := range deviceListeners {
 			if configEvent.Subject() == device {
+				log.Println("Device Simulators must be active")
+				//TODO need a timeout or be done in separate routine
 				deviceChan <- configEvent
 			}
 		}
-		log.Println("nbiListeners")
 		for _, nbiChan := range nbiListeners {
-			log.Println("Writing to NB channel", configEvent)
 			nbiChan <- configEvent
 		}
 

--- a/pkg/listener/listener.go
+++ b/pkg/listener/listener.go
@@ -47,12 +47,15 @@ func Listen(changeChannel <-chan events.Event) {
 	log.Println("Event listener initialized")
 
 	for configEvent := range changeChannel {
+		log.Println("Event", configEvent)
 		for device, deviceChan := range deviceListeners {
 			if configEvent.Subject() == device {
 				deviceChan <- configEvent
 			}
 		}
+		log.Println("nbiListeners")
 		for _, nbiChan := range nbiListeners {
+			log.Println("Writing to NB channel", configEvent)
 			nbiChan <- configEvent
 		}
 

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -92,7 +92,9 @@ func (m *Manager) SetNetworkConfig(target string, configName string, updates map
 	eventValues := make(map[string]string)
 	eventValues[events.ChangeID] = store.B64(configChange.ID)
 	eventValues[events.Committed] = "true"
-	m.ChangesChannel <- events.CreateEvent(deviceConfig.Device,
+	event := events.CreateEvent(deviceConfig.Device,
 		events.EventTypeConfiguration, eventValues)
+	log.Println("Writing to channel", event)
+	m.ChangesChannel <- event
 	return configChange.ID, nil
 }

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -92,9 +92,7 @@ func (m *Manager) SetNetworkConfig(target string, configName string, updates map
 	eventValues := make(map[string]string)
 	eventValues[events.ChangeID] = store.B64(configChange.ID)
 	eventValues[events.Committed] = "true"
-	event := events.CreateEvent(deviceConfig.Device,
+	m.ChangesChannel <- events.CreateEvent(deviceConfig.Device,
 		events.EventTypeConfiguration, eventValues)
-	log.Println("Writing to channel", event)
-	m.ChangesChannel <- event
 	return configChange.ID, nil
 }

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -17,6 +17,7 @@ package gnmi
 import (
 	"context"
 	"github.com/onosproject/onos-config/pkg/manager"
+	"github.com/onosproject/onos-config/pkg/store/change"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"log"
@@ -80,6 +81,10 @@ func GetUpdate(path *gnmi.Path) (*gnmi.Update, error) {
 		return nil, err
 	}
 
+	return buildUpdate(path, configValues), nil
+}
+
+func buildUpdate(path *gnmi.Path, configValues []change.ConfigValue) *gnmi.Update {
 	var value *gnmi.TypedValue
 	if len(configValues) == 0 {
 		value = nil
@@ -100,9 +105,8 @@ func GetUpdate(path *gnmi.Path) (*gnmi.Update, error) {
 			Value: typedValue,
 		}
 	}
-
 	return &gnmi.Update{
 		Path: path,
 		Val:  value,
-	}, nil
+	}
 }

--- a/pkg/northbound/gnmi/service.go
+++ b/pkg/northbound/gnmi/service.go
@@ -35,6 +35,7 @@ type Service struct {
 
 // Register registers the GNMI server with grpc
 func (s Service) Register(r *grpc.Server) {
+	go broadcastNotification()
 	gnmi.RegisterGNMIServer(r, &Server{
 		models: models.NewModels(),
 	})

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -26,29 +26,16 @@ import (
 	"time"
 )
 
-//per each subscribe request we reiceve the map is upated with a channel coprresponding to the path.
+//per each subscribe request we receive the map is updated with a channel corresponding to the path.
 var (
 	PathToChannels = make(map[*gnmi.Path]chan *gnmi.Update)
 )
+
 // Subscribe implements gNMI Subscribe
 func (s *Server) Subscribe(stream gnmi.GNMI_SubscribeServer) error {
-	//Create channel
-	//Spawn go routine with the given channel
-	//forever
-	//read from channel
-	//produce update message
-	//send notification with update message
-	//
-	//Forever
-	//read subscribe request message
-	//add subscription to the subscriber DB for this session --> map update
-	//	if this is subscribe once
-	//	go spawn gatherer for specified paths to generate update events
 	ch := make(chan *gnmi.Update)
-
 	//this for loop handles each subscribe request coming into the server
 	for {
-		//log.Println("Testing loop")
 		in, err := stream.Recv()
 		if err == io.EOF {
 			log.Println("Subscription Terminated")
@@ -85,15 +72,19 @@ func (s *Server) Subscribe(stream gnmi.GNMI_SubscribeServer) error {
 				Response: responseUpdate,
 			}
 			sendResponse(response, stream)
-			//If the subscription mode is ONCE we read from the channel, build a response and issue it
-			if mode == gnmi.SubscriptionList_ONCE {
-				responseUpdate := &gnmi.SubscribeResponse_SyncResponse{
+			//For stream and Poll we also send a Sync Response
+			//TODO make sure that for stream sending this every time adheres to spec.
+			// see section #3.5.1.4 of gnmi-specification.md
+			if mode != gnmi.SubscriptionList_ONCE {
+				responseSync := &gnmi.SubscribeResponse_SyncResponse{
 					SyncResponse: true,
 				}
-				response := &gnmi.SubscribeResponse{
-					Response: responseUpdate,
+				response = &gnmi.SubscribeResponse{
+					Response: responseSync,
 				}
 				sendResponse(response, stream)
+			} else {
+				//If the subscription mode is ONCE we read from the channel, build a response and issue it
 				stopped <- struct{}{}
 			}
 		}()
@@ -112,6 +103,7 @@ func (s *Server) Subscribe(stream gnmi.GNMI_SubscribeServer) error {
 }
 
 func sendResponse(response *gnmi.SubscribeResponse, stream gnmi.GNMI_SubscribeServer) {
+	log.Println("Sending SubscribeResponse out to gNMI client", response)
 	err := stream.Send(response)
 	if err != nil {
 		//TODO remove channel registrations
@@ -131,22 +123,18 @@ func collector(ch chan *gnmi.Update, request *gnmi.SubscriptionList) {
 
 func broadcastNotification() {
 	mgr := manager.GetManager()
-	changes, err := listener.Register("Gnmi NB", false)
+	changes, err := listener.Register("GnmiSubscribeNorthBound", false)
 	if err != nil {
 		log.Println("Error while subscribing to updates", err)
 	}
-	//changes := mgr.ChangesChannel
-	for {
-		log.Println("Listening for updates on updatesChannel")
-		update := <-changes
-		log.Println("event", update)
+	for update := range changes {
 		//TODO needs to be filtered for appropriate paths in the change
-		// currently boradcasting to everybody
+		// currently broadcasting to everybody
 		for _, ch := range PathToChannels {
 			values := update.Values()
 			changeID := (*values)[events.ChangeID]
 			changeInternal := mgr.ChangeStore.Store[changeID]
-			err := getPath(changeInternal, ch)
+			err := sendUpdate(changeInternal, ch)
 			if err != nil {
 				log.Println("Error while parsing path ", err)
 			}
@@ -154,7 +142,7 @@ func broadcastNotification() {
 	}
 }
 
-func getPath(c *change.Change, ch chan *gnmi.Update) error {
+func sendUpdate(c *change.Change, ch chan *gnmi.Update) error {
 	for _, changeValue := range c.Config {
 		elems := utils.SplitPath(changeValue.Path)
 		pathElemsRefs, parseError := utils.ParseGNMIElements(elems)
@@ -162,7 +150,7 @@ func getPath(c *change.Change, ch chan *gnmi.Update) error {
 		if parseError != nil {
 			return parseError
 		}
-
+		//TODO use proper type of value, re-use code in get
 		typedValue := gnmi.TypedValue_StringVal{StringVal: changeValue.Value}
 		value := &gnmi.TypedValue{Value: &typedValue}
 		updatePath := &gnmi.Path{Elem: pathElemsRefs.Elem}


### PR DESCRIPTION
Enables Subscribe for Notifications on the Northbound from a generic gNMI client.

Missing features for future patches:
- Filter for channels according to path to send out the notification to, currently is a broadcast
- Support POLL type
- Support SubscriptionMode (e.g.target_defined)