### PR TITLE
Add PartitionSet to onos-config Helm chart

### DIFF
--- a/deployments/helm/onos-config/templates/deployment.yaml
+++ b/deployments/helm/onos-config/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: ATOMIX_CONTROLLER
+              value: {{ .Values.store.controller | quote }}
+            - name: ATOMIX_APP
+              value: {{ template "fullname" . }}
           command:
             - onos-config
           args:

--- a/deployments/helm/onos-config/templates/deployment.yaml
+++ b/deployments/helm/onos-config/templates/deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ .Values.store.controller | quote }}
             - name: ATOMIX_APP
               value: {{ template "fullname" . }}
+            - name: ATOMIX_RAFT_GROUP
+              value: {{ template "fullname" . }}-raft
           command:
             - onos-config
           args:

--- a/deployments/helm/onos-config/templates/partitionset.yaml
+++ b/deployments/helm/onos-config/templates/partitionset.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.store.enabled }}
+apiVersion: k8s.atomix.io/v1alpha1
+kind: PartitionSet
+metadata:
+  name: {{ template "fullname" . }}-raft
+  chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  release: "{{ .Release.Name }}"
+  heritage: "{{ .Release.Service }}"
+spec:
+  partitions: {{ .Values.store.raft.partitions }}
+  template:
+    spec:
+      size: {{ .Values.store.raft.partitionSize }}
+      protocol: raft
+      config: |
+        electionTimeout: 5s
+        heartbeatInterval: 1s
+{{- end }}

--- a/deployments/helm/onos-config/values.yaml
+++ b/deployments/helm/onos-config/values.yaml
@@ -11,6 +11,13 @@ image:
 
 devices: []
 
+store:
+  enabled: false
+  controller: atomix-controller.kube-system.svc.cluster.local:5679
+  raft:
+    partitions: 3
+    partitionSize: 3
+
 resources:
   requests:
     cpu: 0.5


### PR DESCRIPTION
#310 

This PR adds a `PartitionSet` to the Helm chart. When the chart is deployed with `--set store.enabled=true`, a set of Raft partitions will be deployed with the onos-config pod. It also sets environment variables which can be used by onos-config to connect to the Atomix cluster, connect to Raft partitions, and create namespaced primitives for the onos-config app.

Usage of the `store.enabled` option requires that the [Atomix Kubernetes Controller](https://github.com/atomix/atomix-k8s-controller) be installed in the k8s cluster. The controller defines the `PartitionSet` and `Partition` custom resources and handles configuration/deployment of Atomix protocols. You can use the Atomix CLI to install the controller:
```
> go get -u github.com/atomix/atomix-cli/cmd/atomix
> atomix controller deploy k8s | kubectl apply -f -
```

This PR should be safe to merge since partitions are disabled by default. 