### PR TITLE
Add commands to read logs from onos-config nodes/simulators/partitions

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -232,6 +232,59 @@ To get the logs from a specific test, use `onit get logs` with the test ID:
 PASS
 ```
 
+### Debugging
+
+The `onit` command provides a set of commands for debugging test clusters. The `onit` command
+can be used to `get logs` for every resource deployed in the test cluster. Simply pass the
+resource ID (e.g. test `ID`, node `ID`, partition `ID`, etc) to the `onit get logs` command
+to get the logs for a resource.
+
+To list the onos-config nodes running in the cluster, use `onit get nodes`:
+
+```bash
+> onit get nodes
+ID                            STATUS
+onos-config-f5b7758dc-rdbqt   RUNNING
+> onit get logs onos-config-f5b7758dc-rdbqt
+I0625 21:55:32.027255       1 onos-config.go:114] Starting onos-config
+I0625 21:55:32.030184       1 manager.go:98] Configuration store loaded from /etc/onos-config/configs/configStore.json
+I0625 21:55:32.030358       1 manager.go:105] Change store loaded from /etc/onos-config/configs/changeStore.json
+I0625 21:55:32.031087       1 manager.go:112] Device store loaded from /etc/onos-config/configs/deviceStore.json
+I0625 21:55:32.031222       1 manager.go:119] Network store loaded from /etc/onos-config/configs/networkStore.json
+I0625 21:55:32.031301       1 manager.go:47] Creating Manager
+...
+```
+
+To list the Raft partitions running in the cluster, use `onit get partitions`:
+
+```bash
+> onit get partitions
+ID   GROUP   NODES
+1    raft    raft-1-0
+> onit get logs raft-1-0
+21:10:24.466 [main] INFO  io.atomix.server.AtomixServerRunner - Node ID: raft-1-0
+21:10:24.472 [main] INFO  io.atomix.server.AtomixServerRunner - Partition Config: /etc/atomix/partition.json
+21:10:24.472 [main] INFO  io.atomix.server.AtomixServerRunner - Protocol Config: /etc/atomix/protocol.json
+21:10:24.473 [main] INFO  io.atomix.server.AtomixServerRunner - Starting server
+...
+```
+
+To list the tests that have been run, use `onit get history`:
+
+```bash
+> onit get history
+ID                                     TESTS                   STATUS   EXIT CODE   MESSAGE
+3cf7311a-9776-11e9-bfc3-acde48001122   test-integration-test   PASSED   0
+68ad9154-977c-11e9-bcf2-acde48001122   test-integration-test   FAILED   1
+71a0623c-977c-11e9-8478-acde48001122   test-single-path-test   PASSED   0
+9e512cdc-9720-11e9-ba6e-acde48001122   *                       PASSED   0
+da629d06-9774-11e9-bb50-acde48001122   *                       PASSED   0
+> onit get logs 71a0623c-977c-11e9-8478-acde48001122
+=== RUN   test-single-path-test
+--- PASS: test-single-path-test (0.04s)
+PASS
+```
+
 ## API
 
 Tests are implemented using Go's `testing` package;

--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -15,10 +15,13 @@
 package runner
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	atomixk8s "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	log "k8s.io/klog"
@@ -119,6 +122,58 @@ func (c *ClusterController) RunTests(tests []string, timeout time.Duration) (str
 
 	// Get the exit message and code
 	return c.getStatus(pod)
+}
+
+// GetLogs returns the logs for a test resource
+func (c *ClusterController) GetLogs(resourceId string) ([][]string, error) {
+	pod, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).Get(resourceId, metav1.GetOptions{})
+	if err == nil {
+		return c.getAllLogs([]corev1.Pod{*pod})
+	} else if !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	pods, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).List(metav1.ListOptions{
+		LabelSelector: "resource=" + resourceId,
+	})
+	if err != nil {
+		return nil, err
+	} else if len(pods.Items) == 0 {
+		return nil, errors.New("unknown test resource " + resourceId)
+	} else {
+		return c.getAllLogs(pods.Items)
+	}
+}
+
+// getAllLogs gets the logs from all of the given pods
+func (c *ClusterController) getAllLogs(pods []corev1.Pod) ([][]string, error) {
+	allLogs := make([][]string, len(pods))
+	for i, pod := range pods {
+		logs, err := c.getLogs(pod)
+		if err != nil {
+			return nil, err
+		}
+		allLogs[i] = logs
+	}
+	return allLogs, nil
+}
+
+// getLogs gets the logs from the given pod
+func (c *ClusterController) getLogs(pod corev1.Pod) ([]string, error) {
+	req := c.kubeclient.CoreV1().Pods(c.getClusterName()).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	readCloser, err := req.Stream()
+	if err != nil {
+		return nil, err
+	}
+
+	defer readCloser.Close()
+
+	logs := []string{}
+	scanner := bufio.NewScanner(readCloser)
+	for scanner.Scan() {
+		logs = append(logs, scanner.Text())
+	}
+	return logs, nil
 }
 
 // TeardownSimulator tears down a device simulator with the given name

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -211,6 +211,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						"app": "onos-config",
+						"resource": "onos-config",
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -28,6 +28,44 @@ import (
 	"time"
 )
 
+type NodeStatus string
+
+const (
+	NodeRunning NodeStatus = "RUNNING"
+	NodeFailed  NodeStatus = "FAILED"
+)
+
+// NodeInfo contains information about an onos-config node
+type NodeInfo struct {
+	Id     string
+	Status NodeStatus
+}
+
+// GetNodes returns a list of onos-config nodes running in the cluster
+func (c *ClusterController) GetNodes() ([]NodeInfo, error) {
+	pods, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).List(metav1.ListOptions{
+		LabelSelector: "app=onos-config",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]NodeInfo, len(pods.Items))
+	for i, pod := range pods.Items {
+		var status NodeStatus
+		if pod.Status.Phase == corev1.PodRunning {
+			status = NodeRunning
+		} else if pod.Status.Phase == corev1.PodFailed {
+			status = NodeFailed
+		}
+		nodes[i] = NodeInfo{
+			Id:     pod.Name,
+			Status: status,
+		}
+	}
+	return nodes, nil
+}
+
 // setupOnosConfig sets up the onos-config Deployment
 func (c *ClusterController) setupOnosConfig() error {
 	log.Infof("Setting up onos-config cluster onos-config/%s", c.getClusterName())


### PR DESCRIPTION
This PR adds additional commands to `onit` to:
* Get a list of onos-config nodes
* Get a list of simulators
* Get a list of partitions and partition nodes
* Get the logs from any resource (test, simulator, partition, etc)

Some examples:

```bash
> onit get nodes
ID                            STATUS
onos-config-f5b7758dc-rdbqt   RUNNING
> onit get logs onos-config-f5b7758dc-rdbqt
I0625 21:55:32.027255       1 onos-config.go:114] Starting onos-config
I0625 21:55:32.030184       1 manager.go:98] Configuration store loaded from /etc/onos-config/configs/configStore.json
I0625 21:55:32.030358       1 manager.go:105] Change store loaded from /etc/onos-config/configs/changeStore.json
I0625 21:55:32.031087       1 manager.go:112] Device store loaded from /etc/onos-config/configs/deviceStore.json
I0625 21:55:32.031222       1 manager.go:119] Network store loaded from /etc/onos-config/configs/networkStore.json
I0625 21:55:32.031301       1 manager.go:47] Creating Manager
...
```

```bash
> onit get partitions
ID   GROUP   NODES
1    raft    raft-1-0
> onit get logs raft-1-0
21:10:24.466 [main] INFO  io.atomix.server.AtomixServerRunner - Node ID: raft-1-0
21:10:24.472 [main] INFO  io.atomix.server.AtomixServerRunner - Partition Config: /etc/atomix/partition.json
21:10:24.472 [main] INFO  io.atomix.server.AtomixServerRunner - Protocol Config: /etc/atomix/protocol.json
21:10:24.473 [main] INFO  io.atomix.server.AtomixServerRunner - Starting server
...
```

```bash
> onit get history
ID                                     TESTS                   STATUS   EXIT CODE   MESSAGE
3cf7311a-9776-11e9-bfc3-acde48001122   test-integration-test   PASSED   0
68ad9154-977c-11e9-bcf2-acde48001122   test-integration-test   FAILED   1
71a0623c-977c-11e9-8478-acde48001122   test-single-path-test   PASSED   0
9e512cdc-9720-11e9-ba6e-acde48001122   *                       PASSED   0
da629d06-9774-11e9-bb50-acde48001122   *                       PASSED   0
> onit get logs 71a0623c-977c-11e9-8478-acde48001122
=== RUN   test-single-path-test
--- PASS: test-single-path-test (0.04s)
PASS
```
