### PR TITLE
Add "onit fetch" command to download logs

### DIFF
--- a/test/runner/cli.go
+++ b/test/runner/cli.go
@@ -718,21 +718,21 @@ func getFetchLogsCommand() *cobra.Command {
 			}
 
 			// Get the cluster ID
-			clusterId, err := cmd.Flags().GetString("cluster")
+			clusterID, err := cmd.Flags().GetString("cluster")
 			if err != nil {
 				exitError(err)
 			}
 
 			// Get the cluster controller
-			cluster, err := controller.GetCluster(clusterId)
+			cluster, err := controller.GetCluster(clusterID)
 			if err != nil {
 				exitError(err)
 			}
 
 			destination, _ := cmd.Flags().GetString("destination")
 			if len(args) > 0 {
-				resourceId := args[0]
-				resources, err := cluster.GetResources(resourceId)
+				resourceID := args[0]
+				resources, err := cluster.GetResources(resourceID)
 				if err != nil {
 					exitError(err)
 				}

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -79,14 +79,14 @@ func (c *ClusterController) AddSimulator(name string, config *SimulatorConfig) e
 }
 
 // RunTests runs the given tests on Kubernetes
-func (c *ClusterController) RunTests(testId string, tests []string, timeout time.Duration) (string, int, error) {
+func (c *ClusterController) RunTests(testID string, tests []string, timeout time.Duration) (string, int, error) {
 	// Default the test timeout to 10 minutes
 	if timeout == 0 {
 		timeout = 10 * time.Minute
 	}
 
 	// Start the test job
-	pod, err := c.startTests(testId, tests, timeout)
+	pod, err := c.startTests(testID, tests, timeout)
 	if err != nil {
 		return "", 0, err
 	}
@@ -126,8 +126,8 @@ func (c *ClusterController) GetResources(name string) ([]string, error) {
 }
 
 // GetLogs returns the logs for a single test resource
-func (c *ClusterController) GetLogs(resourceId string) ([]byte, error) {
-	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceId, metav1.GetOptions{})
+func (c *ClusterController) GetLogs(resourceID string) ([]byte, error) {
+	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceID, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -152,9 +152,9 @@ func (c *ClusterController) getLogs(pod corev1.Pod) ([]byte, error) {
 }
 
 // DownloadLogs downloads the logs for the given resource to the given path
-func (c *ClusterController) DownloadLogs(resourceId string, path string) error {
-	log.Infof("Downloading logs from %s", resourceId)
-	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceId, metav1.GetOptions{})
+func (c *ClusterController) DownloadLogs(resourceID string, path string) error {
+	log.Infof("Downloading logs from %s", resourceID)
+	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceID, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#418

This PR adds an `onit fetch` command to download logs to local files:

```bash
> onit fetch logs
I0626 13:56:04.702150   70859 cluster.go:145] Downloading logs from onos-config-65988654df-gkb6b
```

By default, logs are written to `.log` files in the current working directory. An optional `destination` can be provided to write them to a different location. Currently this PR only downloads onos-config node logs. We can extend it in the future for other components.

You can also specify a specific node from which to download logs.

This PR needs more testing.