### PR TITLE
gNMI Northbound Error propagation

### DIFF
--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/store"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"log"
 	"time"
 
@@ -38,7 +40,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 	for _, path := range req.GetPath() {
 		update, err := getUpdate(prefix, path)
 		if err != nil {
-			return nil, err
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 		notification := &gnmi.Notification{
 			Timestamp: time.Now().Unix(),
@@ -52,7 +54,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 	if len(req.GetPath()) == 0 {
 		update, err := getUpdate(prefix, nil)
 		if err != nil {
-			return nil, err
+			return nil, status.Error(codes.Internal, err.Error())
 		}
 		notification := &gnmi.Notification{
 			Timestamp: time.Now().Unix(),

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -76,8 +76,8 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionDeviceType {
 			deviceType = string(ext.GetRegisteredExt().GetMsg())
 		} else {
-			return nil, fmt.Errorf("Unexpected extension %d = '%s' in Set()",
-				ext.GetRegisteredExt().GetId(), ext.GetRegisteredExt().GetMsg())
+			return nil, status.Error(codes.InvalidArgument, fmt.Errorf("Unexpected extension %d = '%s' in Set()",
+				ext.GetRegisteredExt().GetId(), ext.GetRegisteredExt().GetMsg()).Error())
 		}
 	}
 
@@ -89,7 +89,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 
 	if len(updateResults) == 0 {
 		log.Println("All target changes were duplicated - Set rejected")
-		return nil, status.Error(codes.Internal, fmt.Errorf("set change rejected as it is a "+
+		return nil, status.Error(codes.AlreadyExists, fmt.Errorf("set change rejected as it is a "+
 			"duplicate of the last change for all targets").Error())
 	}
 
@@ -100,7 +100,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	// Look for use of this name already
 	for _, nwCfg := range manager.GetManager().NetworkStore.Store {
 		if nwCfg.Name == netcfgchangename {
-			return nil, status.Error(codes.Internal, fmt.Errorf(
+			return nil, status.Error(codes.InvalidArgument, fmt.Errorf(
 				"Name %s is already used for a Network Configuration", netcfgchangename).Error())
 		}
 	}

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -17,10 +17,6 @@ package gnmi
 import (
 	"context"
 	"fmt"
-	"log"
-	"strings"
-	"time"
-
 	"github.com/docker/docker/pkg/namesgenerator"
 	"github.com/onosproject/onos-config/pkg/manager"
 	"github.com/onosproject/onos-config/pkg/store"
@@ -28,11 +24,111 @@ import (
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"log"
+	"strings"
+	"time"
 )
 
 type mapTargetUpdates map[string]map[string]string
 type mapTargetRemoves map[string][]string
 type mapNetworkChanges map[store.ConfigName]change.ID
+
+// Set implements gNMI Set
+func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetResponse, error) {
+	// There is only one set of extensions in Set request, regardless of number of
+	// updates
+	var (
+		netcfgchangename string // May be specified as 100 in extension
+		version          string // May be specified as 101 in extension
+		deviceType       string // May be specified as 102 in extension
+	)
+
+	targetUpdates := make(mapTargetUpdates)
+	targetRemoves := make(mapTargetRemoves)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	//Update
+	for _, u := range req.GetUpdate() {
+		target := u.Path.GetTarget()
+		targetUpdates[target] = s.doUpdateOrReplace(u, targetUpdates)
+	}
+
+	//Replace
+	for _, u := range req.GetReplace() {
+		target := u.Path.GetTarget()
+		targetUpdates[target] = s.doUpdateOrReplace(u, targetUpdates)
+	}
+
+	//Delete
+	for _, u := range req.GetDelete() {
+		target := u.GetTarget()
+		targetRemoves[target] = s.doDelete(u, targetRemoves)
+	}
+
+	for _, ext := range req.GetExtension() {
+		if ext.GetRegisteredExt().GetId() == GnmiExtensionNetwkChangeID {
+			netcfgchangename = string(ext.GetRegisteredExt().GetMsg())
+		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionVersion {
+			version = string(ext.GetRegisteredExt().GetMsg())
+		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionDeviceType {
+			deviceType = string(ext.GetRegisteredExt().GetMsg())
+		} else {
+			return nil, fmt.Errorf("Unexpected extension %d = '%s' in Set()",
+				ext.GetRegisteredExt().GetId(), ext.GetRegisteredExt().GetMsg())
+		}
+	}
+
+	updateResults, networkChanges, err :=
+		s.buildUpdateResults(targetUpdates, targetRemoves, version, deviceType)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	if len(updateResults) == 0 {
+		log.Println("All target changes were duplicated - Set rejected")
+		return nil, status.Error(codes.Internal, fmt.Errorf("set change rejected as it is a "+
+			"duplicate of the last change for all targets").Error())
+	}
+
+	if netcfgchangename == "" {
+		netcfgchangename = namesgenerator.GetRandomName(0)
+	}
+
+	// Look for use of this name already
+	for _, nwCfg := range manager.GetManager().NetworkStore.Store {
+		if nwCfg.Name == netcfgchangename {
+			return nil, status.Error(codes.Internal, fmt.Errorf(
+				"Name %s is already used for a Network Configuration", netcfgchangename).Error())
+		}
+	}
+
+	networkConfig, err := store.NewNetworkConfiguration(netcfgchangename, "User1", networkChanges)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+
+	manager.GetManager().NetworkStore.Store =
+		append(manager.GetManager().NetworkStore.Store, *networkConfig)
+
+	setResponse := &gnmi.SetResponse{
+		Response:  updateResults,
+		Timestamp: time.Now().Unix(),
+		Extension: []*gnmi_ext.Extension{
+			{
+				Ext: &gnmi_ext.Extension_RegisteredExt{
+					RegisteredExt: &gnmi_ext.RegisteredExtension{
+						Id:  100,
+						Msg: []byte(networkConfig.Name),
+					},
+				},
+			},
+		},
+	}
+	return setResponse, nil
+}
 
 func (s *Server) doUpdateOrReplace(u *gnmi.Update, targetUpdates mapTargetUpdates) map[string]string {
 	target := u.Path.GetTarget()
@@ -124,99 +220,4 @@ func (s *Server) buildUpdateResults(targetUpdates mapTargetUpdates,
 	}
 
 	return updateResults, networkChanges, nil
-}
-
-// Set implements gNMI Set
-func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetResponse, error) {
-	// There is only one set of extensions in Set request, regardless of number of
-	// updates
-	var (
-		netcfgchangename string // May be specified as 100 in extension
-		version          string // May be specified as 101 in extension
-		deviceType       string // May be specified as 102 in extension
-	)
-
-	targetUpdates := make(mapTargetUpdates)
-	targetRemoves := make(mapTargetRemoves)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	//Update
-	for _, u := range req.GetUpdate() {
-		target := u.Path.GetTarget()
-		targetUpdates[target] = s.doUpdateOrReplace(u, targetUpdates)
-	}
-
-	//Replace
-	for _, u := range req.GetReplace() {
-		target := u.Path.GetTarget()
-		targetUpdates[target] = s.doUpdateOrReplace(u, targetUpdates)
-	}
-
-	//Delete
-	for _, u := range req.GetDelete() {
-		target := u.GetTarget()
-		targetRemoves[target] = s.doDelete(u, targetRemoves)
-	}
-
-	for _, ext := range req.GetExtension() {
-		if ext.GetRegisteredExt().GetId() == GnmiExtensionNetwkChangeID {
-			netcfgchangename = string(ext.GetRegisteredExt().GetMsg())
-		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionVersion {
-			version = string(ext.GetRegisteredExt().GetMsg())
-		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionDeviceType {
-			deviceType = string(ext.GetRegisteredExt().GetMsg())
-		} else {
-			return nil, fmt.Errorf("Unexpected extension %d = '%s' in Set()",
-				ext.GetRegisteredExt().GetId(), ext.GetRegisteredExt().GetMsg())
-		}
-	}
-
-	updateResults, networkChanges, err :=
-		s.buildUpdateResults(targetUpdates, targetRemoves, version, deviceType)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(updateResults) == 0 {
-		log.Println("All target changes were duplicated - Set rejected")
-		return nil, fmt.Errorf("set change rejected as it is a " +
-			"duplicate of the last change for all targets")
-	}
-
-	if netcfgchangename == "" {
-		netcfgchangename = namesgenerator.GetRandomName(0)
-	}
-
-	// Look for use of this name already
-	for _, nwCfg := range manager.GetManager().NetworkStore.Store {
-		if nwCfg.Name == netcfgchangename {
-			return nil, fmt.Errorf("Name %s is already used for a Network Configuration",
-				netcfgchangename)
-		}
-	}
-
-	networkConfig, err := store.NewNetworkConfiguration(netcfgchangename, "User1", networkChanges)
-	if err != nil {
-		return nil, err
-	}
-
-	manager.GetManager().NetworkStore.Store =
-		append(manager.GetManager().NetworkStore.Store, *networkConfig)
-
-	setResponse := &gnmi.SetResponse{
-		Response:  updateResults,
-		Timestamp: time.Now().Unix(),
-		Extension: []*gnmi_ext.Extension{
-			{
-				Ext: &gnmi_ext.Extension_RegisteredExt{
-					RegisteredExt: &gnmi_ext.RegisteredExtension{
-						Id:  100,
-						Msg: []byte(networkConfig.Name),
-					},
-				},
-			},
-		},
-	}
-	return setResponse, nil
 }

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -275,7 +275,7 @@ func Test_WrongDevice(t *testing.T) {
 
 }
 
-func Test_ErrorDoubleSubsription(t *testing.T) {
+func Test_ErrorDoubleSubscription(t *testing.T) {
 	server, _ := setUp()
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
@@ -311,7 +311,6 @@ func Test_ErrorDoubleSubsription(t *testing.T) {
 		Signal:    make(chan struct{}),
 	}
 
-	//TODO need to block
 	go func() {
 		err = server.Subscribe(serverFake)
 	}()
@@ -320,6 +319,5 @@ func Test_ErrorDoubleSubsription(t *testing.T) {
 	assert.NilError(t, err, "Unexpected error doing Subscribe")
 
 	err = server.Subscribe(serverFake)
-	log.Println("Error", err)
 	assert.ErrorContains(t, err, "is already registered")
 }

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -247,8 +247,9 @@ func Test_WrongDevice(t *testing.T) {
 
 	targets := make(map[string]struct{})
 	subs := make(map[string]struct{})
+	resChan := make(chan result)
 	targets["Device2"] = struct{}{}
-	go listenForUpdates(changeChan, serverFake, mgr, targets, subs)
+	go listenForUpdates(changeChan, serverFake, mgr, targets, subs, resChan)
 	changeChan <- events.CreateConfigEvent("Device1", []byte("test"), true)
 	var response *gnmi.SubscribeResponse
 	select {
@@ -260,7 +261,7 @@ func Test_WrongDevice(t *testing.T) {
 
 	targets["Device1"] = struct{}{}
 	subs["/test1:cont1a/cont2a/leaf3c"] = struct{}{}
-	go listenForUpdates(changeChan, serverFake, mgr, targets, subs)
+	go listenForUpdates(changeChan, serverFake, mgr, targets, subs, resChan)
 	config1Value05, _ := change.CreateChangeValue("/test1:cont1a/cont2a/leaf2c", "def", false)
 	config1Value09, _ := change.CreateChangeValue("/test1:cont1a/list2a[name=txout2]", "", true)
 	change1, err := change.CreateChange(change.ValueCollections{config1Value05, config1Value09}, "Remove txout 2")


### PR DESCRIPTION
Propagates error in the Northbound of gNMI on the gRPC channel through a result go channel and proper codes.

Fixes #331 
