### PR TITLE
Adding a make target to run the development docker image locally

### DIFF
--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,4 +1,6 @@
-FROM onosproject/onos-config-build:stable as builder
+ARG ONOS_BUILD_VERSION=stable
+
+FROM onosproject/onos-config-build:$ONOS_BUILD_VERSION as builder
 COPY . /go/src/github.com/onosproject/onos-config
 RUN cd /go/src/github.com/onosproject/onos-config && make build
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -8,8 +8,8 @@ The project provides a `Makefile` that supports all the  required to unit test,
 validate and build the project.
 The makefile supports the following targets:
 * `test` - pulls dependencies and runs tests, including lint, vet and license
-* `build` - runs `test` and builds an executable
-* `all` - runs `test`, `build`, and creates the run-time `onosproject/onos-config` Docker image
+* `build` - runs `protos`, `test` and builds an executable
+* `all` - runs `protos`, and creates the run-time `onosproject/onos-config` Docker image
   * Requires a local Docker daemon
 
 ## Building via Docker Developer Image

--- a/docs/run.md
+++ b/docs/run.md
@@ -16,15 +16,10 @@ go run github.com/onosproject/onos-config/cmd/onos-config \
 ## Run Server in Docker Image
 Alternatively, to run onos-config via its Docker image like this:
 ```
-docker run -p 5150:5150 -v `pwd`/configs:/etc/onos-config -it onosproject/onos-config \
-    -configStore=/etc/onos-config/configStore-sample.json \
-    -changeStore=/etc/onos-config/changeStore-sample.json \
-    -deviceStore=/etc/onos-config/deviceStore-sample.json \
-    -networkStore=/etc/onos-config/networkStore-sample.json
+make run-docker
 ```
 Note that the local config directory is mounted from the container to allow access to local
-test configuration files. You can [build your own version of the onos-config Docker image](build.md) 
-or use the published one.
+test configuration files. This command will build a docker image form source
 
 
 ## Northbound Get Request via gNMI


### PR DESCRIPTION
This patch adds:
- `make run-docker` to run the runtime image locally
- `make clean` to remove all the build artifacts

Let me know what you think about it.

Also I noticed that we are passing the entire repository to the docker-context, but that means that any change will force a complete rebuild of the image, while I believe we should take advantage of the docker cache and just load the "./cmd" directory in the context. In that way only changes to the code would wipe the docker cache.