### PR TITLE
Refactored onos-config.go and manager.go for easier testing

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -121,6 +121,57 @@ func setUp() (*Manager, map[string]*change.Change, map[store.ConfigName]store.Co
 	return mgrTest, changeStoreTest, configurationStoreTest
 }
 
+func Test_LoadManager(t *testing.T) {
+	mgr, err := LoadManager(
+		"../../configs/configStore-sample.json",
+		"../../configs/changeStore-sample.json",
+		"../../configs/deviceStore-sample.json",
+		"../../configs/networkStore-sample.json",
+	)
+	assert.Assert(t, err == nil, "failed to load manager")
+	assert.Equal(t, len(mgr.DeviceStore.Store), 3, "wrong number of devices loaded")
+}
+
+func Test_LoadManagerBadConfigStore(t *testing.T) {
+	_, err := LoadManager(
+		"../../configs/configStore-sampleX.json",
+		"../../configs/changeStore-sample.json",
+		"../../configs/deviceStore-sample.json",
+		"../../configs/networkStore-sample.json",
+	)
+	assert.Assert(t, err != nil, "should have failed to load manager")
+}
+
+func Test_LoadManagerBadChangeStore(t *testing.T) {
+	_, err := LoadManager(
+		"../../configs/configStore-sample.json",
+		"../../configs/changeStore-sampleX.json",
+		"../../configs/deviceStore-sample.json",
+		"../../configs/networkStore-sample.json",
+	)
+	assert.Assert(t, err != nil, "should have failed to load manager")
+}
+
+func Test_LoadManagerBadDeviceStore(t *testing.T) {
+	_, err := LoadManager(
+		"../../configs/configStore-sample.json",
+		"../../configs/changeStore-sample.json",
+		"../../configs/deviceStore-sampleX.json",
+		"../../configs/networkStore-sample.json",
+	)
+	assert.Assert(t, err != nil, "should have failed to load manager")
+}
+
+func Test_LoadManagerBadNetworkStore(t *testing.T) {
+	_, err := LoadManager(
+		"../../configs/configStore-sample.json",
+		"../../configs/changeStore-sample.json",
+		"../../configs/deviceStore-sample.json",
+		"../../configs/networkStore-sampleX.json",
+	)
+	assert.Assert(t, err != nil, "should have failed to load manager")
+}
+
 func Test_GetNetworkConfig(t *testing.T) {
 
 	mgrTest, _, _ := setUp()

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -19,8 +19,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/manager"
-	"github.com/onosproject/onos-config/pkg/southbound/topocache"
-	"github.com/onosproject/onos-config/pkg/store"
+	"log"
 	"os"
 	"testing"
 )
@@ -36,37 +35,16 @@ func TestMain(m *testing.M) {
 
 // setUp should not depend on any global variables
 func setUp(broadcast bool) *Server {
-	var mgr *manager.Manager
 	var server = &Server{}
 
-	cfgStore, err := store.LoadConfigStore("../../../configs/configStore-sample.json")
+	mgr, err := manager.LoadManager(
+		"../../../configs/configStore-sample.json",
+		"../../../configs/changeStore-sample.json",
+		"../../../configs/deviceStore-sample.json",
+		"../../../configs/networkStore-sample.json",
+	)
 	if err != nil {
-		fmt.Println("Unexpected config store loading error", err)
-		os.Exit(-1)
-	}
-	if cfgStore.Storetype != "config" {
-		fmt.Println("Expected Config store to be loaded")
-		os.Exit(-1)
-	}
-
-	changeStore, err := store.LoadChangeStore("../../../configs/changeStore-sample.json")
-	if err != nil {
-		fmt.Println("Unexpected change store loading error", err)
-		os.Exit(-1)
-	}
-	if changeStore.Storetype != "change" {
-		fmt.Println("Expected Change store to be loaded")
-		os.Exit(-1)
-	}
-
-	networkStore, err := store.LoadNetworkStore("../../../configs/networkStore-sample.json")
-	if err != nil {
-		fmt.Println("Unexpected network store loading error", err)
-		os.Exit(-1)
-	}
-	if networkStore.Storetype != "network" {
-		fmt.Println("Expected Network store to be loaded")
-		os.Exit(-1)
+		log.Println("Expected manager to be loaded")
 	}
 
 	mgr = manager.GetManager()
@@ -80,20 +58,6 @@ func setUp(broadcast bool) *Server {
 		go broadcastConfigNotification()
 	}
 
-	deviceStore, err := topocache.LoadDeviceStore("../../../configs/deviceStore-sample.json", mgr.TopoChannel)
-	if err != nil {
-		fmt.Println("Unexpected device store loading error", err)
-		os.Exit(-1)
-	}
-	if deviceStore.Storetype != "device" {
-		fmt.Println("Expected device store to be loaded")
-		os.Exit(-1)
-	}
-
-	mgr.ConfigStore = &cfgStore
-	mgr.ChangeStore = &changeStore
-	mgr.NetworkStore = networkStore
-	mgr.DeviceStore = deviceStore
 	fmt.Println("Finished setUp()")
 	return server
 }


### PR DESCRIPTION
This is to facilitate easy loading of the manager context in other tests, e.g. northbound