### PR TITLE
Avoid double logging in warning and error. Fixes #393

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -87,10 +87,30 @@ func main() {
 	caPath := flag.String("caPath", "", "path to CA certificate")
 	keyPath := flag.String("keyPath", "", "path to client private key")
 	certPath := flag.String("certPath", "", "path to client certificate")
-
-	flag.Parse()
 	var err error
-	log.SetOutput(os.Stdout)
+
+	//lines 93-109 are implemented according to
+	// https://github.com/kubernetes/klog/blob/master/examples/coexist_glog/coexist_glog.go
+	// because of libraries importing glog. With glog import we can't call log.InitFlags(nil) as per klog readme
+	// thus the alsologtostderr is not set properly and we issue multiple logs.
+	// Calling log.InitFlags(nil) throws panic with error `flag redefined: log_dir`
+	err = flag.Set("alsologtostderr", "true")
+	if err != nil {
+		log.Error("Cant' avoid double Error logging ", err)
+	}
+	flag.Parse()
+
+	klogFlags := flag.NewFlagSet("klog", flag.ExitOnError)
+	log.InitFlags(klogFlags)
+
+	// Sync the glog and klog flags.
+	flag.CommandLine.VisitAll(func(f1 *flag.Flag) {
+		f2 := klogFlags.Lookup(f1.Name)
+		if f2 != nil {
+			value := f1.Value.String()
+			f2.Value.Set(value)
+		}
+	})
 	log.Info("Starting onos-config")
 
 	mgr, err := manager.LoadManager(*configStoreFile, *changeStoreFile, *deviceStoreFile, *networkStoreFile)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -165,7 +165,7 @@ func validateConfiguration(configObj store.Configuration, errChan chan error) {
 			return
 		}
 	} else {
-		fmt.Println("No Model Plugin available for", modelPluginName)
+		log.Warning("No Model Plugin available for ", modelPluginName)
 	}
 	errChan <- nil
 }

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -40,7 +40,7 @@ func Factory(changeStore *store.ChangeStore, deviceStore *topocache.DeviceStore,
 			sync, err := New(ctx, changeStore, &device, configChan, opStateChan)
 			if err != nil {
 				//TODO propagate the ERROR
-				log.Warning("Error in connecting to client: ", err)
+				log.Error("Error in connecting to client: ", err)
 				//unregistering the listener for changes to the device
 				dispatcher.UnregisterDevice(deviceName)
 			} else {


### PR DESCRIPTION
Se #393 for more details.
Has to use a workaround to properly initialise flags and enable co-existance of glog and klog imports.