### PR TITLE
Remove port number from device ID in Helm generated device store

### DIFF
--- a/deployments/helm/onos-config/templates/configmap.yaml
+++ b/deployments/helm/onos-config/templates/configmap.yaml
@@ -14,8 +14,8 @@ data:
       "Storetype": "device",
       "Store": {
         {{- range $i, $device := .Values.devices }}
-        {{ if $i }},{{ end}}{{ printf "%s:10161" $device | quote }}: {
-          "ID": {{ printf "%s:10161" $device | quote }},
+        {{ if $i }},{{ end}}{{ printf "%s" $device | quote }}: {
+          "ID": {{ printf "%s" $device | quote }},
           "Addr": {{ printf "%s:10161" $device | quote }},
           "Timeout": 10000000000,
           "SoftwareVersion": "1.0.0"


### PR DESCRIPTION
This PR removes the port number from the device ID in the device store generated by the Helm chart. However, I found that this actually produces a bug, and I haven't been able to determine why. An example of the configuration generated by this change is:
```
   {
      "Version": "1.0.0",
      "Storetype": "device",
      "Store": {
        "device-1-device-simulator": {
          "ID": "device-1-device-simulator",
          "Addr": "device-1-device-simulator:10161",
          "Timeout": 10000000000,
          "SoftwareVersion": "1.0.0"
        }
      }
    }
```
This appears to be consistent with the device store samples, but the onos-config logs show it has no `Addr` for the device:
```
2019/06/11 18:57:24 Operational State Event listener initialized
2019/06/11 18:57:24 Event listener initialized
2019/06/11 18:57:24 Registering device-1-device-simulator:10161 on channel w0xc0001d4000
2019/06/11 18:57:24 Connecting to  over gNMI
2019/06/11 18:57:24 Loading default CA onfca
2019/06/11 18:57:24 Loading default certificates
2019/06/11 18:57:24 Registering GnmiSubscribeNorthBound on channel w0xc00006a6c0
```

It obviously knows the device's address (device-1-device-simulator:10161), but the line `2019/06/11 18:57:24 Connecting to  over gNMI` should be printing the device's address. It appears `factory.go` is for some reason trying to lookup the device by its `Addr` rather than its `ID`.