### PR TITLE
Define build architecture in onos-config Dockerfile rather than Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,6 @@ ONOS_BUILD_VERSION := stable
 
 build: # @HELP build the Go binaries and run all validations (default)
 build: test
-	export GOOS=linux
-	export GOARCH=amd64
 	go build -o build/_output/onos-config ./cmd/onos-config
 	go build -o build/_output/onos ./cmd/onos
 	go build -o build/_output/testdevice.so.1.0.0 -buildmode=plugin ./modelplugin/TestDevice-1.0.0

--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -2,7 +2,7 @@ ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION as builder
 COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && make build
+RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 make build
 
 FROM alpine:3.8
 


### PR DESCRIPTION
The Go OS and architecture are currently defined in `make build`. These should be undefined in the Makefile and instead defined in the Dockerfile when building for the Alpine image.