### PR TITLE
Support remote debugging in onit clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ onos-config-it-docker: onos-config-base-docker # @HELP build onos-config-integra
 images: # @HELP build all Docker images
 images: build onos-config-docker onos-config-debug-docker onos-cli-docker onos-config-it-docker
 
-kind: # @HELP build onos-config and onos-config-integration-tests images and add them to a kind cluster
+kind: # @HELP build Docker images and add them to the currently configured kind cluster
 kind: images
 	@if [[ ! `kind get clusters` ]]; then echo "no kind cluster found" && exit 1; fi
 	kind load docker-image onosproject/onos-cli:${ONOS_CONFIG_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ kind: # @HELP build Docker images and add them to the currently configured kind 
 kind: images
 	@if [[ ! `kind get clusters` ]]; then echo "no kind cluster found" && exit 1; fi
 	kind load docker-image onosproject/onos-cli:${ONOS_CONFIG_VERSION}
-	kind load docker-image onosproject/onos-config:${ONOS_CONFIG_VERSION}
 	kind load docker-image onosproject/onos-config:${ONOS_CONFIG_DEBUG_VERSION}
 	kind load docker-image onosproject/onos-config-integration-tests:${ONOS_CONFIG_VERSION}
 

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -7,6 +7,7 @@ FROM golang:1.12.6-alpine3.9 as debugBuilder
 RUN apk upgrade --update --no-cache && apk add git && go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM alpine:3.9
+
 RUN apk upgrade --update --no-cache && apk add bash bash-completion libc6-compat
 
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos /usr/local/bin/onos
@@ -17,8 +18,7 @@ COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/device
 COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
-    echo "dlv --listen=:40000 --headless=true --api-version=2 exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
-    echo "dlv --init <(echo \"exit -c\") connect 127.0.0.1:40000" && \
+    echo "dlv --listen=:40000 --headless=true --accept-multiclient=true --api-version=2 exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
     chmod +x /usr/local/bin/onos-config-debug
 
 RUN addgroup -S onos-config && adduser -S -G onos-config onos-config

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -18,6 +18,7 @@ COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
     echo "dlv --listen=:40000 --headless=true --api-version=2 exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
+    echo "dlv --init <(echo \"exit -c\") connect 127.0.0.1:40000" && \
     chmod +x /usr/local/bin/onos-config-debug
 
 RUN addgroup -S onos-config && adduser -S -G onos-config onos-config

--- a/go.sum
+++ b/go.sum
@@ -38,9 +38,9 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
+github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/evanphx/json-patch v4.0.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/test/runner/cli.go
+++ b/test/runner/cli.go
@@ -703,13 +703,13 @@ func getDebugCommand() *cobra.Command {
 			}
 
 			// Get the cluster ID
-			clusterId, err := cmd.Flags().GetString("cluster")
+			clusterID, err := cmd.Flags().GetString("cluster")
 			if err != nil {
 				exitError(err)
 			}
 
 			// Get the cluster controller
-			cluster, err := controller.GetCluster(clusterId)
+			cluster, err := controller.GetCluster(clusterID)
 			if err != nil {
 				exitError(err)
 			}

--- a/test/runner/client.go
+++ b/test/runner/client.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 )
 
-// getRestConfig returns the k8s rest configuration from the environment
+// getRestConfig returns the Kubernetes REST API configuration
 func getRestConfig() (*rest.Config, error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
-		home := homeDir()
+		home := getHomeDir()
 		if home == "" {
 			return nil, errors.New("no home directory configured")
 		}
@@ -37,8 +37,8 @@ func getRestConfig() (*rest.Config, error) {
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
 
-// homeDir returns the user's home directory if defined by environment variables
-func homeDir() string {
+// getHomeDir returns the user's home directory if defined by environment variables
+func getHomeDir() string {
 	if h := os.Getenv("HOME"); h != "" {
 		return h
 	}

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -16,7 +16,9 @@ package runner
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
+	"fmt"
 	atomixk8s "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
 	corev1 "k8s.io/api/core/v1"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -24,7 +26,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
 	log "k8s.io/klog"
+	"net/http"
+	"os"
 	"time"
 )
 
@@ -144,6 +150,52 @@ func (c *ClusterController) getLogs(pod corev1.Pod) ([]string, error) {
 		logs = append(logs, scanner.Text())
 	}
 	return logs, nil
+}
+
+// PortForward forwards a local port to the given remote port on the given resource
+func (c *ClusterController) PortForward(resourceId string, localPort int, remotePort int) error {
+	pod, err := c.kubeclient.CoreV1().Pods(c.ClusterId).Get(resourceId, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	req := c.kubeclient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("portforward")
+
+	roundTripper, upgradeRoundTripper, err := spdy.RoundTripperFor(c.restconfig)
+	if err != nil {
+		return err
+	}
+
+	dialer := spdy.NewDialer(upgradeRoundTripper, &http.Client{Transport: roundTripper}, http.MethodPost, req.URL())
+
+	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
+	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
+
+	ports := make([]string, 2)
+	ports[0] = fmt.Sprintf("%d", localPort)
+	ports[1] = fmt.Sprintf("%d", remotePort)
+
+	forwarder, err := portforward.New(dialer, ports, stopChan, readyChan, out, errOut)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		for range readyChan { // Kubernetes will close this channel when it has something to tell us.
+		}
+		if len(errOut.String()) != 0 {
+			fmt.Println(errOut.String())
+			os.Exit(1)
+		} else if len(out.String()) != 0 {
+			fmt.Println(out.String())
+		}
+	}()
+
+	return forwarder.ForwardPorts()
 }
 
 // RemoveSimulator removes a device simulator with the given name

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -154,7 +154,7 @@ func (c *ClusterController) getLogs(pod corev1.Pod) ([]string, error) {
 
 // PortForward forwards a local port to the given remote port on the given resource
 func (c *ClusterController) PortForward(resourceId string, localPort int, remotePort int) error {
-	pod, err := c.kubeclient.CoreV1().Pods(c.ClusterId).Get(resourceId, metav1.GetOptions{})
+	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceId, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -153,8 +153,8 @@ func (c *ClusterController) getLogs(pod corev1.Pod) ([]string, error) {
 }
 
 // PortForward forwards a local port to the given remote port on the given resource
-func (c *ClusterController) PortForward(resourceId string, localPort int, remotePort int) error {
-	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceId, metav1.GetOptions{})
+func (c *ClusterController) PortForward(resourceID string, localPort int, remotePort int) error {
+	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceID, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -175,11 +175,7 @@ func (c *ClusterController) PortForward(resourceId string, localPort int, remote
 	stopChan, readyChan := make(chan struct{}, 1), make(chan struct{}, 1)
 	out, errOut := new(bytes.Buffer), new(bytes.Buffer)
 
-	ports := make([]string, 2)
-	ports[0] = fmt.Sprintf("%d", localPort)
-	ports[1] = fmt.Sprintf("%d", remotePort)
-
-	forwarder, err := portforward.New(dialer, ports, stopChan, readyChan, out, errOut)
+	forwarder, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", localPort, remotePort)}, stopChan, readyChan, out, errOut)
 	if err != nil {
 		return err
 	}

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -253,7 +253,6 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 							Name:            "onos-config",
 							Image:           "onosproject/onos-config:debug",
 							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command:         []string{"onos-config"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ATOMIX_CONTROLLER",

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -317,6 +317,11 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 									Name:          "grpc",
 									ContainerPort: 5150,
 								},
+								{
+									Name:          "debug",
+									ContainerPort: 40000,
+									Protocol:      corev1.ProtocolTCP,
+								},
 							},
 							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{
@@ -346,6 +351,13 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 									Name:      "secret",
 									MountPath: "/etc/onos-config/certs",
 									ReadOnly:  true,
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{
+										"SYS_PTRACE",
+									},
 								},
 							},
 						},


### PR DESCRIPTION
#402

This PR implements support for remote debugging in onit clusters. Because delve currently [has no elegant way to avoid pausing at startup](https://github.com/go-delve/delve/issues/245) to wait for a debugger to be attached, a hack has to be implemented to unpause the debugger when onos-config nodes are bootstrapped. Because this is a questionable process, I'm adding the WIP tag to test it a bit more before this is merged.