### PR TITLE
Added in an ID to the Device Store (topocache) Fixes #304

### DIFF
--- a/configs/configStore-sample.json
+++ b/configs/configStore-sample.json
@@ -60,9 +60,9 @@
         }
       ]
     },
-    "localhost:10161-1.0.0": {
-      "Name": "localhost:10161-1.0.0",
-      "Device": "localhost:10161",
+    "localhost-1-1.0.0": {
+      "Name": "localhost-1-1.0.0",
+      "Device": "localhost-1",
       "Version": "1.0.0",
       "Type": "Devicesim",
       "Created": "2019-05-21T08:43:17Z",
@@ -94,9 +94,9 @@
         }
       ]
     },
-    "localhost:10162-1.0.0": {
-      "Name": "localhost:10162-1.0.0",
-      "Device": "localhost:10162",
+    "localhost-2-1.0.0": {
+      "Name": "localhost-2-1.0.0",
+      "Device": "localhost-2",
       "Version": "1.0.0",
       "Type": "Devicesim",
       "Created": "2019-05-21T08:43:18Z",
@@ -128,9 +128,9 @@
         }
       ]
     },
-    "localhost:10163-1.0.0": {
-      "Name": "localhost:10163-1.0.0",
-      "Device": "localhost:10163",
+    "localhost-3-1.0.0": {
+      "Name": "localhost-3-1.0.0",
+      "Device": "localhost-3",
       "Version": "1.0.0",
       "Type": "Devicesim",
       "Created": "2019-05-21T08:43:19Z",
@@ -264,9 +264,9 @@
         }
       ]
     },
-    "localhost:50001-1.0.0": {
-      "Name": "localhost:50001-1.0.0",
-      "Device": "localhost:50001",
+    "stratum-sim-1-1.0.0": {
+      "Name": "stratum-sim-1-1.0.0",
+      "Device": "stratum-sim-1",
       "Version": "1.0.0",
       "Type": "Stratum",
       "Created": "2019-06-05T10:03:17Z",

--- a/configs/deviceStore-sample.json
+++ b/configs/deviceStore-sample.json
@@ -2,24 +2,28 @@
   "Version": "1.0.0",
   "Storetype": "device",
   "Store": {
-    "localhost:10161": {
+    "localhost-1": {
+      "ID": "localhost-1",
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
       "Pwd": "notused",
       "Timeout": 10000000000
     },
-    "localhost:10162": {
+    "localhost-2": {
+      "ID": "localhost-2",
       "Addr": "localhost:10162",
       "SoftwareVersion": "1.0.0",
       "Timeout": 10000000000
     },
-    "localhost:10163": {
+    "localhost-3": {
+      "ID": "localhost-3",
       "Addr": "localhost:10163",
       "SoftwareVersion": "1.0.0",
       "Timeout": 10000000000
     },
-    "localhost:50001": {
+    "stratum-sim-1": {
+      "ID": "stratum-sim-1",
       "Addr": "localhost:50001",
       "SoftwareVersion": "1.0.0",
       "Plain": true,

--- a/deployments/helm/onos-config/files/configs/configStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/configStore-sample.json
@@ -60,9 +60,9 @@
         }
       ]
     },
-    "localhost:10161-1.0.0": {
-      "Name": "localhost:10161-1.0.0",
-      "Device": "localhost:10161",
+    "localhost-1-1.0.0": {
+      "Name": "localhost-1-1.0.0",
+      "Device": "localhost-1",
       "Version": "1.0.0",
       "Type": "Devicesim",
       "Created": "2019-05-21T08:43:17Z",
@@ -94,9 +94,9 @@
         }
       ]
     },
-    "localhost:10162-1.0.0": {
-      "Name": "localhost:10162-1.0.0",
-      "Device": "localhost:10162",
+    "localhost-2-1.0.0": {
+      "Name": "localhost-2-1.0.0",
+      "Device": "localhost-2",
       "Version": "1.0.0",
       "Type": "Devicesim",
       "Created": "2019-05-21T08:43:18Z",
@@ -128,9 +128,9 @@
         }
       ]
     },
-    "localhost:10163-1.0.0": {
-      "Name": "localhost:10163-1.0.0",
-      "Device": "localhost:10163",
+    "localhost-3-1.0.0": {
+      "Name": "localhost-3-1.0.0",
+      "Device": "localhost-3",
       "Version": "1.0.0",
       "Type": "Devicesim",
       "Created": "2019-05-21T08:43:19Z",

--- a/deployments/helm/onos-config/files/configs/deviceStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/deviceStore-sample.json
@@ -3,6 +3,7 @@
   "Storetype": "device",
   "Store": {
     "device-1-device-simulator": {
+      "ID": "device-1-device-simulator",
       "Addr": "device-1-device-simulator:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
@@ -10,11 +11,13 @@
       "Timeout": 10000000000
     },
     "device-2-device-simulator": {
+      "ID": "device-2-device-simulator",
       "Addr": "device-2-device-simulator:10161",
       "SoftwareVersion": "1.0.0",
       "Timeout": 10000000000
     },
     "device-3-device-simulator": {
+      "ID": "device-3-device-simulator",
       "Addr": "device-3-device-simulator:10161",
       "SoftwareVersion": "1.0.0",
       "Timeout": 10000000000

--- a/deployments/helm/onos-config/templates/configmap.yaml
+++ b/deployments/helm/onos-config/templates/configmap.yaml
@@ -15,9 +15,10 @@ data:
       "Store": {
         {{- range $i, $device := .Values.devices }}
         {{ if $i }},{{ end}}{{ printf "%s:10161" $device | quote }}: {
+          "ID": {{ printf "%s:10161" $device | quote }},
           "Addr": {{ printf "%s:10161" $device | quote }},
           "Timeout": 10000000000,
-           "SoftwareVersion": "1.0.0"
+          "SoftwareVersion": "1.0.0"
         }
         {{- end }}
       }

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -46,8 +46,8 @@ Removing device device-2
 If you do not specify any options, the command will list all the devices currently in the inventory:
 ```bash
 > go run github.com/onosproject/onos-config/cmd/admin/devices
-device-1: localhost:10161 (1.0.0)
-device-3: localhost:10163 (1.0.0)
-device-4: localhost:10164 (1.0.0)
+device-1: localhost-1 (1.0.0)
+device-3: localhost-3 (1.0.0)
+device-4: localhost-4 (1.0.0)
 ```
 

--- a/docs/diags.md
+++ b/docs/diags.md
@@ -23,7 +23,7 @@ go run github.com/onosproject/onos-config/cmd/diags/configs
 To get the aggregate configuration of a device from the store use
 ```bash
 go run github.com/onosproject/onos-config/cmd/diags/devicetree \
-    -devicename localhost:10161
+    -devicename localhost-1
 ```
 
 > Of course, there will be many more such commands available in the near future

--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -23,7 +23,7 @@ Use `gnmi_cli -get` to get configuration for a particular device (target) from t
 > If config from several devices are required, several paths can be added
 ```bash
 gnmi_cli -get -address localhost:5150 \
-    -proto "path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
+    -proto "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
     -timeout 5s -alsologtostderr\
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -46,11 +46,11 @@ gnmi_cli -get -address localhost:5150 \
 
 ### List complete configuration for a device (target)
 >Use the following value for proto to get all configuration and operational state on a particular device
->    -proto "path: <target: 'localhost:10161'>"
+>    -proto "path: <target: 'localhost-1'>"
 
 ### Get a keyed index in a list
 Use a proto value like:
->    -proto "path: <target: 'localhost:10161',
+>    -proto "path: <target: 'localhost-1',
 >         elem: <name: 'openconfig-system:system'>
 >         elem: <name: 'openconfig-openflow:openflow'> elem: <name: 'controllers'>
 >         elem: <name: 'controller' key: <key: 'name' value: 'main'>>
@@ -62,7 +62,7 @@ Similarly, to make a gNMI Set request, use the `gnmi_cli -set` command as in the
 
 ```bash
 gnmi_cli -address localhost:5150 -set \
-    -proto "update: <path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
+    -proto "update: <path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -84,7 +84,7 @@ response: <
     elem: <
       name: "timezone-name"
     >
-    target: "localhost:10161"
+    target: "localhost-1"
   >
   op: UPDATE
 >
@@ -106,7 +106,7 @@ SetRequest() with the 100 extension at the end of the -proto section like:
 > ", extension: <registered_ext: <id: 100, msg: 'myfirstchange'>>"
 
 > The corresponding -get for this require using the -proto
-> "path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>"
+> "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>"
 
 > Currently (May '19) no checking of the contents is enforced when doing a Set operation
 > and the config is forwarded down to the southbound layer only if a device is registered
@@ -118,7 +118,7 @@ please note the `0` as subscription mode to indicate streaming:
 
 ```bash
 gnmi_cli -address localhost:5150 \
-    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -134,7 +134,7 @@ please note the `1` as subscription mode to indicate to send the response once:
 
 ```bash
 gnmi_cli -address localhost:5150 \
-    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -149,7 +149,7 @@ please note the `2` as subscription mode to indicate to send the response in a p
 
 ```bash
 gnmi_cli -address localhost:5150 \
-     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
      -timeout 5s \
      -polling_interval 5s \
      -client_crt pkg/southbound/testdata/client1.crt \

--- a/docs/run.md
+++ b/docs/run.md
@@ -27,7 +27,7 @@ The system provides a full implementation of the gNMI spec as a northbound servi
 Here is an example on how to use `gnmi_cli -get` to get configuration for a particular device (target) from the system.
 ```bash
 gnmi_cli -get -address localhost:5150 \
-    -proto "path: <target: 'localhost:10161', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
+    -proto "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
     -timeout 5s -alsologtostderr\
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -31,6 +31,9 @@ const (
 
 	// Connect :
 	Connect = "Connect"
+
+	// Address :
+	Address = "Address"
 )
 
 // EventType is an enumerated type

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	eventSubject  = "device22"
+	eventAddress  = "device22:10161"
 	eventTypeCfg  = EventTypeConfiguration
 	eventTypeTopo = EventTypeTopoCache
 	eventValueKey = ChangeID
@@ -68,7 +69,7 @@ func Test_configEventConstruction(t *testing.T) {
 
 func Test_topoEventConstruction(t *testing.T) {
 
-	event := CreateTopoEvent(eventSubject, true)
+	event := CreateTopoEvent(eventSubject, true, eventAddress)
 
 	assert.Equal(t, Event(event).EventType(), eventTypeTopo)
 	assert.Equal(t, Event(event).Subject(), eventSubject)

--- a/pkg/events/topoevent.go
+++ b/pkg/events/topoevent.go
@@ -33,10 +33,18 @@ func (topoEvent *TopoEvent) Connect() bool {
 	return b
 }
 
+// Address represents the device address
+func (topoEvent *TopoEvent) Address() string {
+	return topoEvent.values[Address]
+}
+
 // CreateTopoEvent creates a new topo event object
-func CreateTopoEvent(subject string, connect bool) TopoEvent {
+// It is important not to depend on topocache package here or we will get a
+// circular dependency - we take the device.ID and treat it as a string
+func CreateTopoEvent(subject string, connect bool, address string) TopoEvent {
 	values := make(map[string]string)
 	values[Connect] = strconv.FormatBool(connect)
+	values[Address] = address
 	return TopoEvent{
 		subject:   subject,
 		time:      time.Now(),

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -59,7 +59,7 @@ func setUp() (*Manager, map[string]*change.Change, map[store.ConfigName]store.Co
 		changeStoreTest        map[string]*change.Change
 		configurationStoreTest map[store.ConfigName]store.Configuration
 		networkStoreTest       []store.NetworkConfiguration
-		deviceStoreTest        map[string]topocache.Device
+		deviceStoreTest        map[topocache.ID]topocache.Device
 	)
 
 	var err error
@@ -86,10 +86,12 @@ func setUp() (*Manager, map[string]*change.Change, map[store.ConfigName]store.Co
 	configurationStoreTest = make(map[store.ConfigName]store.Configuration)
 	configurationStoreTest[device1config.Name] = *device1config
 
-	deviceStoreTest = make(map[string]topocache.Device)
+	deviceStoreTest = make(map[topocache.ID]topocache.Device)
 	deviceStoreTest["Device1"] = topocache.Device{
-		Addr:    "127.0.0.1:10161",
-		Timeout: 10,
+		ID:              topocache.ID("Device1"),
+		SoftwareVersion: "1.0.0",
+		Addr:            "127.0.0.1:10161",
+		Timeout:         10,
 	}
 	mgrTest, err = NewManager(
 		&store.ConfigurationStore{
@@ -129,7 +131,7 @@ func Test_LoadManager(t *testing.T) {
 		"../../configs/networkStore-sample.json",
 	)
 	assert.Assert(t, err == nil, "failed to load manager")
-	assert.Equal(t, len(mgr.DeviceStore.Store), 3, "wrong number of devices loaded")
+	assert.Equal(t, len(mgr.DeviceStore.Store), 4, "wrong number of devices loaded")
 }
 
 func Test_LoadManagerBadConfigStore(t *testing.T) {

--- a/pkg/northbound/admin/admin_devices.go
+++ b/pkg/northbound/admin/admin_devices.go
@@ -24,7 +24,8 @@ import (
 
 // AddOrUpdateDevice adds the specified device to the device inventory.
 func (s Server) AddOrUpdateDevice(c context.Context, d *proto.DeviceInfo) (*proto.DeviceResponse, error) {
-	err := manager.GetManager().DeviceStore.AddOrUpdateDevice(d.Id, topocache.Device{
+	err := manager.GetManager().DeviceStore.AddOrUpdateDevice(topocache.ID(d.Id), topocache.Device{
+		ID:              topocache.ID(d.Id),
 		Addr:            d.Address,
 		Target:          d.Target,
 		SoftwareVersion: d.Version,
@@ -42,7 +43,7 @@ func (s Server) AddOrUpdateDevice(c context.Context, d *proto.DeviceInfo) (*prot
 
 // RemoveDevice removes the specified device from the inventory.
 func (s Server) RemoveDevice(c context.Context, d *proto.DeviceInfo) (*proto.DeviceResponse, error) {
-	manager.GetManager().DeviceStore.RemoveDevice(d.Id)
+	manager.GetManager().DeviceStore.RemoveDevice(topocache.ID(d.Id))
 	return &proto.DeviceResponse{}, nil
 }
 
@@ -52,7 +53,7 @@ func (s Server) GetDevices(r *proto.GetDevicesRequest, stream proto.DeviceInvent
 
 		// Build the device info message
 		msg := &proto.DeviceInfo{
-			Id: id, Address: dev.Addr, Target: dev.Target, Version: dev.SoftwareVersion,
+			Id: string(id), Address: dev.Addr, Target: dev.Target, Version: dev.SoftwareVersion,
 			User: dev.Usr, Password: dev.Pwd,
 			CaPath: dev.CaPath, CertPath: dev.CertPath, KeyPath: dev.KeyPath,
 			Plain: dev.Plain, Insecure: dev.Insecure, Timeout: dev.Timeout.Nanoseconds(),

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -97,7 +97,7 @@ func Test_getAllDevices(t *testing.T) {
 	deviceListStr := utils.StrVal(result.Notification[0].Update[0].Val)
 
 	assert.Equal(t, deviceListStr,
-		"[Device1 (1.0.0), Device2 (1.0.0), Device2 (2.0.0), device-1-device-simulator (1.0.0), device-2-device-simulator (1.0.0), device-3-device-simulator (1.0.0), localhost:10161 (1.0.0), localhost:10162 (1.0.0), localhost:10163 (1.0.0), localhost:50001 (1.0.0)]")
+		"[Device1 (1.0.0), Device2 (1.0.0), Device2 (2.0.0), device-1-device-simulator (1.0.0), device-2-device-simulator (1.0.0), device-3-device-simulator (1.0.0), localhost-1 (1.0.0), localhost-2 (1.0.0), localhost-3 (1.0.0), stratum-sim-1 (1.0.0)]")
 }
 
 // Test_getalldevices is where a wildcard is used for target - path is ignored
@@ -118,7 +118,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 	deviceListStr := utils.StrVal(result.Notification[0].Update[0].Val)
 
 	assert.Equal(t, deviceListStr,
-		"[Device1 (1.0.0), Device2 (1.0.0), Device2 (2.0.0), device-1-device-simulator (1.0.0), device-2-device-simulator (1.0.0), device-3-device-simulator (1.0.0), localhost:10161 (1.0.0), localhost:10162 (1.0.0), localhost:10163 (1.0.0), localhost:50001 (1.0.0)]",
+		"[Device1 (1.0.0), Device2 (1.0.0), Device2 (2.0.0), device-1-device-simulator (1.0.0), device-2-device-simulator (1.0.0), device-3-device-simulator (1.0.0), localhost-1 (1.0.0), localhost-2 (1.0.0), localhost-3 (1.0.0), stratum-sim-1 (1.0.0)]",
 		"Expected value")
 }
 

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -96,14 +96,14 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 	value1Str := gnmi.TypedValue_StringVal{StringVal: "newValue2b"}
 	value := gnmi.TypedValue{Value: &value1Str}
 
-	updatePath1 := gnmi.Path{Elem: pathElemsRefs1.Elem, Target: "localhost:10161"}
+	updatePath1 := gnmi.Path{Elem: pathElemsRefs1.Elem, Target: "localhost-1"}
 	updatedPaths = append(updatedPaths, &gnmi.Update{Path: &updatePath1, Val: &value})
 
 	pathElemsRefs2, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2c"})
 	value2Str := gnmi.TypedValue_StringVal{StringVal: "newValue2c"}
 	value2 := gnmi.TypedValue{Value: &value2Str}
 
-	updatePath2 := gnmi.Path{Elem: pathElemsRefs2.Elem, Target: "localhost:10161"}
+	updatePath2 := gnmi.Path{Elem: pathElemsRefs2.Elem, Target: "localhost-1"}
 	updatedPaths = append(updatedPaths, &gnmi.Update{Path: &updatePath2, Val: &value2})
 
 	var setRequest = gnmi.SetRequest{
@@ -128,7 +128,7 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 
 	// Response parts might not be in the same order because changes are stored in a map
 	for _, res := range setResponse.Response {
-		assert.Equal(t, res.Path.Target, "localhost:10161")
+		assert.Equal(t, res.Path.Target, "localhost-1")
 	}
 }
 
@@ -145,10 +145,10 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 	typedValue := gnmi.TypedValue_StringVal{StringVal: "2ndValue2a"}
 	value := gnmi.TypedValue{Value: &typedValue}
 
-	updatePathTgt1 := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "localhost:10161"}
+	updatePathTgt1 := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "localhost-1"}
 	updatedPaths = append(updatedPaths, &gnmi.Update{Path: &updatePathTgt1, Val: &value})
 
-	updatePathTgt2 := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "localhost:10162"}
+	updatePathTgt2 := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "localhost-2"}
 	updatedPaths = append(updatedPaths, &gnmi.Update{Path: &updatePathTgt2, Val: &value})
 
 	var setRequest = gnmi.SetRequest{
@@ -194,21 +194,21 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 
 	// 2 changes on Target 1
 	updatedPaths = append(updatedPaths, &gnmi.Update{
-		Path: &gnmi.Path{Elem: pathElemsRefs2a.Elem, Target: "localhost:10161"},
+		Path: &gnmi.Path{Elem: pathElemsRefs2a.Elem, Target: "localhost-1"},
 		Val:  &gnmi.TypedValue{Value: &valueStr2a},
 	})
 	updatedPaths = append(updatedPaths, &gnmi.Update{
-		Path: &gnmi.Path{Elem: pathElemsRefs2b.Elem, Target: "localhost:10161"},
+		Path: &gnmi.Path{Elem: pathElemsRefs2b.Elem, Target: "localhost-1"},
 		Val:  &gnmi.TypedValue{Value: &valueStr2b},
 	})
 
 	// 2 changes on Target 2 - one of them is a delete
 	updatedPaths = append(updatedPaths, &gnmi.Update{
-		Path: &gnmi.Path{Elem: pathElemsRefs2a.Elem, Target: "localhost:10162"},
+		Path: &gnmi.Path{Elem: pathElemsRefs2a.Elem, Target: "localhost-2"},
 		Val:  &gnmi.TypedValue{Value: &valueStr2a},
 	})
 	deletePaths = append(deletePaths,
-		&gnmi.Path{Elem: pathElemsRefs2c.Elem, Target: "localhost:10162"})
+		&gnmi.Path{Elem: pathElemsRefs2c.Elem, Target: "localhost-2"})
 
 	var setRequest = gnmi.SetRequest{
 		Delete:  deletePaths,
@@ -228,7 +228,7 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 	// The order of response items is not ordered because it is held in a map
 	for _, res := range setResponse.Response {
 		if res.Op.String() == gnmi.UpdateResult_DELETE.String() {
-			assert.Equal(t, res.Path.Target, "localhost:10162")
+			assert.Equal(t, res.Path.Target, "localhost-2")
 		}
 	}
 }
@@ -248,7 +248,7 @@ func Test_doDuplicateSetSingleTarget(t *testing.T) {
 		&gnmi.Update{
 			Path: &gnmi.Path{
 				Elem:   pathElemsRefs2a.Elem,
-				Target: "localhost:10161",
+				Target: "localhost-1",
 			},
 			Val: &gnmi.TypedValue{Value: &valueStr2a},
 		})
@@ -259,7 +259,7 @@ func Test_doDuplicateSetSingleTarget(t *testing.T) {
 		&gnmi.Update{
 			Path: &gnmi.Path{
 				Elem:   pathElemsRefs2b.Elem,
-				Target: "localhost:10161",
+				Target: "localhost-1",
 			},
 			Val: &gnmi.TypedValue{Value: &valueStr2b},
 		})
@@ -307,7 +307,7 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 		&gnmi.Update{
 			Path: &gnmi.Path{
 				Elem:   pathElemsRefs2a.Elem,
-				Target: "localhost:10161",
+				Target: "localhost-1",
 			},
 			Val: &gnmi.TypedValue{Value: &valueStr2a},
 		})
@@ -315,7 +315,7 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 		&gnmi.Update{
 			Path: &gnmi.Path{
 				Elem:   pathElemsRefs2a.Elem,
-				Target: "localhost:10162",
+				Target: "localhost-2",
 			},
 			Val: &gnmi.TypedValue{Value: &valueStr2a},
 		})
@@ -326,7 +326,7 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 		&gnmi.Update{
 			Path: &gnmi.Path{
 				Elem:   pathElemsRefs2b.Elem,
-				Target: "localhost:10161",
+				Target: "localhost-1",
 			},
 			Val: &gnmi.TypedValue{Value: &valueStr2b},
 		})
@@ -335,7 +335,7 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 		&gnmi.Update{
 			Path: &gnmi.Path{
 				Elem:   pathElemsRefs2b.Elem,
-				Target: "localhost:10162",
+				Target: "localhost-2",
 			},
 			Val: &gnmi.TypedValue{Value: &valueStr2b},
 		})
@@ -380,7 +380,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 	update1a := gnmi.Update{
 		Path: &gnmi.Path{
 			Elem:   pathElemsRefs2a.Elem,
-			Target: "localhost:10161",
+			Target: "localhost-1",
 		},
 		Val: &gnmi.TypedValue{Value: &valueStr2a},
 	}
@@ -388,7 +388,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 	update2a := gnmi.Update{
 		Path: &gnmi.Path{
 			Elem:   pathElemsRefs2a.Elem,
-			Target: "localhost:10162",
+			Target: "localhost-2",
 		},
 		Val: &gnmi.TypedValue{Value: &valueStr2a},
 	}
@@ -399,7 +399,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 	update1b := gnmi.Update{
 		Path: &gnmi.Path{
 			Elem:   pathElemsRefs2b.Elem,
-			Target: "localhost:10161",
+			Target: "localhost-1",
 		},
 		Val: &gnmi.TypedValue{Value: &valueStr2b},
 	}
@@ -407,7 +407,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 	update2b := gnmi.Update{
 		Path: &gnmi.Path{
 			Elem:   pathElemsRefs2b.Elem,
-			Target: "localhost:10162",
+			Target: "localhost-2",
 		},
 		Val: &gnmi.TypedValue{Value: &valueStr2b},
 	}
@@ -436,7 +436,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 	update2b1 := gnmi.Update{
 		Path: &gnmi.Path{
 			Elem:   pathElemsRefs2b.Elem,
-			Target: "localhost:10162",
+			Target: "localhost-2",
 		},
 		Val: &gnmi.TypedValue{Value: &valueStr2aCh},
 	}

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -137,7 +137,7 @@ func collector(updateChan chan<- *gnmi.Update, request *gnmi.SubscriptionList) {
 
 func broadcastConfigNotification() {
 	mgr := manager.GetManager()
-	changesChan, err := mgr.Dispatcher.Register("GnmiSubscribeNorthBound", false)
+	changesChan, err := mgr.Dispatcher.RegisterNbi("GnmiSubscribeNorthBound")
 	if err != nil {
 		log.Println("Error while subscribing to updates", err)
 	}

--- a/pkg/southbound/testdata/deviceStore.json
+++ b/pkg/southbound/testdata/deviceStore.json
@@ -3,6 +3,7 @@
   "Storetype": "device",
   "Store": {
     "localhost-1": {
+      "ID": "localhost-1",
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
@@ -10,11 +11,13 @@
       "Timeout": 10000000000
     },
     "localhost-2": {
+      "ID": "localhost-2",
       "Addr": "localhost:10162",
       "SoftwareVersion": "1.0.0",
       "Timeout": 10000000000
     },
     "localhost-3": {
+      "ID": "localhost-3",
       "Addr": "localhost:10163",
       "SoftwareVersion": "1.0.0",
       "Timeout": 10000000000

--- a/pkg/southbound/topocache/testdata/deviceStore.json
+++ b/pkg/southbound/topocache/testdata/deviceStore.json
@@ -3,6 +3,7 @@
   "Storetype": "device",
   "Store": {
     "localhost-1": {
+      "ID": "localhost-1",
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
@@ -10,10 +11,12 @@
       "Timeout": 10000000000
     },
     "localhost-2": {
+      "ID": "localhost-2",
       "Addr": "localhost:10162",
       "SoftwareVersion": "1.0.0"
     },
     "localhost-3": {
+      "ID": "localhost-3",
       "Addr": "localhost:10163",
       "SoftwareVersion": "1.0.0"
     }

--- a/pkg/southbound/topocache/testdata/deviceStoreMismatchId.json
+++ b/pkg/southbound/topocache/testdata/deviceStoreMismatchId.json
@@ -7,18 +7,12 @@
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
-      "Pwd": "notused",
-      "Timeout": 10000000000
+      "Pwd": "notused"
     },
     "localhost-2": {
-      "ID": "localhost-2",
-      "Addr": "localhost:101621",
+      "ID": "localhost-12",
+      "Addr": "localhost:10162",
       "SoftwareVersion": "1.0.0"
-    },
-    "localhost-2": {
-      "ID": "localhost-2",
-      "Addr": "localhost:101622",
-      "SoftwareVersion": "2.0.0"
     },
     "localhost-3": {
       "ID": "localhost-3",

--- a/pkg/southbound/topocache/testdata/deviceStoreNoAddr.json
+++ b/pkg/southbound/topocache/testdata/deviceStoreNoAddr.json
@@ -3,15 +3,18 @@
   "Storetype": "device",
   "Store": {
     "localhost-1": {
+      "ID": "localhost-1",
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
       "Pwd": "notused"
     },
     "localhost-2": {
+      "ID": "localhost-2",
       "SoftwareVersion": "1.0.0"
     },
     "localhost-3": {
+      "ID": "localhost-3",
       "Addr": "localhost:10163",
       "SoftwareVersion": "1.0.0"
     }

--- a/pkg/southbound/topocache/testdata/deviceStoreNoId.json
+++ b/pkg/southbound/topocache/testdata/deviceStoreNoId.json
@@ -7,18 +7,11 @@
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
-      "Pwd": "notused",
-      "Timeout": 10000000000
+      "Pwd": "notused"
     },
     "localhost-2": {
-      "ID": "localhost-2",
-      "Addr": "localhost:101621",
+      "Addr": "localhost:10162",
       "SoftwareVersion": "1.0.0"
-    },
-    "localhost-2": {
-      "ID": "localhost-2",
-      "Addr": "localhost:101622",
-      "SoftwareVersion": "2.0.0"
     },
     "localhost-3": {
       "ID": "localhost-3",

--- a/pkg/southbound/topocache/testdata/deviceStoreNoVersion.json
+++ b/pkg/southbound/topocache/testdata/deviceStoreNoVersion.json
@@ -3,6 +3,7 @@
   "Storetype": "device",
   "Store": {
     "localhost-1": {
+      "ID": "localhost-1",
       "Addr": "localhost:10161",
       "SoftwareVersion": "1.0.0",
       "User": "devicesim",
@@ -10,9 +11,11 @@
       "Timeout": 10000000000
     },
     "localhost-2": {
+      "ID": "localhost-2",
       "Addr": "localhost:10162"
     },
     "localhost-3": {
+      "ID": "localhost-3",
       "Addr": "localhost:10163",
       "SoftwareVersion": "1.0.0"
     }

--- a/pkg/southbound/topocache/topocache_test.go
+++ b/pkg/southbound/topocache/topocache_test.go
@@ -55,6 +55,16 @@ func Test_DeviceStoreNoSwVer(t *testing.T) {
 	assert.ErrorContains(t, err, "has blank software version")
 }
 
+func Test_DeviceStoreNoId(t *testing.T) {
+	_, err := LoadDeviceStore("testdata/deviceStoreNoId.json", nil)
+	assert.ErrorContains(t, err, "has blank ID")
+}
+
+func Test_DeviceStoremismatchedId(t *testing.T) {
+	_, err := LoadDeviceStore("testdata/deviceStoreMismatchId.json", nil)
+	assert.ErrorContains(t, err, "ID mismatch with key")
+}
+
 func Test_NonexistentDeviceStore(t *testing.T) {
 	topoChannel := make(chan events.TopoEvent, 10)
 	_, err := LoadDeviceStore("testdata/noSuchDeviceStore.json", topoChannel)
@@ -73,7 +83,7 @@ func Test_DeviceStoreDuplicates(t *testing.T) {
 
 func Test_AddDevice(t *testing.T) {
 	deviceStore := loadDeviceStore(t)
-	deviceStore.AddOrUpdateDevice("foobar", Device{Addr: "foobar:123", SoftwareVersion: "1.0"})
+	deviceStore.AddOrUpdateDevice("foobar", Device{ID: "foobar", Addr: "foobar:123", SoftwareVersion: "1.0"})
 	d, ok := deviceStore.Store["foobar"]
 	assert.Assert(t, ok, "device not added")
 	assert.Assert(t, d.Addr == "foobar:123", "wrong device added")

--- a/pkg/store/store-api_test.go
+++ b/pkg/store/store-api_test.go
@@ -502,24 +502,24 @@ func TestCreateConfiguration_badname(t *testing.T) {
 
 func TestCreateConfiguration_badversion(t *testing.T) {
 	_, err :=
-		CreateConfiguration("localhost:10161", "1.234567890", "TestDevice",
+		CreateConfiguration("localhost-1", "1.234567890", "TestDevice",
 			[]gnmi.ModelData{}, []change.ID{})
 	assert.ErrorContains(t, err, "version 1.234567890 does not match pattern", "Too long")
 
 	_, err =
-		CreateConfiguration("localhost:10161", "a", "TestDevice",
+		CreateConfiguration("localhost-1", "a", "TestDevice",
 			[]gnmi.ModelData{}, []change.ID{})
 	assert.ErrorContains(t, err, "version a does not match pattern", "Too short")
 
 	_, err =
-		CreateConfiguration("localhost:10161", "1:0:0", "TestDevice",
+		CreateConfiguration("localhost-1", "1:0:0", "TestDevice",
 			[]gnmi.ModelData{}, []change.ID{})
 	assert.ErrorContains(t, err, "version 1:0:0 does not match pattern", "Illegal char")
 }
 
 func TestCreateConfiguration_badtype(t *testing.T) {
 	_, err :=
-		CreateConfiguration("localhost:10161", "1.0.0", "TestDeviceType",
+		CreateConfiguration("localhost-1", "1.0.0", "TestDeviceType",
 			[]gnmi.ModelData{}, []change.ID{})
 	assert.ErrorContains(t, err, "deviceType TestDeviceType does not match pattern", "Too long")
 }


### PR DESCRIPTION
I have renamed **localhost:10161** to **localhost-1** etc in all of the stores, to show that the Topocache device ID is not restricted to be an address
The address is only specified in the Addr field of TopoCache


Ray/Jordan I have updated the same file as you did yesterday:
```
deployments/helm/onos-config/templates/configmap.yaml
```
 I think
```
{{ printf "%s:10161" $device | quote }}
```
on lines 17 and 18 (but not 19) can become
```
{{ printf "%s" $device | quote }}
```
please look to see if this will break anything else