### PR TITLE
Check gopkg.lock has been committed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ image: # @HELP build onos-config image
 
 deps: # @HELP ensure that the required dependencies are in place
 	dep ensure -v
+	bash -c "diff -u <(echo -n) <(git diff Gopkg.lock)"
 
 lint: # @HELP run the linters for Go source code
 	golint -set_exit_status github.com/onosproject/onos-config/pkg/...


### PR DESCRIPTION
This change ensures the build will fail if there is a change to the gopkg.lock which is not committed. 