### PR TITLE
Namespace onit clusters from cluster ID

### DIFF
--- a/test/runner/atomix.go
+++ b/test/runner/atomix.go
@@ -27,7 +27,7 @@ import (
 
 // setupAtomixController sets up the Atomix controller and associated resources
 func (c *ClusterController) setupAtomixController() error {
-	log.Infof("Setting up Atomix controller atomix-controller/%s", c.getClusterName())
+	log.Infof("Setting up Atomix controller atomix-controller/%s", c.ClusterId)
 	if err := c.createAtomixPartitionSetResource(); err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func (c *ClusterController) setupAtomixController() error {
 		return err
 	}
 
-	log.Infof("Waiting for Atomix controller atomix-controller/%s to become ready", c.getClusterName())
+	log.Infof("Waiting for Atomix controller atomix-controller/%s to become ready", c.ClusterId)
 	if err := c.awaitAtomixControllerReady(); err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (c *ClusterController) createAtomixClusterRole() error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "atomix-controller",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -201,13 +201,13 @@ func (c *ClusterController) createAtomixClusterRoleBinding() error {
 	roleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "atomix-controller",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Subjects: []rbacv1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      "atomix-controller",
-				Namespace: c.getClusterName(),
+				Namespace: c.ClusterId,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -233,10 +233,10 @@ func (c *ClusterController) createAtomixServiceAccount() error {
 	serviceAccount := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "atomix-controller",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 	}
-	_, err := c.kubeclient.CoreV1().ServiceAccounts(c.getClusterName()).Create(serviceAccount)
+	_, err := c.kubeclient.CoreV1().ServiceAccounts(c.ClusterId).Create(serviceAccount)
 	return err
 }
 
@@ -246,7 +246,7 @@ func (c *ClusterController) createAtomixDeployment() error {
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "atomix-controller",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -324,7 +324,7 @@ func (c *ClusterController) createAtomixDeployment() error {
 			},
 		},
 	}
-	_, err := c.kubeclient.AppsV1().Deployments(c.getClusterName()).Create(deployment)
+	_, err := c.kubeclient.AppsV1().Deployments(c.ClusterId).Create(deployment)
 	return err
 }
 
@@ -333,7 +333,7 @@ func (c *ClusterController) createAtomixService() error {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "atomix-controller",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -347,14 +347,14 @@ func (c *ClusterController) createAtomixService() error {
 			},
 		},
 	}
-	_, err := c.kubeclient.CoreV1().Services(c.getClusterName()).Create(service)
+	_, err := c.kubeclient.CoreV1().Services(c.ClusterId).Create(service)
 	return err
 }
 
 // awaitAtomixControllerReady blocks until the Atomix controller is ready
 func (c *ClusterController) awaitAtomixControllerReady() error {
 	for {
-		dep, err := c.kubeclient.AppsV1().Deployments(c.getClusterName()).Get("atomix-controller", metav1.GetOptions{})
+		dep, err := c.kubeclient.AppsV1().Deployments(c.ClusterId).Get("atomix-controller", metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if dep.Status.ReadyReplicas == 1 {

--- a/test/runner/cli.go
+++ b/test/runner/cli.go
@@ -111,7 +111,7 @@ func getCreateClusterCommand() *cobra.Command {
 			if len(args) > 0 {
 				clusterId = args[0]
 			} else {
-				clusterId = newUuidString()
+				clusterId = fmt.Sprintf("cluster-%s", newUuidString())
 			}
 
 			// Acquire a lock on the configuration to add the cluster

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -43,7 +43,7 @@ type NodeInfo struct {
 
 // GetNodes returns a list of onos-config nodes running in the cluster
 func (c *ClusterController) GetNodes() ([]NodeInfo, error) {
-	pods, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).List(metav1.ListOptions{
+	pods, err := c.kubeclient.CoreV1().Pods(c.ClusterId).List(metav1.ListOptions{
 		LabelSelector: "app=onos-config",
 	})
 	if err != nil {

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -68,7 +68,7 @@ func (c *ClusterController) GetNodes() ([]NodeInfo, error) {
 
 // setupOnosConfig sets up the onos-config Deployment
 func (c *ClusterController) setupOnosConfig() error {
-	log.Infof("Setting up onos-config cluster onos-config/%s", c.getClusterName())
+	log.Infof("Setting up onos-config cluster onos-config/%s", c.ClusterId)
 	if err := c.createOnosConfigSecret(); err != nil {
 		return err
 	}
@@ -82,7 +82,7 @@ func (c *ClusterController) setupOnosConfig() error {
 		return err
 	}
 
-	log.Infof("Waiting for onos-config cluster onos-config/%s to become ready", c.getClusterName())
+	log.Infof("Waiting for onos-config cluster onos-config/%s to become ready", c.ClusterId)
 	if err := c.awaitOnosConfigDeploymentReady(); err != nil {
 		return err
 	}
@@ -93,8 +93,8 @@ func (c *ClusterController) setupOnosConfig() error {
 func (c *ClusterController) createOnosConfigSecret() error {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.getClusterName(),
-			Namespace: c.getClusterName(),
+			Name:      c.ClusterId,
+			Namespace: c.ClusterId,
 		},
 		StringData: map[string]string{},
 	}
@@ -121,7 +121,7 @@ func (c *ClusterController) createOnosConfigSecret() error {
 		return err
 	}
 
-	_, err = c.kubeclient.CoreV1().Secrets(c.getClusterName()).Create(secret)
+	_, err = c.kubeclient.CoreV1().Secrets(c.ClusterId).Create(secret)
 	return err
 }
 
@@ -179,7 +179,7 @@ func (c *ClusterController) createOnosConfigConfigMap() error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "onos-config",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Data: map[string]string{
 			"changeStore.json":  string(changeStore),
@@ -188,7 +188,7 @@ func (c *ClusterController) createOnosConfigConfigMap() error {
 			"networkStore.json": string(networkStore),
 		},
 	}
-	_, err = c.kubeclient.CoreV1().ConfigMaps(c.getClusterName()).Create(cm)
+	_, err = c.kubeclient.CoreV1().ConfigMaps(c.ClusterId).Create(cm)
 	return err
 }
 
@@ -198,7 +198,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "onos-config",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &nodes,
@@ -223,7 +223,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ATOMIX_CONTROLLER",
-									Value: fmt.Sprintf("atomix-controller.%s.svc.cluster.local:5679", c.getClusterName()),
+									Value: fmt.Sprintf("atomix-controller.%s.svc.cluster.local:5679", c.ClusterId),
 								},
 								{
 									Name:  "ATOMIX_APP",
@@ -231,7 +231,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 								},
 								{
 									Name:  "ATOMIX_NAMESPACE",
-									Value: c.getClusterName(),
+									Value: c.ClusterId,
 								},
 							},
 							Args: []string{
@@ -296,7 +296,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 							Name: "secret",
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: c.getClusterName(),
+									SecretName: c.ClusterId,
 								},
 							},
 						},
@@ -305,7 +305,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 			},
 		},
 	}
-	_, err := c.kubeclient.AppsV1().Deployments(c.getClusterName()).Create(dep)
+	_, err := c.kubeclient.AppsV1().Deployments(c.ClusterId).Create(dep)
 	return err
 }
 
@@ -314,7 +314,7 @@ func (c *ClusterController) createOnosConfigService() error {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "onos-config",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -328,14 +328,14 @@ func (c *ClusterController) createOnosConfigService() error {
 			},
 		},
 	}
-	_, err := c.kubeclient.CoreV1().Services(c.getClusterName()).Create(service)
+	_, err := c.kubeclient.CoreV1().Services(c.ClusterId).Create(service)
 	return err
 }
 
 // awaitOnosConfigDeploymentReady waits for the onos-config pods to complete startup
 func (c *ClusterController) awaitOnosConfigDeploymentReady() error {
 	for {
-		dep, err := c.kubeclient.AppsV1().Deployments(c.getClusterName()).Get("onos-config", metav1.GetOptions{})
+		dep, err := c.kubeclient.AppsV1().Deployments(c.ClusterId).Get("onos-config", metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -350,7 +350,7 @@ func (c *ClusterController) awaitOnosConfigDeploymentReady() error {
 
 // teardownOnosConfig tears down the onos-config deployment
 func (c *ClusterController) redeployOnosConfig() error {
-	log.Infof("Redeploying onos-config cluster onos-config/%s", c.getClusterName())
+	log.Infof("Redeploying onos-config cluster onos-config/%s", c.ClusterId)
 	if err := c.deleteOnosConfigDeployment(); err != nil {
 		return err
 	}
@@ -363,7 +363,7 @@ func (c *ClusterController) redeployOnosConfig() error {
 	if err := c.createOnosConfigDeployment(); err != nil {
 		return err
 	}
-	log.Infof("Waiting for onos-config cluster onos-config/%s to become ready", c.getClusterName())
+	log.Infof("Waiting for onos-config cluster onos-config/%s to become ready", c.ClusterId)
 	if err := c.awaitOnosConfigDeploymentReady(); err != nil {
 		return err
 	}
@@ -372,10 +372,10 @@ func (c *ClusterController) redeployOnosConfig() error {
 
 // deleteOnosConfigConfigMap deletes the onos-config ConfigMap
 func (c *ClusterController) deleteOnosConfigConfigMap() error {
-	return c.kubeclient.CoreV1().ConfigMaps(c.getClusterName()).Delete("onos-config", &metav1.DeleteOptions{})
+	return c.kubeclient.CoreV1().ConfigMaps(c.ClusterId).Delete("onos-config", &metav1.DeleteOptions{})
 }
 
 // deleteOnosConfigDeployment deletes the onos-config Deployment
 func (c *ClusterController) deleteOnosConfigDeployment() error {
-	return c.kubeclient.AppsV1().Deployments(c.getClusterName()).Delete("onos-config", &metav1.DeleteOptions{})
+	return c.kubeclient.AppsV1().Deployments(c.ClusterId).Delete("onos-config", &metav1.DeleteOptions{})
 }

--- a/test/runner/partitions.go
+++ b/test/runner/partitions.go
@@ -94,12 +94,12 @@ func (c *ClusterController) GetPartitionNodes(partition int) ([]NodeInfo, error)
 
 // setupPartitions creates a Raft partition set
 func (c *ClusterController) setupPartitions() error {
-	log.Infof("Setting up partitions raft/%s", c.getClusterName())
+	log.Infof("Setting up partitions raft/%s", c.ClusterId)
 	if err := c.createPartitionSet(); err != nil {
 		return err
 	}
 
-	log.Infof("Waiting for partitions raft/%s to become ready", c.getClusterName())
+	log.Infof("Waiting for partitions raft/%s to become ready", c.ClusterId)
 	if err := c.awaitPartitionsReady(); err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (c *ClusterController) createPartitionSet() error {
 	set := &v1alpha1.PartitionSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "raft",
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Spec: v1alpha1.PartitionSetSpec{
 			Partitions: c.config.Partitions,
@@ -135,14 +135,14 @@ func (c *ClusterController) createPartitionSet() error {
 			},
 		},
 	}
-	_, err = c.atomixclient.K8sV1alpha1().PartitionSets(c.getClusterName()).Create(set)
+	_, err = c.atomixclient.K8sV1alpha1().PartitionSets(c.ClusterId).Create(set)
 	return err
 }
 
 // awaitPartitionsReady waits for Raft partitions to complete startup
 func (c *ClusterController) awaitPartitionsReady() error {
 	for {
-		set, err := c.atomixclient.K8sV1alpha1().PartitionSets(c.getClusterName()).Get("raft", metav1.GetOptions{})
+		set, err := c.atomixclient.K8sV1alpha1().PartitionSets(c.ClusterId).Get("raft", metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if int(set.Status.ReadyPartitions) == set.Spec.Partitions {

--- a/test/runner/partitions.go
+++ b/test/runner/partitions.go
@@ -35,7 +35,7 @@ type PartitionInfo struct {
 
 // GetPartitions returns a list of partition info
 func (c *ClusterController) GetPartitions() ([]PartitionInfo, error) {
-	partitionList, err := c.atomixclient.K8sV1alpha1().Partitions(c.getClusterName()).List(metav1.ListOptions{
+	partitionList, err := c.atomixclient.K8sV1alpha1().Partitions(c.ClusterId).List(metav1.ListOptions{
 		LabelSelector: "group=raft",
 	})
 	if err != nil {
@@ -69,7 +69,7 @@ func (c *ClusterController) GetPartitions() ([]PartitionInfo, error) {
 
 // GetPartitionNodes returns a list of node info for the given partition
 func (c *ClusterController) GetPartitionNodes(partition int) ([]NodeInfo, error) {
-	pods, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).List(metav1.ListOptions{
+	pods, err := c.kubeclient.CoreV1().Pods(c.ClusterId).List(metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("group=raft,partition=%d", partition),
 	})
 	if err != nil {

--- a/test/runner/simulator.go
+++ b/test/runner/simulator.go
@@ -45,13 +45,13 @@ func (c *ClusterController) createSimulatorConfigMap(name string, config *Simula
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Data: map[string]string{
 			"config.json": string(configJson),
 		},
 	}
-	_, err = c.kubeclient.CoreV1().ConfigMaps(c.getClusterName()).Create(cm)
+	_, err = c.kubeclient.CoreV1().ConfigMaps(c.ClusterId).Create(cm)
 	return err
 }
 
@@ -60,7 +60,7 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 			Labels: map[string]string{
 				"simulator": name,
 			},
@@ -118,7 +118,7 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 			},
 		},
 	}
-	_, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).Create(pod)
+	_, err := c.kubeclient.CoreV1().Pods(c.ClusterId).Create(pod)
 	return err
 }
 
@@ -127,7 +127,7 @@ func (c *ClusterController) createSimulatorService(name string) error {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: c.getClusterName(),
+			Namespace: c.ClusterId,
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
@@ -141,14 +141,14 @@ func (c *ClusterController) createSimulatorService(name string) error {
 			},
 		},
 	}
-	_, err := c.kubeclient.CoreV1().Services(c.getClusterName()).Create(service)
+	_, err := c.kubeclient.CoreV1().Services(c.ClusterId).Create(service)
 	return err
 }
 
 // awaitSimulatorReady waits for the given simulator to complete startup
 func (c *ClusterController) awaitSimulatorReady(name string) error {
 	for {
-		pod, err := c.kubeclient.CoreV1().Pods(c.getClusterName()).Get(name, metav1.GetOptions{})
+		pod, err := c.kubeclient.CoreV1().Pods(c.ClusterId).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		} else if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
@@ -175,15 +175,15 @@ func (c *ClusterController) teardownSimulator(name string) error {
 
 // deleteSimulatorConfigMap deletes a simulator ConfigMap by name
 func (c *ClusterController) deleteSimulatorConfigMap(name string) error {
-	return c.kubeclient.CoreV1().ConfigMaps(c.getClusterName()).Delete(name, &metav1.DeleteOptions{})
+	return c.kubeclient.CoreV1().ConfigMaps(c.ClusterId).Delete(name, &metav1.DeleteOptions{})
 }
 
 // deleteSimulatorPod deletes a simulator Pod by name
 func (c *ClusterController) deleteSimulatorPod(name string) error {
-	return c.kubeclient.CoreV1().Pods(c.getClusterName()).Delete(name, &metav1.DeleteOptions{})
+	return c.kubeclient.CoreV1().Pods(c.ClusterId).Delete(name, &metav1.DeleteOptions{})
 }
 
 // deleteSimulatorService deletes a simulator Service by name
 func (c *ClusterController) deleteSimulatorService(name string) error {
-	return c.kubeclient.CoreV1().Services(c.getClusterName()).Delete(name, &metav1.DeleteOptions{})
+	return c.kubeclient.CoreV1().Services(c.ClusterId).Delete(name, &metav1.DeleteOptions{})
 }


### PR DESCRIPTION
This PR modifies the use of a generated name for the cluster namespace in onit to allow users to pass a cluster ID which will be used directly to create the test namespace. This allows `kubectl` commands to more easily be used when a cluster is explicitly named.