### PR TITLE
Replaced all standard log entries with klog Fixes #324

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -48,6 +48,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
 	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
 	log "k8s.io/klog"
+	"os"
 	"time"
 )
 
@@ -89,7 +90,7 @@ func main() {
 
 	flag.Parse()
 	var err error
-
+	log.SetOutput(os.Stdout)
 	log.Info("Starting onos-config")
 
 	mgr, err := manager.LoadManager(*configStoreFile, *changeStoreFile, *deviceStoreFile, *networkStoreFile)

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
-	"log"
+	log "k8s.io/klog"
 )
 
 // Dispatcher manages SB and NB configuration event listeners
@@ -51,15 +51,14 @@ func NewDispatcher() Dispatcher {
 // Southbound listeners are only sent the events that matter to them
 // All events.Events are sent to northbound listeners
 func (d *Dispatcher) Listen(changeChannel <-chan events.ConfigEvent) {
-	log.Println("Event listener initialized")
+	log.Info("Event listener initialized")
 
 	for configEvent := range changeChannel {
-		log.Println("Listener: Event", configEvent)
+		log.Info("Listener: Event", configEvent)
 		deviceChan, ok := d.deviceListeners[topocache.ID(events.Event(configEvent).Subject())]
 		if ok {
-			log.Println("Device Simulators must be active")
+			log.Warning("Device not connected - config event discarded", configEvent)
 			//TODO need a timeout or be done in separate routine, blocks if there is some error underneath
-			log.Println(deviceChan)
 			deviceChan <- configEvent
 		}
 
@@ -68,7 +67,7 @@ func (d *Dispatcher) Listen(changeChannel <-chan events.ConfigEvent) {
 		}
 
 		if len(d.deviceListeners)+len(d.nbiListeners) == 0 {
-			log.Println("Event discarded", configEvent)
+			log.Info("Event discarded", configEvent)
 		}
 	}
 }
@@ -79,7 +78,7 @@ func (d *Dispatcher) Listen(changeChannel <-chan events.ConfigEvent) {
 // Southbound listeners are only sent the events that matter to them
 // All events.Events are sent to northbound listeners
 func (d *Dispatcher) ListenOperationalState(operationalStateChannel <-chan events.OperationalStateEvent) {
-	log.Println("Operational State Event listener initialized")
+	log.Info("Operational State Event listener initialized")
 
 	for operationalStateEvent := range operationalStateChannel {
 		for _, nbiChan := range d.nbiOpStateListeners {
@@ -96,7 +95,7 @@ func (d *Dispatcher) RegisterDevice(id topocache.ID) (chan events.ConfigEvent, e
 	}
 	channel := make(chan events.ConfigEvent)
 	d.deviceListeners[id] = channel
-	log.Printf("Registering Device %s on channel w%v", id, channel)
+	log.Infof("Registering Device %s on channel w%v", id, channel)
 	return channel, nil
 }
 
@@ -108,7 +107,7 @@ func (d *Dispatcher) RegisterNbi(subscriber string) (chan events.ConfigEvent, er
 	}
 	channel := make(chan events.ConfigEvent)
 	d.nbiListeners[subscriber] = channel
-	log.Printf("Registering NBI %s on channel w%v", subscriber, channel)
+	log.Infof("Registering NBI %s on channel w%v", subscriber, channel)
 	return channel, nil
 }
 
@@ -138,7 +137,7 @@ func (d *Dispatcher) UnregisterDevice(id topocache.ID) error {
 func (d *Dispatcher) UnregisterNbi(subscriber string) {
 	channel, ok := d.nbiListeners[subscriber]
 	if !ok {
-		log.Println(fmt.Sprintf("Subscriber %s had not been registered", subscriber))
+		log.Infof("Subscriber %s had not been registered", subscriber)
 		return
 	}
 	delete(d.nbiListeners, subscriber)
@@ -149,7 +148,7 @@ func (d *Dispatcher) UnregisterNbi(subscriber string) {
 func (d *Dispatcher) UnregisterOperationalState(subscriber string) {
 	channel, ok := d.nbiOpStateListeners[subscriber]
 	if !ok {
-		log.Println(fmt.Sprintf("Subscriber %s had not been registered", subscriber))
+		log.Infof("Subscriber %s had not been registered", subscriber)
 		return
 	}
 	delete(d.nbiOpStateListeners, subscriber)

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -16,13 +16,12 @@ package dispatcher
 
 import (
 	"encoding/base64"
-	"fmt"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
-	"log"
+	log "k8s.io/klog"
 	"os"
 	"strings"
 	"testing"
@@ -64,6 +63,8 @@ func tearDown(d *Dispatcher) {
 }
 
 func TestMain(m *testing.M) {
+	log.SetOutput(os.Stdout)
+
 	device1 = topocache.Device{ID: "localhost-1", Addr: "localhost:10161"}
 	device2 = topocache.Device{ID: "localhost-2", Addr: "localhost:10162"}
 	device3 = topocache.Device{ID: "localhost-3", Addr: "localhost:10163"}
@@ -71,14 +72,14 @@ func TestMain(m *testing.M) {
 	configStoreTest, err = store.LoadConfigStore(configStoreDefaultFileName)
 	if err != nil {
 		wd, _ := os.Getwd()
-		fmt.Println("Cannot load config store ", err, wd)
+		log.Warning("Cannot load config store ", err, wd)
 		return
 	}
-	fmt.Println("Configuration store loaded from", configStoreDefaultFileName)
+	log.Info("Configuration store loaded from", configStoreDefaultFileName)
 
 	changeStoreTest, err = store.LoadChangeStore(changeStoreDefaultFileName)
 	if err != nil {
-		fmt.Println("Cannot load change store ", err)
+		log.Error("Cannot load change store ", err)
 		return
 	}
 
@@ -239,23 +240,23 @@ func Test_register_dup(t *testing.T) {
 }
 
 func testSync(testChan <-chan events.ConfigEvent, changes map[string]bool) {
-	log.Println("Listen for config changes for Test")
+	log.Info("Listen for config changes for Test")
 
 	for nbiChange := range testChan {
 		changeID := nbiChange.ChangeID()
 		changes[changeID] = nbiChange.Applied()
-		fmt.Println("Change for Test", nbiChange)
+		log.Info("Change for Test", nbiChange)
 	}
 }
 
 func testSyncOpState(testChan <-chan events.OperationalStateEvent, changes map[string]string) {
-	log.Println("Listen for config changes for Test")
+	log.Info("Listen for config changes for Test")
 
 	for opStateChange := range testChan {
 		changesEvent := events.Event(opStateChange).Values()
 		for k, v := range *changesEvent {
 			changes[k] = v
 		}
-		fmt.Println("OperationalState change for Test", opStateChange)
+		log.Info("OperationalState change for Test", opStateChange)
 	}
 }

--- a/pkg/events/configevent.go
+++ b/pkg/events/configevent.go
@@ -17,7 +17,7 @@ package events
 import (
 	"encoding/base64"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	"log"
+	log "k8s.io/klog"
 	"strconv"
 	"time"
 )
@@ -34,7 +34,7 @@ func (cfgevent *ConfigEvent) ChangeID() string {
 func (cfgevent *ConfigEvent) Applied() bool {
 	b, err := strconv.ParseBool(cfgevent.values[Applied])
 	if err != nil {
-		log.Println("error in conversion", err)
+		log.Warning("error in conversion", err)
 		return false
 	}
 	return b

--- a/pkg/events/topoevent.go
+++ b/pkg/events/topoevent.go
@@ -15,7 +15,7 @@
 package events
 
 import (
-	"log"
+	log "k8s.io/klog"
 	"strconv"
 	"time"
 )
@@ -27,7 +27,7 @@ type TopoEvent Event
 func (topoEvent *TopoEvent) Connect() bool {
 	b, err := strconv.ParseBool(topoEvent.values[Connect])
 	if err != nil {
-		log.Println("error in conversion", err)
+		log.Warning("error in conversion", err)
 		return false
 	}
 	return b

--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
+	log "k8s.io/klog"
 	"sort"
 	"strings"
 )
@@ -25,7 +26,7 @@ import (
 // GetNetworkConfig returns a set of change values given a target, a configuration name, a path and a layer.
 // The layer is the numbers of config changes we want to go back in time for. 0 is the latest
 func (m *Manager) GetNetworkConfig(target string, configname string, path string, layer int) ([]*change.ConfigValue, error) {
-	fmt.Println("Getting config for", target, path)
+	log.Info("Getting config for", target, path)
 	//TODO the key of the config store should be a tuple of (devicename, configname) use the param
 	var config store.Configuration
 	if target != "" {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -15,12 +15,12 @@
 package manager
 
 import (
-	"fmt"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"gotest.tools/assert"
+	log "k8s.io/klog"
 	"os"
 	"strings"
 	"testing"
@@ -45,6 +45,7 @@ const (
 // anything is shared the order of it's modification is not deterministic
 // Also there can only be one TestMain per package
 func TestMain(m *testing.M) {
+	log.SetOutput(os.Stdout)
 	os.Exit(m.Run())
 }
 
@@ -68,7 +69,7 @@ func setUp() (*Manager, map[string]*change.Change, map[store.ConfigName]store.Co
 	change1, err = change.CreateChange(change.ValueCollections{
 		config1Value01, config1Value02, config1Value03}, "Original Config for test switch")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 	changeStoreTest = make(map[string]*change.Change)
@@ -77,7 +78,7 @@ func setUp() (*Manager, map[string]*change.Change, map[store.ConfigName]store.Co
 	device1config, err = store.CreateConfiguration("Device1", "1.0.0", "TestDevice",
 		[]change.ID{change1.ID})
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -114,7 +115,7 @@ func setUp() (*Manager, map[string]*change.Change, map[store.ConfigName]store.Co
 		},
 		make(chan events.TopoEvent, 10))
 	if err != nil {
-		fmt.Println(err)
+		log.Warning(err)
 		os.Exit(-1)
 	}
 	mgrTest.Run()

--- a/pkg/manager/modelregistry.go
+++ b/pkg/manager/modelregistry.go
@@ -33,7 +33,6 @@ type ModelPlugin interface {
 // or through the 'admin' gRPC interface. Once plugins are loaded they cannot be unloaded
 func (m *Manager) RegisterModelPlugin(moduleName string) (string, string, error) {
 	log.Info("Loading module", moduleName)
-	fmt.Println("Loading module:", moduleName)
 	modelPluginModule, err := plugin.Open(moduleName)
 	if err != nil {
 		log.Warning("Unable to load module", moduleName)
@@ -53,8 +52,6 @@ func (m *Manager) RegisterModelPlugin(moduleName string) (string, string, error)
 	name, version, _, _ := modelPlugin.ModelData()
 	modelName := toModelName(name, version)
 	m.ModelRegistry[modelName] = modelPlugin
-	fmt.Println("Model Plugin loaded:", modelName)
-
 	return name, version, nil
 }
 

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	"log"
+	log "k8s.io/klog"
 	"strings"
 	"time"
 )
@@ -43,7 +43,7 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 		}
 
 		if len(similarDevices) == 1 {
-			log.Println("No exact match in Configurations for", configName,
+			log.Warning("No exact match in Configurations for", configName,
 				"using", similarDevices[0])
 			configName = similarDevices[0]
 			deviceConfig = m.ConfigStore.Store[configName]
@@ -86,16 +86,16 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 	}
 
 	if m.ChangeStore.Store[store.B64(configChange.ID)] != nil {
-		log.Println("Change ID", store.B64(configChange.ID), "already exists - not overwriting")
+		log.Info("Change ID", store.B64(configChange.ID), "already exists - not overwriting")
 	} else {
 		m.ChangeStore.Store[store.B64(configChange.ID)] = configChange
-		log.Println("Added change", store.B64(configChange.ID), "to ChangeStore (in memory)")
+		log.Info("Added change", store.B64(configChange.ID), "to ChangeStore (in memory)")
 	}
 
 	// If the last change applied to deviceConfig is the same as this one then don't apply it again
 	if len(deviceConfig.Changes) > 0 &&
 		store.B64(deviceConfig.Changes[len(deviceConfig.Changes)-1]) == store.B64(configChange.ID) {
-		log.Println("Change", store.B64(configChange.ID),
+		log.Info("Change", store.B64(configChange.ID),
 			"has already been applied to", configName, "Ignoring")
 		return configChange.ID, configName, fmt.Errorf("%s %s",
 			SetConfigAlreadyApplied, store.B64(configChange.ID))
@@ -107,23 +107,23 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 	modelName := fmt.Sprintf("%s-%s", deviceConfig.Type, deviceConfig.Version)
 	deviceModelYgotPlugin, ok := m.ModelRegistry[modelName]
 	if !ok {
-		log.Println("No model", modelName, "available as a plugin")
+		log.Warning("No model", modelName, "available as a plugin")
 	} else {
 		configValues := deviceConfig.ExtractFullConfig(m.ChangeStore.Store, 0)
 		jsonTree, err := store.BuildTree(configValues)
 		if err != nil {
-			log.Println("Error building JSON tree from Config Values", err, jsonTree)
+			log.Error("Error building JSON tree from Config Values", err, jsonTree)
 		} else {
 			ygotModel, err := deviceModelYgotPlugin.UnmarshalConfigValues(jsonTree)
 			if err != nil {
-				log.Println("Error unmarshaling JSON tree in to YGOT model", err)
+				log.Error("Error unmarshaling JSON tree in to YGOT model", err)
 				return nil, configName, err
 			}
 			err = deviceModelYgotPlugin.Validate(ygotModel)
 			if err != nil {
 				return nil, configName, err
 			}
-			log.Println("Configuration is Valid according to model",
+			log.Info("Configuration is Valid according to model",
 				modelName, "after adding change", store.B64(configChange.ID))
 		}
 	}

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -20,7 +20,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"log"
+	log "k8s.io/klog"
 	"time"
 
 	"github.com/onosproject/onos-config/pkg/manager"
@@ -85,7 +85,7 @@ func getUpdate(prefix *gnmi.Path, path *gnmi.Path) (*gnmi.Update, error) {
 	// Special case - if target is "*" then ignore path and just return a list
 	// of devices - note, this can be done in addition to other Paths in the same Get
 	if target == "*" {
-		log.Println("Testing subscription")
+		log.Info("Testing subscription")
 		deviceIds := make([]*gnmi.TypedValue, 0)
 
 		for _, deviceID := range *manager.GetManager().GetAllDeviceIds() {

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -15,11 +15,10 @@
 package gnmi
 
 import (
-	"fmt"
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/manager"
-	"log"
+	log "k8s.io/klog"
 	"os"
 	"testing"
 )
@@ -29,7 +28,7 @@ import (
 // anything is shared the order of it's modification is not deterministic
 // Also there can only be one TestMain per package
 func TestMain(m *testing.M) {
-	//var err error
+	log.SetOutput(os.Stdout)
 	os.Exit(m.Run())
 }
 
@@ -44,7 +43,8 @@ func setUp() (*Server, *manager.Manager) {
 		"../../../configs/networkStore-sample.json",
 	)
 	if err != nil {
-		log.Println("Expected manager to be loaded")
+		log.Error("Expected manager to be loaded", err)
+		os.Exit(-1)
 	}
 
 	mgr = manager.GetManager()
@@ -54,12 +54,12 @@ func setUp() (*Server, *manager.Manager) {
 	mgr.ChangesChannel = make(chan events.ConfigEvent)
 	go mgr.Dispatcher.Listen(mgr.ChangesChannel)
 
-	fmt.Println("Finished setUp()")
+	log.Info("Finished setUp()")
 	return server, mgr
 }
 
 func listenToTopoLoading(deviceChan <-chan events.TopoEvent) {
-	for range deviceChan {
-		// fmt.Printf("Ignoring event for testing %v\n", deviceConfigEvent)
+	for deviceConfigEvent := range deviceChan {
+		log.Info("Ignoring event for testing", deviceConfigEvent)
 	}
 }

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc"
 	"gotest.tools/assert"
-	"log"
+	log "k8s.io/klog"
 	"testing"
 	"time"
 )
@@ -101,7 +101,7 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 	assert.Equal(t, len(responseReq.GetUpdate().Update), 1)
 
 	if responseReq.GetUpdate().Update[0] == nil {
-		log.Println("response should contain at least one update and that should not be nil")
+		log.Error("response should contain at least one update and that should not be nil")
 		t.FailNow()
 	}
 
@@ -168,7 +168,7 @@ func Test_SubscribeLeafStream(t *testing.T) {
 	valueReply := "14"
 
 	for response := range responsesChan {
-		log.Println("response", response)
+		log.Info("response", response)
 		if len(response.GetUpdate().GetUpdate()) != 0 {
 			assertResponse(t, response, device1, path1Stream, path2Stream, path3Stream, valueReply)
 		} else {
@@ -206,7 +206,7 @@ func Test_WrongDevice(t *testing.T) {
 	var response *gnmi.SubscribeResponse
 	select {
 	case response = <-responsesChan:
-		log.Println("Should not be receiving response ", response)
+		log.Error("Should not be receiving response ", response)
 		t.FailNow()
 	case <-time.After(50 * time.Millisecond):
 	}
@@ -220,7 +220,7 @@ func Test_WrongDevice(t *testing.T) {
 	changeChan <- events.CreateConfigEvent("Device1", change1.ID, true)
 	select {
 	case response = <-responsesChan:
-		log.Println("Should not be receiving response ", response)
+		log.Error("Should not be receiving response ", response)
 		t.FailNow()
 	case <-time.After(50 * time.Millisecond):
 	}
@@ -301,7 +301,7 @@ func Test_Poll(t *testing.T) {
 
 	for i := 1; i < 4; i++ {
 		response := <-responsesChan
-		log.Println("response", response)
+		log.Info("response", response)
 		if len(response.GetUpdate().GetUpdate()) != 0 {
 			assertResponse(t, response, device1, path1Poll, path2Poll, path3Poll, value)
 		} else {
@@ -336,7 +336,7 @@ func assertResponse(t *testing.T, response *gnmi.SubscribeResponse, device1 stri
 	assert.Assert(t, response.GetUpdate().GetUpdate() != nil, "Update should not be nil")
 	assert.Equal(t, len(response.GetUpdate().GetUpdate()), 1)
 	if response.GetUpdate().GetUpdate()[0] == nil {
-		log.Println("response should contain at least one update and that should not be nil")
+		log.Error("response should contain at least one update and that should not be nil")
 		t.FailNow()
 	}
 	pathResponse := response.GetUpdate().GetUpdate()[0].Path

--- a/pkg/northbound/testUtils.go
+++ b/pkg/northbound/testUtils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/certs"
 	"github.com/onosproject/onos-config/pkg/manager"
 	"google.golang.org/grpc"
-	"log"
+	log "k8s.io/klog"
 	"sync"
 )
 
@@ -42,7 +42,7 @@ func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) {
 		"../../../configs/networkStore-sample.json",
 	)
 	if err != nil {
-		log.Fatal("Unable to load manager")
+		log.Error("Unable to load manager")
 	}
 
 	config := NewServerConfig("", "", "")
@@ -54,7 +54,7 @@ func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) {
 	Address = fmt.Sprintf(":%d", port)
 	Opts, err = certs.HandleCertArgs(&empty, &empty)
 	if err != nil {
-		log.Fatal("Error loading cert", err)
+		log.Error("Error loading cert", err)
 	}
 	go func() {
 		err := s.Serve(func(started string) {
@@ -62,7 +62,7 @@ func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) {
 			fmt.Printf("Started %v", started)
 		})
 		if err != nil {
-			log.Fatal("Unable to serve", err)
+			log.Error("Unable to serve", err)
 		}
 	}()
 }

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -20,7 +20,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
-	"log"
+	log "k8s.io/klog"
 )
 
 // Factory is a go routine thread that listens out for Device creation
@@ -33,14 +33,14 @@ func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore,
 		if !dispatcher.HasListener(deviceName) && topoEvent.Connect() {
 			configChan, err := dispatcher.RegisterDevice(deviceName)
 			if err != nil {
-				log.Fatal(err)
+				log.Error(err)
 			}
 			device := deviceStore.Store[topocache.ID(deviceName)]
 			ctx := context.Background()
 			sync, err := New(ctx, changeStore, &device, configChan, opStateChan)
 			if err != nil {
 				//TODO propagate the ERROR
-				log.Println("Error in connecting to client", err)
+				log.Warning("Error in connecting to client: ", err)
 				//unregistering the listener for changes to the device
 				dispatcher.UnregisterDevice(deviceName)
 			} else {
@@ -54,7 +54,7 @@ func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore,
 
 			err := dispatcher.UnregisterDevice(deviceName)
 			if err != nil {
-				log.Fatal(err)
+				log.Error(err)
 			}
 		}
 	}

--- a/pkg/store/change/change_test.go
+++ b/pkg/store/change/change_test.go
@@ -17,9 +17,9 @@ package change
 import (
 	"crypto/sha1"
 	"encoding/json"
-	"fmt"
 	"gotest.tools/assert"
 	"io"
+	log "k8s.io/klog"
 	"os"
 	"strings"
 	"testing"
@@ -62,6 +62,7 @@ const (
 
 func TestMain(m *testing.M) {
 	var err error
+	log.SetOutput(os.Stdout)
 	config1Value01, _ := CreateChangeValue(Test1Cont1A, ValueEmpty, false)
 	config1Value02, _ := CreateChangeValue(Test1Cont1ACont2A, ValueEmpty, false)
 	config1Value03, _ := CreateChangeValue(Test1Cont1ACont2ALeaf2A, ValueLeaf2A13, false)
@@ -79,7 +80,7 @@ func TestMain(m *testing.M) {
 		config1Value11,
 	}, "Original Config for test switch")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -100,7 +101,7 @@ func Test_ConfigValue(t *testing.T) {
 
 func Test_changecreation(t *testing.T) {
 
-	fmt.Printf("Change %x created\n", change1.ID)
+	log.Infof("Change %x created\n", change1.ID)
 	h := sha1.New()
 	jsonstr, _ := json.Marshal(change1.Config)
 	_, err1 := io.WriteString(h, string(jsonstr))

--- a/pkg/store/store-api_test.go
+++ b/pkg/store/store-api_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"gotest.tools/assert"
+	log "k8s.io/klog"
 	"os"
 	"strconv"
 	"testing"
@@ -171,6 +172,11 @@ var Config2Values = [11]string{
 	ValueLeaftopWxy1234,
 }
 
+func TestMain(m *testing.M) {
+	log.SetOutput(os.Stdout)
+	os.Exit(m.Run())
+}
+
 func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.Change) {
 	var err error
 
@@ -195,7 +201,7 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		config1Value11,
 	}, "Original Config for test switch")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -206,7 +212,7 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		config2Value01, config2Value02, config2Value03,
 	}, "Trim power level")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -216,7 +222,7 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		config3Value01, config3Value02,
 	}, "Remove txout 2")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -228,7 +234,7 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 	device1V, err = CreateConfiguration("Device1", "1.0.0", "TestDevice",
 		[]change.ID{change1.ID, change2.ID, change3.ID})
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -238,7 +244,7 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		config4Value01, config4Value02,
 	}, "Remove txout 1")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 	changeStore[B64(change4.ID)] = change4
@@ -246,7 +252,7 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 	device2V, err = CreateConfiguration("Device2", "1.0.0", "TestDevice",
 		[]change.ID{change1.ID, change2.ID, change4.ID})
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -256,16 +262,16 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 func Test_device1_version(t *testing.T) {
 	device1V, _, changeStore := setUp()
 
-	fmt.Println("Configuration", device1V.Name, " (latest) Changes:")
+	log.Info("Configuration", device1V.Name, " (latest) Changes:")
 	for idx, cid := range device1V.Changes {
-		fmt.Printf("%d: %s\n", idx, B64([]byte(cid)))
+		log.Infof("%d: %s\n", idx, B64([]byte(cid)))
 	}
 
 	assert.Equal(t, device1V.Name, ConfigName("Device1-1.0.0"))
 
 	config := device1V.ExtractFullConfig(changeStore, 0)
 	for _, c := range config {
-		fmt.Printf("Path %s = %s\n", c.Path, c.Value)
+		log.Infof("Path %s = %s\n", c.Path, c.Value)
 	}
 
 	for i := 0; i < len(Config1Paths); i++ {
@@ -278,16 +284,16 @@ func Test_device1_prev_version(t *testing.T) {
 	device1V, _, changeStore := setUp()
 
 	const changePrevious = 1
-	fmt.Println("Configuration", device1V.Name, " (n-1) Changes:")
+	log.Info("Configuration", device1V.Name, " (n-1) Changes:")
 	for idx, cid := range device1V.Changes[0 : len(device1V.Changes)-changePrevious] {
-		fmt.Printf("%d: %s\n", idx, B64([]byte(cid)))
+		log.Infof("%d: %s\n", idx, B64([]byte(cid)))
 	}
 
 	assert.Equal(t, device1V.Name, ConfigName("Device1-1.0.0"))
 
 	config := device1V.ExtractFullConfig(changeStore, changePrevious)
 	for _, c := range config {
-		fmt.Printf("Path %s = %s\n", c.Path, c.Value)
+		log.Infof("Path %s = %s\n", c.Path, c.Value)
 	}
 
 	for i := 0; i < len(Config1PreviousPaths); i++ {
@@ -299,16 +305,16 @@ func Test_device1_prev_version(t *testing.T) {
 func Test_device1_first_version(t *testing.T) {
 	device1V, _, changeStore := setUp()
 	const changePrevious = 2
-	fmt.Println("Configuration", device1V.Name, " (n-2) Changes:")
+	log.Info("Configuration", device1V.Name, " (n-2) Changes:")
 	for idx, cid := range device1V.Changes[0 : len(device1V.Changes)-changePrevious] {
-		fmt.Printf("%d: %s\n", idx, B64([]byte(cid)))
+		log.Infof("%d: %s\n", idx, B64([]byte(cid)))
 	}
 
 	assert.Equal(t, device1V.Name, ConfigName("Device1-1.0.0"))
 
 	config := device1V.ExtractFullConfig(changeStore, changePrevious)
 	for _, c := range config {
-		fmt.Printf("Path %s = %s\n", c.Path, c.Value)
+		log.Infof("Path %s = %s\n", c.Path, c.Value)
 	}
 
 	for i := 0; i < len(Config1FirstPaths); i++ {
@@ -320,9 +326,9 @@ func Test_device1_first_version(t *testing.T) {
 func Test_device1_invalid_version(t *testing.T) {
 	device1V, _, changeStore := setUp()
 	const changePrevious = 3
-	fmt.Println("Configuration", device1V.Name, " (n-3) Changes:")
+	log.Info("Configuration", device1V.Name, " (n-3) Changes:")
 	for idx, cid := range device1V.Changes[0 : len(device1V.Changes)-changePrevious] {
-		fmt.Printf("%d: %s\n", idx, B64([]byte(cid)))
+		log.Infof("%d: %s\n", idx, B64([]byte(cid)))
 	}
 
 	assert.Equal(t, device1V.Name, ConfigName("Device1-1.0.0"))
@@ -336,16 +342,16 @@ func Test_device1_invalid_version(t *testing.T) {
 
 func Test_device2_version(t *testing.T) {
 	_, device2V, changeStore := setUp()
-	fmt.Println("Configuration", device2V.Name, " (latest) Changes:")
+	log.Info("Configuration", device2V.Name, " (latest) Changes:")
 	for idx, cid := range device2V.Changes {
-		fmt.Printf("%d: %s\n", idx, B64([]byte(cid)))
+		log.Infof("%d: %s\n", idx, B64([]byte(cid)))
 	}
 
 	assert.Equal(t, device2V.Name, ConfigName("Device2-1.0.0"))
 
 	config := device2V.ExtractFullConfig(changeStore, 0)
 	for _, c := range config {
-		fmt.Printf("Path %s = %s\n", c.Path, c.Value)
+		log.Infof("Path %s = %s\n", c.Path, c.Value)
 	}
 
 	for i := 0; i < len(Config2Paths); i++ {
@@ -377,7 +383,7 @@ func Test_convertChangeToGnmi(t *testing.T) {
 		config3Value01, config3Value02,
 	}, "Remove txout 2")
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 
@@ -416,7 +422,7 @@ func Test_writeOutChangeFile(t *testing.T) {
 		Storetype: StoreTypeChange, Store: changeStore}
 	err = jsonEncoder.Encode(csf)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 	defer changeStoreFile.Close()
@@ -528,7 +534,7 @@ func Test_writeOutConfigFile(t *testing.T) {
 	err := jsonEncoder.Encode(ConfigurationStore{Version: StoreVersion,
 		Storetype: StoreTypeConfig, Store: configurationStore})
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 	defer configStoreFile.Close()
@@ -554,7 +560,7 @@ func Test_writeOutNetworkFile(t *testing.T) {
 	ccs["Device2VersionMain"] = []byte("LsDuwm2XJjdOq+u9QEcUJo/HxaM=")
 	nw1, err := NewNetworkConfiguration("testChange", "nw1", ccs)
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 	networkStore = append(networkStore, *nw1)
@@ -564,7 +570,7 @@ func Test_writeOutNetworkFile(t *testing.T) {
 	err = jsonEncoder.Encode(NetworkStore{Version: StoreVersion,
 		Storetype: StoreTypeNetwork, Store: networkStore})
 	if err != nil {
-		fmt.Println(err)
+		log.Error(err)
 		os.Exit(-1)
 	}
 	defer networkStoreFile.Close()


### PR DESCRIPTION
klog.SetOutput(os.Stdout) is called in

- onos-config - should it always be called in here - will it impede writing to K8s logs?
- each TestMain

fmt.Println is still left there for Command Line utils and their associated pkg files