### PR TITLE
use go mod download to avoid vendoring for building the images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,9 @@ protos: # @HELP compile the protobuf files (using protoc-go Docker)
 		onosproject/protoc-go:stable
 
 onos-config-base-docker: # @HELP build onos-config base Docker image
-	@go mod vendor
 	docker build . -f build/base/Dockerfile \
 		--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config-base:${ONOS_CONFIG_VERSION}
-	@rm -rf vendor
 
 onos-config-docker: onos-config-base-docker # @HELP build onos-config Docker image
 	docker build . -f build/onos-config/Dockerfile \

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -2,5 +2,7 @@ ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION
 ENV GO111MODULE=on
+COPY go.mod go.sum /go/src/github.com/onosproject/onos-config/
+RUN  go mod download
 COPY . /go/src/github.com/onosproject/onos-config
-RUN cd /go/src/github.com/onosproject/onos-config && GOFLAGS=-mod=vendor make build
+RUN cd /go/src/github.com/onosproject/onos-config && make build


### PR DESCRIPTION
After discussing it with Jordan, I think we can use go mod download to avoid vendoring and speed up the build process for the images. 
