### PR TITLE
Properly unregistering device

### DIFF
--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -58,7 +58,7 @@ func (d *Dispatcher) Listen(changeChannel <-chan events.ConfigEvent) {
 		deviceChan, ok := d.deviceListeners[topocache.ID(events.Event(configEvent).Subject())]
 		if ok {
 			log.Println("Device Simulators must be active")
-			//TODO need a timeout or be done in separate routine
+			//TODO need a timeout or be done in separate routine, blocks if there is some error underneath
 			log.Println(deviceChan)
 			deviceChan <- configEvent
 		}

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -90,6 +90,8 @@ func listenOnChannel(stream gnmi.GNMI_SubscribeServer, mgr *manager.Manager, has
 			code, ok := status.FromError(err)
 			if ok && code.Code() == codes.Canceled {
 				log.Println("Subscription Terminated, Canceled")
+				mgr.Dispatcher.UnregisterNbi(hash)
+				mgr.Dispatcher.UnregisterOperationalState(hash)
 				resChan <- result{success: true, err: nil}
 			} else {
 				log.Println("Error in subscription", err)

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -45,10 +45,10 @@ func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore,
 				dispatcher.UnregisterDevice(deviceName)
 			} else {
 				//spawning two go routines to propagate changes and to get operational state
-				go sync.syncNbConfiguration()
+				go sync.syncConfigEventsToDevice()
 				//TODO error handling
 				go sync.syncOperationalState()
-				//TODO push configuration to the device if any is present
+				//TODO push configuration to the device if any was set before it's connection
 			}
 		} else if dispatcher.HasListener(deviceName) && !topoEvent.Connect() {
 

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -41,11 +41,14 @@ func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore,
 			if err != nil {
 				//TODO propagate the ERROR
 				log.Println("Error in connecting to client", err)
+				//unregistering the listener for changes to the device
+				dispatcher.UnregisterDevice(deviceName)
 			} else {
 				//spawning two go routines to propagate changes and to get operational state
 				go sync.syncNbConfiguration()
 				//TODO error handling
 				go sync.syncOperationalState()
+				//TODO push configuration to the device if any is present
 			}
 		} else if dispatcher.HasListener(deviceName) && !topoEvent.Connect() {
 

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -74,9 +74,9 @@ func New(context context.Context, changeStore *store.ChangeStore, device *topoca
 	return sync, nil
 }
 
-// Devicesync is a go routine that listens out for configuration events specific
+// syncConfigEventsToDevice is a go routine that listens out for configuration events specific
 // to a device and propagates them downwards through southbound interface
-func (sync *Synchronizer) syncNbConfiguration() {
+func (sync *Synchronizer) syncConfigEventsToDevice() {
 
 	for deviceConfigEvent := range sync.deviceConfigChan {
 		change := sync.ChangeStore.Store[deviceConfigEvent.ChangeID()]


### PR DESCRIPTION
Removing a device listener from the listeners stores.
Avoids blocking on the channel when a change is issued for a non connected device.
Enable receiving notifications on NB even if device is disconnected. 