### PR TITLE
Detect test job complete when pod completes between polling intervals

### DIFF
--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -1214,7 +1214,9 @@ func (c *kubeController) awaitTestJobRunning() (corev1.Pod, error) {
 			return corev1.Pod{}, err
 		} else if len(pods.Items) > 0 {
 			for _, pod := range pods.Items {
-				if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+				if pod.Status.Phase == corev1.PodRunning && len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+					return pod, nil
+				} else if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
 					return pod, nil
 				}
 			}


### PR DESCRIPTION
The k8s test controller has a race condition wherein the controller will block indefinitely waiting for the test `Job` to become ready if the job becomes ready and then completes between polls or if the job completes before ever becoming ready. This PR adds additional conditions to complete blocking if the pod phase is `Succeeded` or `Failed` as well.

Fixes one of the issues in #384