### PR TITLE
Refactor onit configuration to read all configuration data from Kubernetes resources

### DIFF
--- a/test/runner/atomix.go
+++ b/test/runner/atomix.go
@@ -219,13 +219,18 @@ func (c *ClusterController) createAtomixClusterRoleBinding() error {
 	_, err := c.kubeclient.RbacV1().ClusterRoleBindings().Create(roleBinding)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			c.deleteClusterRoleBinding()
+			c.deleteAtomixClusterRoleBinding()
 			return c.createAtomixClusterRoleBinding()
 		} else {
 			return err
 		}
 	}
 	return nil
+}
+
+// deleteAtomixClusterRoleBinding deletes the ClusterRoleBinding required by the Atomix controller
+func (c *ClusterController) deleteAtomixClusterRoleBinding() error {
+	return c.kubeclient.RbacV1().ClusterRoleBindings().Delete("atomix-controller", &metav1.DeleteOptions{})
 }
 
 // createAtomixServiceAccount creates a ServiceAccount used by the Atomix controller

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -1,0 +1,149 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"bufio"
+	"errors"
+	atomixk8s "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
+	corev1 "k8s.io/api/core/v1"
+	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	log "k8s.io/klog"
+	"time"
+)
+
+// ClusterController manages a single cluster in Kubernetes
+type ClusterController struct {
+	ClusterId        string
+	kubeclient       *kubernetes.Clientset
+	atomixclient     *atomixk8s.Clientset
+	extensionsclient *apiextension.Clientset
+	config           *ClusterConfig
+}
+
+// Setup sets up a test cluster with the given configuration
+func (c *ClusterController) Setup() error {
+	log.Infof("Setting up test cluster %s", c.ClusterId)
+	if err := c.setupAtomixController(); err != nil {
+		return err
+	}
+	if err := c.setupPartitions(); err != nil {
+		return err
+	}
+	if err := c.setupOnosConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// AddSimulator adds a device simulator with the given configuration
+func (c *ClusterController) AddSimulator(name string, config *SimulatorConfig) error {
+	log.Infof("Setting up simulator %s/%s", name, c.ClusterId)
+	if err := c.setupSimulator(name, config); err != nil {
+		return err
+	}
+
+	log.Infof("Waiting for simulator %s/%s to become ready", name, c.ClusterId)
+	if err := c.awaitSimulatorReady(name); err != nil {
+		return err
+	}
+	return c.redeployOnosConfig()
+}
+
+// RunTests runs the given tests on Kubernetes
+func (c *ClusterController) RunTests(testId string, tests []string, timeout time.Duration) (string, int, error) {
+	// Default the test timeout to 10 minutes
+	if timeout == 0 {
+		timeout = 10 * time.Minute
+	}
+
+	// Start the test job
+	pod, err := c.startTests(testId, tests, timeout)
+	if err != nil {
+		return "", 0, err
+	}
+
+	// Stream the logs to stdout
+	if err = c.streamLogs(pod); err != nil {
+		return "", 0, err
+	}
+
+	// Get the exit message and code
+	return c.getStatus(pod)
+}
+
+// GetLogs returns the logs for a test resource
+func (c *ClusterController) GetLogs(resourceId string) ([][]string, error) {
+	pod, err := c.kubeclient.CoreV1().Pods(c.ClusterId).Get(resourceId, metav1.GetOptions{})
+	if err == nil {
+		return c.getAllLogs([]corev1.Pod{*pod})
+	} else if !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	pods, err := c.kubeclient.CoreV1().Pods(c.ClusterId).List(metav1.ListOptions{
+		LabelSelector: "resource=" + resourceId,
+	})
+	if err != nil {
+		return nil, err
+	} else if len(pods.Items) == 0 {
+		return nil, errors.New("unknown test resource " + resourceId)
+	} else {
+		return c.getAllLogs(pods.Items)
+	}
+}
+
+// getAllLogs gets the logs from all of the given pods
+func (c *ClusterController) getAllLogs(pods []corev1.Pod) ([][]string, error) {
+	allLogs := make([][]string, len(pods))
+	for i, pod := range pods {
+		logs, err := c.getLogs(pod)
+		if err != nil {
+			return nil, err
+		}
+		allLogs[i] = logs
+	}
+	return allLogs, nil
+}
+
+// getLogs gets the logs from the given pod
+func (c *ClusterController) getLogs(pod corev1.Pod) ([]string, error) {
+	req := c.kubeclient.CoreV1().Pods(c.ClusterId).GetLogs(pod.Name, &corev1.PodLogOptions{})
+	readCloser, err := req.Stream()
+	if err != nil {
+		return nil, err
+	}
+
+	defer readCloser.Close()
+
+	logs := []string{}
+	scanner := bufio.NewScanner(readCloser)
+	for scanner.Scan() {
+		logs = append(logs, scanner.Text())
+	}
+	return logs, nil
+}
+
+// RemoveSimulator removes a device simulator with the given name
+func (c *ClusterController) RemoveSimulator(name string) error {
+	log.Infof("Tearing down simulator %s/%s", name, c.ClusterId)
+	if err := c.teardownSimulator(name); err != nil {
+		return err
+	}
+	return c.redeployOnosConfig()
+}

--- a/test/runner/config.go
+++ b/test/runner/config.go
@@ -15,13 +15,10 @@
 package runner
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
 	"github.com/gofrs/flock"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v1"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -39,24 +36,6 @@ var (
 	configLock *flock.Flock
 )
 
-// getSimulatorPreset gets a device configuration by name
-func getSimulatorPreset(name string) (map[string]interface{}, error) {
-	file, err := os.Open(filepath.Join(deviceConfigsPath, name+".json"))
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	jsonBytes, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, err
-	}
-
-	var jsonObj map[string]interface{}
-	err = json.Unmarshal(jsonBytes, &jsonObj)
-	return jsonObj, err
-}
-
 // getSimulatorPresets returns a list of store configurations from the configs/store directory
 func getSimulatorPresets() []string {
 	configs := []string{}
@@ -72,53 +51,6 @@ func getSimulatorPresets() []string {
 		return nil
 	})
 	return configs
-}
-
-// getStorePreset returns a named store configuration from the given stores configuration
-func getStorePreset(configName string, storeType string) (map[string]interface{}, error) {
-	file, err := os.Open(filepath.Join(storeConfigsPath, configName+".json"))
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	jsonBytes, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, err
-	}
-
-	var jsonObj map[string]interface{}
-	err = json.Unmarshal(jsonBytes, &jsonObj)
-	if err != nil {
-		return nil, err
-	}
-
-	storeObj, ok := jsonObj[storeType]
-	if !ok {
-		return nil, errors.New("malformed store configuration: " + storeType + " key not found")
-	}
-
-	return storeObj.(map[string]interface{}), nil
-}
-
-// getChangeStorePreset returns the change store from the given stores configuration
-func getChangeStorePreset(name string) (map[string]interface{}, error) {
-	return getStorePreset(name, "changeStore")
-}
-
-// getConfigStorePreset returns the config store from the given stores configuration
-func getConfigStorePreset(name string) (map[string]interface{}, error) {
-	return getStorePreset(name, "configStore")
-}
-
-// getNetworkStorePreset returns the network store from the given stores configuration
-func getNetworkStorePreset(name string) (map[string]interface{}, error) {
-	return getStorePreset(name, "networkStore")
-}
-
-// getDeviceStorePreset returns the device store from the given stores configuration
-func getDeviceStorePreset(name string) (map[string]interface{}, error) {
-	return getStorePreset(name, "deviceStore")
 }
 
 // getStorePresets returns a list of store configurations from the configs/store directory
@@ -138,159 +70,70 @@ func getStorePresets() []string {
 	return configs
 }
 
-// LoadConfig loads the onit configuration from a configuration file
-func LoadConfig() (*OnitConfig, error) {
-	config := &OnitConfig{Clusters: make(map[string]*ClusterConfig)}
-	if err := viper.Unmarshal(config); err != nil {
-		return nil, err
-	}
-	return config, nil
-}
-
-// OnitConfig provides the configuration for onit
-type OnitConfig struct {
-	DefaultCluster string                    `yaml:"default" mapstructure:"default"`
-	Clusters       map[string]*ClusterConfig `yaml:"clusters" mapstructure:"clusters"`
-}
-
-// getDefaultCluster returns the default cluster ID
-func (c *OnitConfig) getDefaultCluster() (string, error) {
-	cluster := c.DefaultCluster
-	if cluster == "" {
-		return "", errors.New("no default cluster set")
-	}
-	return cluster, nil
-}
-
-// getClusterConfig returns the configuration for the given cluster
-func (c *OnitConfig) getClusterConfig(clusterId string) (*ClusterConfig, error) {
-	config, ok := c.Clusters[clusterId]
-	if !ok {
-		return nil, errors.New("unknown cluster " + clusterId)
-	}
-	setClusterConfigDefaults(config)
-	return config, nil
-}
-
-// Lock acquires a lock on the configuration
-func (c *OnitConfig) Lock() error {
-	// Get the configuration file used by viper and create a lock file from it
-	configFile := viper.ConfigFileUsed()
-	lockFile := configFile[0:len(configFile)-len(filepath.Ext(configFile))] + ".lock"
-	configLock := flock.New(lockFile)
-
-	// Acquire the lock on the configuration file
-	if err := configLock.Lock(); err != nil {
-		return err
-	}
-
-	// Once the lock has been acquired, load the configuration from the file to ensure it's up-to-date
-	return viper.Unmarshal(c)
-}
-
-// Unlock releases a lock on the configuration
-func (c *OnitConfig) Unlock() error {
-	lock := configLock
-	if lock == nil {
-		return errors.New("no configuration lock acquired")
-	}
-	return lock.Unlock()
-}
-
-// Write writes the configuration to a configuration file
-func (c *OnitConfig) Write() error {
+// setDefaultCluster sets the default cluster
+func setDefaultCluster(clusterId string) error {
 	if err := initConfig(); err != nil {
 		return err
 	}
-	encoded, err := yaml.Marshal(c)
-	if err != nil {
-		return err
-	}
-	if err = viper.ReadConfig(bytes.NewReader(encoded)); err != nil {
-		return err
-	}
+	viper.Set("cluster", clusterId)
 	return viper.WriteConfig()
+}
+
+// getDefaultCluster returns the default cluster
+func getDefaultCluster() string {
+	return viper.GetString("cluster")
 }
 
 // ClusterConfig provides the configuration for the Kubernetes test cluster
 type ClusterConfig struct {
-	ChangeStore   map[string]interface{}      `yaml:"changeStore" mapstructure:"changeStore"`
-	ConfigStore   map[string]interface{}      `yaml:"configStore" mapstructure:"configStore"`
-	DeviceStore   map[string]interface{}      `yaml:"deviceStore" mapstructure:"deviceStore"`
-	NetworkStore  map[string]interface{}      `yaml:"networkStore" mapstructure:"networkStore"`
-	Simulators    map[string]*SimulatorConfig `yaml:"simulators" mapstructure:"simulators"`
-	Nodes         int                         `yaml:"nodes" mapstructure:"nodes"`
-	Partitions    int                         `yaml:"partitions" mapstructure:"partitions"`
-	PartitionSize int                         `yaml:"partitionSize" mapstructure:"partitionSize"`
+	Preset        string `yaml:"preset" mapstructure:"preset"`
+	Nodes         int    `yaml:"nodes" mapstructure:"nodes"`
+	Partitions    int    `yaml:"partitions" mapstructure:"partitions"`
+	PartitionSize int    `yaml:"partitionSize" mapstructure:"partitionSize"`
 }
 
-// getSimulator returns a simulator configuration
-func (c *ClusterConfig) getSimulator(name string) (*SimulatorConfig, error) {
-	simulator, ok := c.Simulators[name]
-	if !ok {
-		return nil, errors.New("unknown simulator " + name)
+// load loads the preset configuration for the cluster
+func (c *ClusterConfig) load() (map[string]interface{}, error) {
+	file, err := os.Open(filepath.Join(storeConfigsPath, c.Preset+".json"))
+	if err != nil {
+		return nil, err
 	}
-	return simulator, nil
-}
+	defer file.Close()
 
-func setClusterConfigDefaults(config *ClusterConfig) {
-	if config.ChangeStore == nil {
-		config.ChangeStore = map[string]interface{}{
-			"Version":   "1.0.0",
-			"Storetype": "change",
-			"Store":     make(map[string]interface{}),
-		}
-	} else if _, ok := config.ChangeStore["Store"]; !ok {
-		config.ChangeStore["Store"] = make(map[string]interface{})
+	jsonBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
 	}
 
-	if config.DeviceStore == nil {
-		config.DeviceStore = map[string]interface{}{
-			"Version":   "1.0.0",
-			"Storetype": "device",
-			"Store":     make(map[string]interface{}),
-		}
-	} else if _, ok := config.DeviceStore["Store"]; !ok {
-		config.DeviceStore["Store"] = make(map[string]interface{})
+	var jsonObj map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonObj)
+	if err != nil {
+		return nil, err
 	}
-
-	if config.ConfigStore == nil {
-		config.ConfigStore = map[string]interface{}{
-			"Version":   "1.0.0",
-			"Storetype": "config",
-			"Store":     make(map[string]interface{}),
-		}
-	} else if _, ok := config.ConfigStore["Store"]; !ok {
-		config.ConfigStore["Store"] = make(map[string]interface{})
-	}
-
-	if config.NetworkStore == nil {
-		config.NetworkStore = map[string]interface{}{
-			"Version":   "1.0.0",
-			"Storetype": "network",
-			"Store":     make([]interface{}, 0),
-		}
-	} else if _, ok := config.NetworkStore["Store"]; !ok {
-		config.NetworkStore["Store"] = make([]interface{}, 0)
-	}
-
-	if config.Simulators == nil {
-		config.Simulators = make(map[string]*SimulatorConfig)
-	}
-	if config.Nodes == 0 {
-		config.Nodes = 1
-	}
-	if config.Partitions == 0 {
-		config.Partitions = 1
-	}
-	if config.PartitionSize == 0 {
-		config.PartitionSize = 1
-	}
+	return jsonObj, nil
 }
 
 // SimulatorConfig provides the configuration for a device simulator
 type SimulatorConfig struct {
-	Config map[string]interface{} `yaml:"config" mapstructure:"config"`
+	Config string `yaml:"config" mapstructure:"config"`
+}
+
+// load loads the simulator configuration
+func (c *SimulatorConfig) load() (map[string]interface{}, error) {
+	file, err := os.Open(filepath.Join(deviceConfigsPath, c.Config+".json"))
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	jsonBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	var jsonObj map[string]interface{}
+	err = json.Unmarshal(jsonBytes, &jsonObj)
+	return jsonObj, err
 }
 
 func initConfig() error {

--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -15,22 +15,16 @@
 package runner
 
 import (
-	"bufio"
-	"errors"
 	atomixk8s "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
+	"gopkg.in/yaml.v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	log "k8s.io/klog"
-	"time"
 )
 
-// GetClusterController returns a Kubernetes integration test controller for the given test ID
-func GetClusterController(clusterId string, config *ClusterConfig) (*ClusterController, error) {
-	setClusterConfigDefaults(config)
-
+// NewController creates a new onit controller
+func NewController() (*OnitController, error) {
 	kubeclient, err := newKubeClient()
 	if err != nil {
 		return nil, err
@@ -46,169 +40,122 @@ func GetClusterController(clusterId string, config *ClusterConfig) (*ClusterCont
 		return nil, err
 	}
 
-	return &ClusterController{
-		ClusterId:        clusterId,
+	return &OnitController{
 		kubeclient:       kubeclient,
 		atomixclient:     atomixclient,
 		extensionsclient: extensionsclient,
+	}, nil
+}
+
+// OnitController manages clusters for onit
+type OnitController struct {
+	kubeclient       *kubernetes.Clientset
+	atomixclient     *atomixk8s.Clientset
+	extensionsclient *apiextension.Clientset
+}
+
+// GetClusters returns a list of onit clusters
+func (c *OnitController) GetClusters() (map[string]*ClusterConfig, error) {
+	namespaces, err := c.kubeclient.CoreV1().Namespaces().List(metav1.ListOptions{
+		LabelSelector: "app=onit",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	clusters := make(map[string]*ClusterConfig)
+	for _, ns := range namespaces.Items {
+		name := ns.Name
+		cm, err := c.kubeclient.CoreV1().ConfigMaps(name).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		config := &ClusterConfig{}
+		if err = yaml.Unmarshal(cm.BinaryData["config"], config); err != nil {
+			return nil, err
+		}
+		clusters[name] = config
+	}
+	return clusters, nil
+}
+
+// NewCluster creates a new cluster controller
+func (c *OnitController) NewCluster(clusterId string, config *ClusterConfig) (*ClusterController, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterId,
+			Labels: map[string]string{
+				"app": "onit",
+			},
+		},
+	}
+	_, err := c.kubeclient.CoreV1().Namespaces().Create(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	configString, err := yaml.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterId,
+			Namespace: clusterId,
+		},
+		BinaryData: map[string][]byte{
+			"config": configString,
+		},
+	}
+	_, err = c.kubeclient.CoreV1().ConfigMaps(clusterId).Create(cm)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClusterController{
+		ClusterId:        clusterId,
+		kubeclient:       c.kubeclient,
+		atomixclient:     c.atomixclient,
+		extensionsclient: c.extensionsclient,
 		config:           config,
 	}, nil
 }
 
-// Kubernetes cluster controller
-type ClusterController struct {
-	ClusterId        string
-	kubeclient       *kubernetes.Clientset
-	atomixclient     *atomixk8s.Clientset
-	extensionsclient *apiextension.Clientset
-	config           *ClusterConfig
+// GetCluster returns a cluster controller
+func (c *OnitController) GetCluster(clusterId string) (*ClusterController, error) {
+	_, err := c.kubeclient.CoreV1().Namespaces().Get(clusterId, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	cm, err := c.kubeclient.CoreV1().ConfigMaps(clusterId).Get(clusterId, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	config := &ClusterConfig{}
+	if err = yaml.Unmarshal(cm.BinaryData["config"], config); err != nil {
+		return nil, err
+	}
+
+	return &ClusterController{
+		ClusterId:        clusterId,
+		kubeclient:       c.kubeclient,
+		atomixclient:     c.atomixclient,
+		extensionsclient: c.extensionsclient,
+		config:           config,
+	}, nil
 }
 
-// SetupCluster sets up a test cluster with the given configuration
-func (c *ClusterController) SetupCluster() error {
-	log.Infof("Setting up test cluster %s", c.ClusterId)
-	if err := c.setupNamespace(); err != nil {
+// DeleteCluster deletes a cluster controller
+func (c *OnitController) DeleteCluster(clusterId string) error {
+	if err := c.kubeclient.RbacV1().ClusterRoleBindings().Delete("atomix-controller", &metav1.DeleteOptions{}); err != nil {
 		return err
 	}
-	if err := c.setupAtomixController(); err != nil {
-		return err
-	}
-	if err := c.setupPartitions(); err != nil {
-		return err
-	}
-	if err := c.setupOnosConfig(); err != nil {
+	if err := c.kubeclient.CoreV1().Namespaces().Delete(clusterId, &metav1.DeleteOptions{}); err != nil {
 		return err
 	}
 	return nil
-}
-
-// SetupSimulator sets up a device simulator with the given configuration
-func (c *ClusterController) SetupSimulator(name string, config *SimulatorConfig) error {
-	log.Infof("Setting up simulator %s/%s", name, c.ClusterId)
-	if err := c.setupSimulator(name, config); err != nil {
-		return err
-	}
-
-	log.Infof("Waiting for simulator %s/%s to become ready", name, c.ClusterId)
-	if err := c.awaitSimulatorReady(name); err != nil {
-		return err
-	}
-	return c.redeployOnosConfig()
-}
-
-// RunTests runs the given tests on Kubernetes
-func (c *ClusterController) RunTests(testId string, tests []string, timeout time.Duration) (string, int, error) {
-	// Default the test timeout to 10 minutes
-	if timeout == 0 {
-		timeout = 10 * time.Minute
-	}
-
-	// Start the test job
-	pod, err := c.startTests(testId, tests, timeout)
-	if err != nil {
-		return "", 0, err
-	}
-
-	// Stream the logs to stdout
-	if err = c.streamLogs(pod); err != nil {
-		return "", 0, err
-	}
-
-	// Get the exit message and code
-	return c.getStatus(pod)
-}
-
-// GetLogs returns the logs for a test resource
-func (c *ClusterController) GetLogs(resourceId string) ([][]string, error) {
-	pod, err := c.kubeclient.CoreV1().Pods(c.ClusterId).Get(resourceId, metav1.GetOptions{})
-	if err == nil {
-		return c.getAllLogs([]corev1.Pod{*pod})
-	} else if !k8serrors.IsNotFound(err) {
-		return nil, err
-	}
-
-	pods, err := c.kubeclient.CoreV1().Pods(c.ClusterId).List(metav1.ListOptions{
-		LabelSelector: "resource=" + resourceId,
-	})
-	if err != nil {
-		return nil, err
-	} else if len(pods.Items) == 0 {
-		return nil, errors.New("unknown test resource " + resourceId)
-	} else {
-		return c.getAllLogs(pods.Items)
-	}
-}
-
-// getAllLogs gets the logs from all of the given pods
-func (c *ClusterController) getAllLogs(pods []corev1.Pod) ([][]string, error) {
-	allLogs := make([][]string, len(pods))
-	for i, pod := range pods {
-		logs, err := c.getLogs(pod)
-		if err != nil {
-			return nil, err
-		}
-		allLogs[i] = logs
-	}
-	return allLogs, nil
-}
-
-// getLogs gets the logs from the given pod
-func (c *ClusterController) getLogs(pod corev1.Pod) ([]string, error) {
-	req := c.kubeclient.CoreV1().Pods(c.ClusterId).GetLogs(pod.Name, &corev1.PodLogOptions{})
-	readCloser, err := req.Stream()
-	if err != nil {
-		return nil, err
-	}
-
-	defer readCloser.Close()
-
-	logs := []string{}
-	scanner := bufio.NewScanner(readCloser)
-	for scanner.Scan() {
-		logs = append(logs, scanner.Text())
-	}
-	return logs, nil
-}
-
-// TeardownSimulator tears down a device simulator with the given name
-func (c *ClusterController) TeardownSimulator(name string) error {
-	log.Infof("Tearing down simulator %s/%s", name, c.ClusterId)
-	if err := c.teardownSimulator(name); err != nil {
-		return err
-	}
-	return c.redeployOnosConfig()
-}
-
-// TeardownCluster tears down the test cluster
-func (c *ClusterController) TeardownCluster() error {
-	log.Infof("Tearing down test namespace %s", c.ClusterId)
-	if err := c.deleteNamespace(); err != nil {
-		return err
-	}
-	if err := c.deleteClusterRoleBinding(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// setupNamespace creates a uniquely named namespace with which to run tests
-func (c *ClusterController) setupNamespace() error {
-	log.Infof("Setting up test namespace %s", c.ClusterId)
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: c.ClusterId,
-		},
-	}
-	_, err := c.kubeclient.CoreV1().Namespaces().Create(namespace)
-	return err
-}
-
-// deleteClusterRoleBinding deletes the ClusterRoleBinding used by the test
-func (c *ClusterController) deleteClusterRoleBinding() error {
-	return c.kubeclient.RbacV1().ClusterRoleBindings().Delete("atomix-controller", &metav1.DeleteOptions{})
-}
-
-// deleteNamespace deletes the Namespace used by the test and all resources within it
-func (c *ClusterController) deleteNamespace() error {
-	return c.kubeclient.CoreV1().Namespaces().Delete(c.ClusterId, &metav1.DeleteOptions{})
 }


### PR DESCRIPTION
#408 

This PR modifies the onit configuration to move the majority of it to Kubernetes. Clusters are read from k8s, as are nodes, partitions, and tests. This ensures the cli is consistent with whatever k8s cluster it's connected to.