### PR TITLE
Get response change according to gnmi spec. Fixes:#211

### DIFF
--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -17,19 +17,17 @@ package gnmi
 import (
 	"context"
 	"fmt"
-	"log"
-	"time"
-
 	"github.com/onosproject/onos-config/pkg/manager"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
+	"log"
+	"time"
 )
 
 // Get implements gNMI Get
 func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetResponse, error) {
-
-	updates := make([]*gnmi.Update, 0)
+	notifications := make([]*gnmi.Notification, 0)
 
 	prefix := req.GetPrefix()
 
@@ -38,7 +36,13 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		if err != nil {
 			return nil, err
 		}
-		updates = append(updates, update)
+		notification := &gnmi.Notification{
+			Timestamp: time.Now().Unix(),
+			Update:    []*gnmi.Update{update},
+			Prefix:    prefix,
+		}
+
+		notifications = append(notifications, notification)
 	}
 	// Alternatively - if there's only the prefix
 	if len(req.GetPath()) == 0 {
@@ -46,16 +50,15 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		if err != nil {
 			return nil, err
 		}
-		updates = append(updates, update)
+		notification := &gnmi.Notification{
+			Timestamp: time.Now().Unix(),
+			Update:    []*gnmi.Update{update},
+			Prefix:    prefix,
+		}
+
+		notifications = append(notifications, notification)
 	}
 
-	notification := &gnmi.Notification{
-		Timestamp: time.Now().Unix(),
-		Update:    updates,
-		Prefix:    prefix,
-	}
-	notifications := make([]*gnmi.Notification, 0)
-	notifications = append(notifications, notification)
 	response := gnmi.GetResponse{
 		Notification: notifications,
 	}

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -66,9 +66,11 @@ func Test_getNoPathElems(t *testing.T) {
 	result, err := server.Get(nil, &request)
 	assert.NilError(t, err, "Unexpected error")
 
-	assert.Equal(t, len(result.Notification), 1)
+	assert.Equal(t, len(result.Notification), 2)
 
-	assert.Equal(t, len(result.Notification[0].Update), 2)
+	assert.Equal(t, len(result.Notification[0].Update), 1)
+
+	assert.Equal(t, len(result.Notification[1].Update), 1)
 }
 
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
@@ -139,18 +141,19 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 	result, err := server.Get(nil, &request)
 	assert.NilError(t, err, "Unexpected error")
 
-	assert.Equal(t, len(result.Notification), 1)
+	assert.Equal(t, len(result.Notification), 2)
 
-	assert.Equal(t, len(result.Notification[0].Update), 2)
+	assert.Equal(t, len(result.Notification[0].Update), 1)
 
 	assert.Equal(t, utils.StrPath(result.Notification[0].Prefix),
 		"/test1:cont1a/cont2a")
 	assert.Equal(t, utils.StrPath(result.Notification[0].Update[0].Path),
 		"/leaf2a")
 	assert.Equal(t, utils.StrVal(result.Notification[0].Update[0].Val), "13")
-	assert.Equal(t, utils.StrPath(result.Notification[0].Update[1].Path),
+
+	assert.Equal(t, utils.StrPath(result.Notification[1].Update[0].Path),
 		"/leaf2b")
-	assert.Equal(t, utils.StrVal(result.Notification[0].Update[1].Val), "3.14159")
+	assert.Equal(t, utils.StrVal(result.Notification[1].Update[0].Val), "3.14159")
 }
 
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {


### PR DESCRIPTION
The gNMI NB get response now returns multiple notification with one update each according to the gNMI spec here: get-fix