### PR TITLE
Move test ID generation to CLI for consistency with other UUIDs

### DIFF
--- a/test/runner/cli.go
+++ b/test/runner/cli.go
@@ -695,6 +695,8 @@ func getRunCommand() *cobra.Command {
 		Use:   "run [tests]",
 		Short: "Run integration tests on Kubernetes",
 		Run: func(cmd *cobra.Command, args []string) {
+			testId := fmt.Sprintf("test-%d", newUuidInt())
+
 			// Load the onit configuration from disk
 			config, err := LoadConfig()
 			if err != nil {
@@ -720,7 +722,7 @@ func getRunCommand() *cobra.Command {
 			}
 
 			timeout, _ := cmd.Flags().GetInt("timeout")
-			message, code, err := controller.RunTests(args, time.Duration(timeout)*time.Second)
+			message, code, err := controller.RunTests(testId, args, time.Duration(timeout)*time.Second)
 			if err != nil {
 				exitError(err)
 			} else {

--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -100,14 +100,14 @@ func (c *ClusterController) SetupSimulator(name string, config *SimulatorConfig)
 }
 
 // RunTests runs the given tests on Kubernetes
-func (c *ClusterController) RunTests(tests []string, timeout time.Duration) (string, int, error) {
+func (c *ClusterController) RunTests(testId string, tests []string, timeout time.Duration) (string, int, error) {
 	// Default the test timeout to 10 minutes
 	if timeout == 0 {
 		timeout = 10 * time.Minute
 	}
 
 	// Start the test job
-	pod, err := c.startTests(tests, timeout)
+	pod, err := c.startTests(testId, tests, timeout)
 	if err != nil {
 		return "", 0, err
 	}

--- a/test/runner/test.go
+++ b/test/runner/test.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"github.com/onosproject/onos-config/test/env"
 	"io"
 	batchv1 "k8s.io/api/batch/v1"
@@ -49,13 +48,7 @@ type TestRecord struct {
 }
 
 // startTests starts running a test job
-func (c *ClusterController) startTests(tests []string, timeout time.Duration) (corev1.Pod, error) {
-	id, err := uuid.NewUUID()
-	if err != nil {
-		return corev1.Pod{}, err
-	}
-
-	testId := id.String()
+func (c *ClusterController) startTests(testId string, tests []string, timeout time.Duration) (corev1.Pod, error) {
 	if err := c.createTestJob(testId, tests, timeout); err != nil {
 		return corev1.Pod{}, err
 	}
@@ -64,12 +57,12 @@ func (c *ClusterController) startTests(tests []string, timeout time.Duration) (c
 
 // createTestJob creates the job to run tests
 func (c *ClusterController) createTestJob(testId string, args []string, timeout time.Duration) error {
-	log.Infof("Starting test job %s", getTestName(testId))
+	log.Infof("Starting test job %s", testId)
 	one := int32(1)
 	timeoutSeconds := int64(timeout / time.Second)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getTestName(testId),
+			Name:      testId,
 			Namespace: c.getClusterName(),
 			Annotations: map[string]string{
 				"test-args": strings.Join(args, ","),
@@ -206,7 +199,7 @@ func (c *ClusterController) GetHistory() ([]TestRecord, error) {
 
 // GetRecord returns a single record for the given test
 func (c *ClusterController) GetRecord(testId string) (TestRecord, error) {
-	job, err := c.kubeclient.BatchV1().Jobs(c.getClusterName()).Get(getTestName(testId), metav1.GetOptions{})
+	job, err := c.kubeclient.BatchV1().Jobs(c.getClusterName()).Get(testId, metav1.GetOptions{})
 	if err != nil {
 		return TestRecord{}, err
 	}
@@ -309,9 +302,4 @@ func (c *ClusterController) getDeviceIds() []string {
 		devices = append(devices, name)
 	}
 	return devices
-}
-
-// getTestName returns a qualified test name derived from the given test ID suitable for use in k8s resource names
-func getTestName(testId string) string {
-	return fmt.Sprintf("onos-test-%s", testId)
 }


### PR DESCRIPTION
This PR modifies the `onit run` command to generate a UUID-based test ID within the command itself rather than in the cluster controller for consistency with other commands.