### PR TITLE
Remove bogus comment left over from cut & paste

### DIFF
--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -73,7 +73,6 @@ func TestTransaction(t *testing.T) {
 	assert.NotNil(t, response)
 
 	// Check that the values were really rolled back
-	// Check that the values were set correctly
 	_, errorAfterRollback := GNMIGet(MakeContext(), c, devicePathsForGet)
 	assert.Error(t, errorAfterRollback)
 }


### PR DESCRIPTION
Removed a meaningless comment line that was left over from cut & paste