### PR TITLE
Updated manager to validate configs at startup Fixes #357

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -112,6 +112,11 @@ func main() {
 				log.Fatal("Unable to start onos-config ", err)
 			}
 		}
+		err = mgr.ValidateStores()
+		if err != nil {
+			log.Error("Error when validating configurations against model plugins: ", err)
+			os.Exit(-1)
+		}
 
 		mgr.Run()
 		err = startServer(*caPath, *keyPath, *certPath)

--- a/configs/changeStore-sample.json
+++ b/configs/changeStore-sample.json
@@ -197,14 +197,14 @@
         }
       ]
     },
-    "i86kLjjNFr5IBa+O3YTuv9HBqJg=": {
-      "ID": "i86kLjjNFr5IBa+O3YTuv9HBqJg=",
+    "UwIDulssBgfXoeKco0eirkKkJUI=": {
+      "ID": "UwIDulssBgfXoeKco0eirkKkJUI=",
       "Description": "Modification of device sim 1",
       "Created": "2019-05-21T08:43:02Z",
       "Config": [
         {
           "Path": "/openconfig-system:system/config/hostname",
-          "Value": "localhost:10161"
+          "Value": "localhost-1"
         },
         {
           "Path": "/openconfig-system:system/config/motd-banner",
@@ -212,14 +212,14 @@
         }
       ]
     },
-    "UyPwBSOxDqQM/ZCohHFannSF5ME=": {
-      "ID": "UyPwBSOxDqQM/ZCohHFannSF5ME=",
+    "oWFKpOajlRkQf38YTlCJivn3QlU=": {
+      "ID": "oWFKpOajlRkQf38YTlCJivn3QlU=",
       "Description": "Modification of device sim 2",
       "Created": "2019-05-21T08:43:03Z",
       "Config": [
         {
           "Path": "/openconfig-system:system/config/hostname",
-          "Value": "localhost:10162"
+          "Value": "localhost-2"
         },
         {
           "Path": "/openconfig-system:system/config/motd-banner",
@@ -227,14 +227,14 @@
         }
       ]
     },
-    "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y=": {
-      "ID": "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y=",
+    "1EvL+9i1ZGjKyuSjxh1hlfZ9/74=": {
+      "ID": "1EvL+9i1ZGjKyuSjxh1hlfZ9/74=",
       "Description": "Modification of device sim 3",
       "Created": "2019-05-21T08:43:04Z",
       "Config": [
         {
           "Path": "/openconfig-system:system/config/hostname",
-          "Value": "localhost:10163"
+          "Value": "localhost-3"
         },
         {
           "Path": "/openconfig-system:system/config/motd-banner",

--- a/configs/configStore-sample.json
+++ b/configs/configStore-sample.json
@@ -48,7 +48,7 @@
       "Updated": "2019-05-21T08:43:17Z",
       "Changes": [
         "4cQNf/bxKWdRO0h5GG4a58q5YEQ=",
-        "i86kLjjNFr5IBa+O3YTuv9HBqJg="
+        "UwIDulssBgfXoeKco0eirkKkJUI="
       ]
     },
     "localhost-2-1.0.0": {
@@ -60,7 +60,7 @@
       "Updated": "2019-05-21T08:43:18Z",
       "Changes": [
         "4cQNf/bxKWdRO0h5GG4a58q5YEQ=",
-        "UyPwBSOxDqQM/ZCohHFannSF5ME="
+        "oWFKpOajlRkQf38YTlCJivn3QlU="
       ]
     },
     "localhost-3-1.0.0": {
@@ -72,7 +72,7 @@
       "Updated": "2019-05-21T08:43:19Z",
       "Changes": [
         "4cQNf/bxKWdRO0h5GG4a58q5YEQ=",
-        "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y="
+        "1EvL+9i1ZGjKyuSjxh1hlfZ9/74="
       ]
     },
     "device-1-device-simulator-1.0.0": {

--- a/deployments/helm/onos-config/files/configs/changeStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/changeStore-sample.json
@@ -197,14 +197,14 @@
         }
       ]
     },
-    "i86kLjjNFr5IBa+O3YTuv9HBqJg=": {
-      "ID": "i86kLjjNFr5IBa+O3YTuv9HBqJg=",
+    "UwIDulssBgfXoeKco0eirkKkJUI=": {
+      "ID": "UwIDulssBgfXoeKco0eirkKkJUI=",
       "Description": "Modification of device sim 1",
       "Created": "2019-05-21T08:43:02Z",
       "Config": [
         {
           "Path": "/openconfig-system:system/config/hostname",
-          "Value": "localhost:10161"
+          "Value": "localhost-1"
         },
         {
           "Path": "/openconfig-system:system/config/motd-banner",
@@ -212,14 +212,14 @@
         }
       ]
     },
-    "UyPwBSOxDqQM/ZCohHFannSF5ME=": {
-      "ID": "UyPwBSOxDqQM/ZCohHFannSF5ME=",
+    "oWFKpOajlRkQf38YTlCJivn3QlU=": {
+      "ID": "oWFKpOajlRkQf38YTlCJivn3QlU=",
       "Description": "Modification of device sim 2",
       "Created": "2019-05-21T08:43:03Z",
       "Config": [
         {
           "Path": "/openconfig-system:system/config/hostname",
-          "Value": "localhost:10162"
+          "Value": "localhost-2"
         },
         {
           "Path": "/openconfig-system:system/config/motd-banner",
@@ -227,14 +227,14 @@
         }
       ]
     },
-    "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y=": {
-      "ID": "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y=",
+    "1EvL+9i1ZGjKyuSjxh1hlfZ9/74=": {
+      "ID": "1EvL+9i1ZGjKyuSjxh1hlfZ9/74=",
       "Description": "Modification of device sim 3",
       "Created": "2019-05-21T08:43:04Z",
       "Config": [
         {
           "Path": "/openconfig-system:system/config/hostname",
-          "Value": "localhost:10163"
+          "Value": "localhost-3"
         },
         {
           "Path": "/openconfig-system:system/config/motd-banner",

--- a/deployments/helm/onos-config/files/configs/configStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/configStore-sample.json
@@ -48,7 +48,7 @@
       "Updated": "2019-05-21T08:43:17Z",
       "Changes": [
         "4cQNf/bxKWdRO0h5GG4a58q5YEQ=",
-        "i86kLjjNFr5IBa+O3YTuv9HBqJg="
+        "UwIDulssBgfXoeKco0eirkKkJUI="
       ]
     },
     "localhost-2-1.0.0": {
@@ -60,7 +60,7 @@
       "Updated": "2019-05-21T08:43:18Z",
       "Changes": [
         "4cQNf/bxKWdRO0h5GG4a58q5YEQ=",
-        "UyPwBSOxDqQM/ZCohHFannSF5ME="
+        "oWFKpOajlRkQf38YTlCJivn3QlU="
       ]
     },
     "localhost-3-1.0.0": {
@@ -72,7 +72,7 @@
       "Updated": "2019-05-21T08:43:19Z",
       "Changes": [
         "4cQNf/bxKWdRO0h5GG4a58q5YEQ=",
-        "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y="
+        "1EvL+9i1ZGjKyuSjxh1hlfZ9/74="
       ]
     },
     "device-1-device-simulator-1.0.0": {

--- a/docs/run.md
+++ b/docs/run.md
@@ -25,7 +25,7 @@ go run github.com/onosproject/onos-config/cmd/onos-config \
 ```
 > The plugins here were built locally with a command like
 ```bash
-> CGO_ENABLED=1 go build -o modelplugin/TestDevice-1.0.0/testdevice.so.1.0.0 -buildmode=plugin ./modelplugin/TestDevice-1.0.0
+> CGO_ENABLED=1 go build -o modelplugin/TestDevice-1.0.0/testdevice.so.1.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/TestDevice-1.0.0
 ```
 > When running with Docker or Kubernetes these plugins will be built and (optionally) loaded
 at startup. To check the list of currently loaded plugins use:
@@ -49,7 +49,7 @@ Here is an example on how to use `gnmi_cli -get` to get configuration for a part
 ```bash
 gnmi_cli -get -address localhost:5150 \
     -proto "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
-    -timeout 5s -alsologtostderr\
+    -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
     -ca_crt pkg/southbound/testdata/onfca.crt

--- a/modelplugin/Devicesim-1.0.0/modelmain.go
+++ b/modelplugin/Devicesim-1.0.0/modelmain.go
@@ -44,7 +44,7 @@ func (m modelplugin) UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoSt
 	vgs := ygot.ValidatedGoStruct(device)
 
 	if err := devicesim_1_0_0.Unmarshal([]byte(jsonTree), device); err != nil {
-		panic(fmt.Sprintf("Cannot unmarshal JSON: %v", err))
+		return nil, err
 	}
 
 	return &vgs, nil

--- a/modelplugin/ModelGenerator.sh
+++ b/modelplugin/ModelGenerator.sh
@@ -77,7 +77,7 @@ func (m modelplugin) UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoSt
 	vgs := ygot.ValidatedGoStruct(device)
 
 	if err := $TYPEVERSIONPKG.Unmarshal([]byte(jsonTree), device); err != nil {
-		panic(fmt.Sprintf("Cannot unmarshal JSON: %v", err))
+		return nil, err
 	}
 
 	return &vgs, nil

--- a/modelplugin/TestDevice-2.0.0/modelmain.go
+++ b/modelplugin/TestDevice-2.0.0/modelmain.go
@@ -44,7 +44,7 @@ func (m modelplugin) UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoSt
 	vgs := ygot.ValidatedGoStruct(device)
 
 	if err := testdevice_2_0_0.Unmarshal([]byte(jsonTree), device); err != nil {
-		panic(fmt.Sprintf("Cannot unmarshal JSON: %v", err))
+		return nil, err
 	}
 
 	return &vgs, nil

--- a/pkg/northbound/diags/diags_test.go
+++ b/pkg/northbound/diags/diags_test.go
@@ -45,7 +45,7 @@ func Test_GetChanges_All(t *testing.T) {
 }
 
 func Test_GetChanges_Change(t *testing.T) {
-	testGetChanges(t, "5FTJ5QDC0y/RoFnJPfdh8NsB+4Y=")
+	testGetChanges(t, "1EvL+9i1ZGjKyuSjxh1hlfZ9/74=")
 }
 
 func testGetChanges(t *testing.T, changeID string) {


### PR DESCRIPTION
Added in checks of Validation at startup - but only if appropriate model plugin is loaded.

I had to do a hack on tree.go to handle leaf-list - I will deal with this when I get back with a custom un-marshaller for out paths&values to YGOT.