### PR TITLE
Remove calls to compile protos during binary/image build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ ONOS_BUILD_VERSION := stable
 all: image
 
 image: # @HELP build onos-config image
-	docker run --rm -it -v `pwd`:/go/src/github.com/onosproject/onos-config onosproject/golang-build:${ONOS_BUILD_VERSION} protos
 	docker build . -f build/onos-config/Dockerfile \
 	--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 	-t onosproject/onos-config:${ONOS_CONFIG_VERSION}
@@ -35,7 +34,7 @@ protos: # @HELP compile the protobuf files
 	./build/dev-docker/compile-protos.sh
 
 build: # @HELP build the go binary in the cmd/onos-config package
-build: protos test
+build: test
 	export GOOS=linux
 	export GOARCH=amd64
 	go build -o build/_output/onos-config ./cmd/onos-config


### PR DESCRIPTION
The Makefile currently re-generates Protobuf types both when building the binary and when building the image. But code generation should only be run when `.proto` files are changed. So this PR removes the `proto` target from all other targets. When changes are made to `.proto` files, `make protos` needs to be run manually to generate files.