### PR TITLE
Setting pre-existing config to device. Fixes #379

### DIFF
--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -115,6 +115,11 @@ SetRequest() with the 100 extension at the end of the -proto section like:
 > and the config is forwarded down to the southbound layer only if a device is registered
 > in the topocache (currently in the deviceStore)
 
+If the `target` device is not currently known to `onos-config` the system will store the configuration internally and apply
+it to the `target` device when/if it becomes available.  
+When the `target` becomes availabe `onos-config` will compute the latest configuration for it based on the set of 
+applied changes and push it to the `target` with a standard `set` operation. 
+
 ## Northbound Delete Request via gNMI
 A delete request in gNMI is done using the set request with `delete` paths instead of `update` or `replace`.
 To make a gNMI Set request do delete a path, use the `gnmi_cli -set` command as in the example below:

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -176,7 +176,8 @@ func (m *Manager) Run() {
 	// Start the main dispatcher system
 	go m.Dispatcher.Listen(m.ChangesChannel)
 	go m.Dispatcher.ListenOperationalState(m.OperationalStateChannel)
-	go synchronizer.Factory(m.ChangeStore, m.DeviceStore, m.TopoChannel, m.OperationalStateChannel, &m.Dispatcher)
+	go synchronizer.Factory(m.ChangeStore, m.ConfigStore, m.DeviceStore, m.TopoChannel,
+		m.OperationalStateChannel, &m.Dispatcher)
 }
 
 //Close kills the channels and manager related objects

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -26,8 +26,9 @@ import (
 // Factory is a go routine thread that listens out for Device creation
 // and deletion events and spawns Synchronizer threads for them
 // These synchronizers then listen out for configEvents relative to a device and
-func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore, topoChannel <-chan events.TopoEvent,
-	opStateChan chan<- events.OperationalStateEvent, dispatcher *dispatcher.Dispatcher) {
+func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationStore, deviceStore *topocache.DeviceStore,
+	topoChannel <-chan events.TopoEvent, opStateChan chan<- events.OperationalStateEvent,
+	dispatcher *dispatcher.Dispatcher) {
 	for topoEvent := range topoChannel {
 		deviceName := topocache.ID(events.Event(topoEvent).Subject())
 		if !dispatcher.HasListener(deviceName) && topoEvent.Connect() {
@@ -37,7 +38,7 @@ func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore,
 			}
 			device := deviceStore.Store[topocache.ID(deviceName)]
 			ctx := context.Background()
-			sync, err := New(ctx, changeStore, &device, configChan, opStateChan)
+			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan)
 			if err != nil {
 				//TODO propagate the ERROR
 				log.Warning("Error in connecting to client: ", err)


### PR DESCRIPTION
This patch adds capability when a device connects to check against the config store and to set any pre-specified configuration to that device. 