### PR TITLE
Support DEBUG variable to build binaries with debugging support enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@ export CGO_ENABLED=0
 .PHONY: build
 
 ONOS_CONFIG_VERSION := latest
+ONOS_CONFIG_DEBUG_VERSION := debug
 ONOS_BUILD_VERSION := stable
-ONOS_CONFIG_BUILD_FLAGS := ""
 
 build: # @HELP build the Go binaries and run all validations (default)
 build: test
 ifndef DEBUG
 	go build -o build/_output/onos-config ./cmd/onos-config
 else
-	go build -gcflags "-N -l" -o build/_output/onos-config ./cmd/onos-config
+	go build -gcflags "all=-N -l" -o build/_output/onos-config ./cmd/onos-config
 endif
 	go build -o build/_output/onos ./cmd/onos
 	go build -o build/_output/testdevice.so.1.0.0 -buildmode=plugin ./modelplugin/TestDevice-1.0.0
@@ -55,9 +55,13 @@ protos: # @HELP compile the protobuf files (using protoc-go Docker)
 
 onos-config-docker: # @HELP build onos-config Docker image
 	docker build . -f build/onos-config/Dockerfile \
-		--build-arg ONOS_CONFIG_DEBUG=${DEBUG} \
     	--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config:${ONOS_CONFIG_VERSION}
+
+onos-config-docker-debug: # @HELP build onos-config Docker debug image
+	docker build . -f build/onos-config-debug/Dockerfile \
+		--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
+		-t onosproject/onos-config:${ONOS_CONFIG_DEBUG_VERSION}
 
 onos-cli-docker: # @HELP build onos-cli Docker image
 	docker build . -f build/onos-cli/Dockerfile \
@@ -65,7 +69,7 @@ onos-cli-docker: # @HELP build onos-cli Docker image
         -t onosproject/onos-cli:${ONOS_CONFIG_VERSION}
 
 images: # @HELP build all Docker images
-images: onos-config-docker onos-cli-docker
+images: onos-config-docker onos-config-docker-debug onos-cli-docker
 
 all: build images
 

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,15 @@ export CGO_ENABLED=0
 
 ONOS_CONFIG_VERSION := latest
 ONOS_BUILD_VERSION := stable
+ONOS_CONFIG_BUILD_FLAGS := ""
 
 build: # @HELP build the Go binaries and run all validations (default)
 build: test
+ifndef DEBUG
 	go build -o build/_output/onos-config ./cmd/onos-config
+else
+	go build -gcflags "-N -l" -o build/_output/onos-config ./cmd/onos-config
+endif
 	go build -o build/_output/onos ./cmd/onos
 	go build -o build/_output/testdevice.so.1.0.0 -buildmode=plugin ./modelplugin/TestDevice-1.0.0
 	go build -o build/_output/testdevice.so.2.0.0 -buildmode=plugin ./modelplugin/TestDevice-2.0.0
@@ -50,6 +55,7 @@ protos: # @HELP compile the protobuf files (using protoc-go Docker)
 
 onos-config-docker: # @HELP build onos-config Docker image
 	docker build . -f build/onos-config/Dockerfile \
+		--build-arg ONOS_CONFIG_DEBUG=${DEBUG} \
     	--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config:${ONOS_CONFIG_VERSION}
 

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ onos-config-docker: # @HELP build onos-config Docker image
     	--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config:${ONOS_CONFIG_VERSION}
 
-onos-config-docker-debug: # @HELP build onos-config Docker debug image
+onos-config-debug-docker: # @HELP build onos-config Docker debug image
 	docker build . -f build/onos-config-debug/Dockerfile \
 		--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config:${ONOS_CONFIG_DEBUG_VERSION}
@@ -69,12 +69,12 @@ onos-cli-docker: # @HELP build onos-cli Docker image
         -t onosproject/onos-cli:${ONOS_CONFIG_VERSION}
 
 images: # @HELP build all Docker images
-images: onos-config-docker onos-config-docker-debug onos-cli-docker
+images: onos-config-docker onos-config-debug-docker onos-cli-docker
 
 all: build images
 
 run-docker: # @HELP run onos-config docker image
-run-docker: images
+run-docker: onos-config-docker
 	docker run -d -p 5150:5150 -v `pwd`/configs:/etc/onos-config \
     	--name onos-config onosproject/onos-config \
     	-configStore=/etc/onos-config/configStore-sample.json \

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -1,0 +1,27 @@
+ARG ONOS_BUILD_VERSION=stable
+
+FROM onosproject/golang-build:$ONOS_BUILD_VERSION as onosBuilder
+COPY . /go/src/github.com/onosproject/onos-config
+RUN cd /go/src/github.com/onosproject/onos-config && DEBUG=true make build
+
+FROM golang:1.12.6-alpine3.9 as debugBuilder
+
+RUN apk upgrade --update --no-cache && apk add git && go get -u github.com/go-delve/delve/cmd/dlv
+
+FROM alpine:3.8
+
+COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/onos-config /usr/local/bin/onos-config
+COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0
+COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
+COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
+COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
+
+RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
+    echo "dlv --listen=:40000 --headless=true --api-version=2 exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
+    chmod +x /usr/local/bin/onos-config-debug
+
+RUN addgroup -S onos-config && adduser -S -G onos-config onos-config
+USER onos-config
+WORKDIR /home/onos-config
+
+ENTRYPOINT ["onos-config-debug"]

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -2,13 +2,13 @@ ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION as onosBuilder
 COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && DEBUG=true make build
+RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 DEBUG=true make build
 
 FROM golang:1.12.6-alpine3.9 as debugBuilder
 
 RUN apk upgrade --update --no-cache && apk add git && go get -u github.com/go-delve/delve/cmd/dlv
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/onos-config /usr/local/bin/onos-config
 COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0

--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,8 +1,9 @@
 ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION as builder
+ARG ONOS_CONFIG_DEBUG=""
 COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 make build
+RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 DEBUG=$ONOS_CONFIG_DEBUG make build
 
 FROM alpine:3.8
 

--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,9 +1,8 @@
 ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION as builder
-ARG ONOS_CONFIG_DEBUG=""
 COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 DEBUG=$ONOS_CONFIG_DEBUG make build
+RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 make build
 
 FROM alpine:3.8
 

--- a/deployments/helm/onos-config/templates/deployment.yaml
+++ b/deployments/helm/onos-config/templates/deployment.yaml
@@ -44,8 +44,6 @@ spec:
               value: {{ template "fullname" . }}
             - name: ATOMIX_RAFT_GROUP
               value: {{ template "fullname" . }}-raft
-          command:
-            - onos-config
           args:
             - "-caPath=/etc/onos-config/certs/tls.cacrt"
             - "-keyPath=/etc/onos-config/certs/tls.key"
@@ -61,6 +59,11 @@ spec:
           ports:
             - name: grpc
               containerPort: 5150
+            {{- if .Values.debug }}
+            - name: debug
+              containerPort: 40000
+              protocol: TCP
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: 5150
@@ -80,6 +83,12 @@ spec:
             - name: secret
               mountPath: /etc/onos-config/certs
               readOnly: true
+      {{- if .Values.debug }}
+      securityContext:
+        capabilities:
+          add:
+            - SYS_PTRACE
+      {{- end }}
       {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{- range .Values.image.pullSecrets }}

--- a/deployments/helm/onos-config/templates/deployment.yaml
+++ b/deployments/helm/onos-config/templates/deployment.yaml
@@ -59,11 +59,15 @@ spec:
           ports:
             - name: grpc
               containerPort: 5150
+            # Expose the debug port for debugging
             {{- if .Values.debug }}
             - name: debug
               containerPort: 40000
               protocol: TCP
             {{- end }}
+          # Disable probes for debugging since application starts paused
+          # See https://github.com/go-delve/delve/issues/245
+          {{- if not .Values.debug }}
           readinessProbe:
             tcpSocket:
               port: 5150
@@ -74,6 +78,7 @@ spec:
               port: 5150
             initialDelaySeconds: 15
             periodSeconds: 20
+          {{- end }}
           # Mount the test configuration
           # TODO: This should be removed when stores are added!
           volumeMounts:
@@ -83,6 +88,7 @@ spec:
             - name: secret
               mountPath: /etc/onos-config/certs
               readOnly: true
+      # Enable ptrace for debugging
       {{- if .Values.debug }}
       securityContext:
         capabilities:

--- a/deployments/helm/onos-config/values.yaml
+++ b/deployments/helm/onos-config/values.yaml
@@ -9,6 +9,8 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+debug: false
+
 devices: []
 
 store:


### PR DESCRIPTION
This PR adds support for building binaries with support for debugging enabled. This is done by supporting a `DEBUG` environment variable in the Makefile. When set, the `go build` command for onos-config is modified to add flags for the compiler to enable remote debugging. Additionally, the Dockerfile is updated to support the `DEBUG` flag through build arguments, so a debug image can be built.

This is just a first pass at this to ensure we can properly support debugging in k8s. I'm open to suggestions. I actually haven't been able to test this change in k8s because the `make images` command is failing for me (I'll open another bug report for that issue) on this PR and in master.

@ray-milkey once we figure this out, I think the Docker-y thing to do would be to always produce both an `onosproject/onos-config:x.x.x` image _and_ an `onosproject/onos-config:x.x.x-debug` image so users can deploy clusters with debugging enabled by changing the image, e.g. `helm install --set image="onosproject/onos-config:1.2.3-debug"`