### PR TITLE
Rename integration tests to be easier to type

### DIFF
--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -70,5 +70,5 @@ func TestSinglePath(t *testing.T) {
 }
 
 func init() {
-	Registry.Register("test-single-path-test", TestSinglePath)
+	Registry.Register("single-path", TestSinglePath)
 }

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -33,7 +33,7 @@ const (
 )
 
 func init() {
-	Registry.Register("subscribe-test", TestSubscribe)
+	Registry.Register("subscribe", TestSubscribe)
 }
 
 func TestSubscribe(t *testing.T) {

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -78,5 +78,5 @@ func TestTransaction(t *testing.T) {
 }
 
 func init() {
-	Registry.Register("test-transaction-test", TestTransaction)
+	Registry.Register("transaction", TestTransaction)
 }


### PR DESCRIPTION
Simplified naming scheme for integration tests

Fixes #414 