### PR TITLE
Optimize docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,9 +54,11 @@ protos: # @HELP compile the protobuf files (using protoc-go Docker)
 		onosproject/protoc-go:stable
 
 onos-config-base-docker: # @HELP build onos-config base Docker image
+	go mod vendor
 	docker build . -f build/base/Dockerfile \
 		--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config-base:${ONOS_CONFIG_VERSION}
+	rm -rf vendor
 
 onos-config-docker: onos-config-base-docker # @HELP build onos-config Docker image
 	docker build . -f build/onos-config/Dockerfile \
@@ -79,7 +81,7 @@ onos-it-docker: onos-config-base-docker # @HELP build onos-config-integration-te
 		-t onosproject/onos-config-integration-tests:${ONOS_CONFIG_VERSION}
 
 images: # @HELP build all Docker images
-images: onos-config-docker onos-config-debug-docker onos-cli-docker onos-it-docker
+images: build onos-config-docker onos-config-debug-docker onos-cli-docker onos-it-docker
 
 all: build images
 

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,5 +1,6 @@
 ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION
+ENV GO111MODULE=on
 COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && make build
+RUN cd /go/src/github.com/onosproject/onos-config && GOFLAGS=-mod=vendor make build

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,0 +1,5 @@
+ARG ONOS_BUILD_VERSION=stable
+
+FROM onosproject/golang-build:$ONOS_BUILD_VERSION
+COPY . /go/src/github.com/onosproject/onos-config
+RUN cd /go/src/github.com/onosproject/onos-config && make build

--- a/build/onos-cli/Dockerfile
+++ b/build/onos-cli/Dockerfile
@@ -1,8 +1,6 @@
-ARG ONOS_BUILD_VERSION=stable
+ARG ONOS_CONFIG_BASE_VERSION=latest
 
-FROM onosproject/golang-build:$ONOS_BUILD_VERSION as builder
-COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && make build
+FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
 
 FROM alpine:3.8
 
@@ -12,7 +10,7 @@ RUN addgroup -S onos && adduser -S -G onos onos
 USER onos
 WORKDIR /home/onos
 
-COPY --from=builder /go/src/github.com/onosproject/onos-config/build/_output/onos /usr/local/bin/onos
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos /usr/local/bin/onos
 
 RUN onos init && \
     cp /etc/profile /home/onos/.bashrc && \

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -1,8 +1,6 @@
-ARG ONOS_BUILD_VERSION=stable
+ARG ONOS_CONFIG_BASE_VERSION=latest
 
-FROM onosproject/golang-build:$ONOS_BUILD_VERSION as onosBuilder
-COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 DEBUG=true make build
+FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
 
 FROM golang:1.12.6-alpine3.9 as debugBuilder
 
@@ -11,10 +9,10 @@ RUN apk upgrade --update --no-cache && apk add git && go get -u github.com/go-de
 FROM alpine:3.9
 RUN apk add libc6-compat
 
-COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/onos-config /usr/local/bin/onos-config
-COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0
-COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
-COPY --from=onosBuilder /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos-config-debug /usr/local/bin/onos-config-debug
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
 COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \

--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,17 +1,15 @@
-ARG ONOS_BUILD_VERSION=stable
+ARG ONOS_CONFIG_BASE_VERSION=latest
 
-FROM onosproject/golang-build:$ONOS_BUILD_VERSION as builder
-COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && GOOS=linux GOARCH=amd64 make build
+FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
 
 FROM alpine:3.9
 RUN apk add libc6-compat
 
 USER nobody
 
-COPY --from=builder /go/src/github.com/onosproject/onos-config/build/_output/onos-config /usr/local/bin/onos-config
-COPY --from=builder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0
-COPY --from=builder /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
-COPY --from=builder /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos-config /usr/local/bin/onos-config
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
 
 ENTRYPOINT ["onos-config"]

--- a/build/onos-it/Dockerfile
+++ b/build/onos-it/Dockerfile
@@ -1,8 +1,11 @@
-FROM golang:1.12
+ARG ONOS_CONFIG_BASE_VERSION=latest
 
-ENV GO111MODULE=on
-COPY . /go/src/github.com/onosproject/onos-config
-WORKDIR /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && go build ./...
+FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
 
-ENTRYPOINT ["go", "run", "github.com/onosproject/onos-config/test/cmd/onit", "test"]
+FROM alpine:3.8
+
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onit /usr/local/bin/onit
+
+USER nobody
+
+ENTRYPOINT ["onit", "test"]

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
 	google.golang.org/grpc v1.21.1
-	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.0.0-20190620073856-dcce3486da33
 	k8s.io/apiextensions-apiserver v0.0.0-20190325193600-475668423e9f

--- a/go.sum
+++ b/go.sum
@@ -437,6 +437,7 @@ gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6d
 gonum.org/v1/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20170731182057-09f6ed296fc6/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -471,6 +472,7 @@ gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gotest.tools v0.0.0-20181223230014-1083505acf35 h1:zpdCK+REwbk+rqjJmHhiCN6iBIigrZ39glqSF0P3KF0=
 gotest.tools v0.0.0-20181223230014-1083505acf35/go.mod h1:R//lfYlUuTOTfblYI3lGoAAAebUdzjvbmQsuB7Ykd90=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20181126151915-b503174bad59/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=


### PR DESCRIPTION
#376 

Currently, the `make images` target builds four containers and pulls dependencies each time it builds one of those containers. This requires an unreasonable amount of time. This PR significantly optimizes the Docker build by adding a base image `onosproject/onos-config-base` which pulls dependencies and builds the binaries only once.

But optimally, the Docker build shouldn't even need to pull dependencies at all. The dependencies are normally available on the host. But because of the way the go module system works, it was difficult to figure out how to add the module's dependencies to the base image. So, instead, `make onos-config-base-docker` target and the base Docker image use Go modules' support for legacy vendoring to sneak the dependencies into the base image. When `make images` is run, `go mod vendor` is used to create the `vendor` cache, and the `vendor` is then added to the base image to ensure dependencies don't need to be pulled. After the Docker build is complete, the `vendor` folder is removed.

Obviously the vendoring approach is not ideal, but it saves a huge amount of time on image builds. I'd prefer if we could move the `vendor` folder to a hidden folder like `build/_output`, but alas I couldn't figure out how to make that happen. 