### PR TITLE
Fix gofmt warnings based on goreport

### DIFF
--- a/modelplugin/Devicesim-1.0.0/modelmain.go
+++ b/modelplugin/Devicesim-1.0.0/modelmain.go
@@ -31,7 +31,7 @@ const modelversion = "1.0.0"
 const modulename = "devicesim.so.1.0.0"
 
 var modelData = []*gnmi.ModelData{
-    {Name: "openconfig-interfaces",Organization: "OpenConfig working group",Version: "2017-07-14"},{Name: "openconfig-openflow",Organization: "OpenConfig working group",Version: "2017-06-01"},{Name: "openconfig-platform", Organization: "OpenConfig working group",Version: "2016-12-22"},{Name: "openconfig-system", Organization: "OpenConfig working group",Version: "2017-07-06"},
+	{Name: "openconfig-interfaces", Organization: "OpenConfig working group", Version: "2017-07-14"}, {Name: "openconfig-openflow", Organization: "OpenConfig working group", Version: "2017-06-01"}, {Name: "openconfig-platform", Organization: "OpenConfig working group", Version: "2016-12-22"}, {Name: "openconfig-system", Organization: "OpenConfig working group", Version: "2017-07-06"},
 }
 
 func (m modelplugin) ModelData() (string, string, []*gnmi.ModelData, string) {

--- a/modelplugin/ModelGenerator.sh
+++ b/modelplugin/ModelGenerator.sh
@@ -64,7 +64,7 @@ const modelversion = "$VERSION"
 const modulename = $TYPEMODULE
 
 var modelData = []*gnmi.ModelData{
-    $MODELDATA
+      $MODELDATA	
 }
 
 func (m modelplugin) ModelData() (string, string, []*gnmi.ModelData, string) {

--- a/modelplugin/TestDevice-1.0.0/modelmain.go
+++ b/modelplugin/TestDevice-1.0.0/modelmain.go
@@ -31,7 +31,7 @@ const modelversion = "1.0.0"
 const modulename = "testdevice.so.1.0.0"
 
 var modelData = []*gnmi.ModelData{
-    {Name: "test1",Version: "2018-02-20",Organization: "Open Networking Foundation"},
+	{Name: "test1", Version: "2018-02-20", Organization: "Open Networking Foundation"},
 }
 
 func (m modelplugin) ModelData() (string, string, []*gnmi.ModelData, string) {

--- a/modelplugin/TestDevice-2.0.0/modelmain.go
+++ b/modelplugin/TestDevice-2.0.0/modelmain.go
@@ -31,7 +31,7 @@ const modelversion = "2.0.0"
 const modulename = "testdevice.so.2.0.0"
 
 var modelData = []*gnmi.ModelData{
-    {Name: "test1",Version: "2019-06-10",Organization: "Open Networking Foundation"},
+	{Name: "test1", Version: "2019-06-10", Organization: "Open Networking Foundation"},
 }
 
 func (m modelplugin) ModelData() (string, string, []*gnmi.ModelData, string) {

--- a/test/runner/cli.go
+++ b/test/runner/cli.go
@@ -50,7 +50,6 @@ func GetCommand(registry *TestRegistry) *cobra.Command {
 	return cmd
 }
 
-
 func getCompletionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:       "completion <shell>",
@@ -60,7 +59,6 @@ func getCompletionCommand() *cobra.Command {
 		Run:       runCompletionCommand,
 	}
 }
-
 
 func runCompletionCommand(cmd *cobra.Command, args []string) {
 	if args[0] == "bash" {
@@ -84,7 +82,6 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	return cmd.GenZshCompletion(out)
 }
-
 
 // getCreateCommand returns a cobra "setup" command for setting up resources
 func getCreateCommand() *cobra.Command {

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -36,7 +36,7 @@ const (
 	NodeRunning NodeStatus = "RUNNING"
 
 	// NodeFailed node has failed
-	NodeFailed  NodeStatus = "FAILED"
+	NodeFailed NodeStatus = "FAILED"
 )
 
 // NodeInfo contains information about an onos-config node

--- a/test/runner/test.go
+++ b/test/runner/test.go
@@ -36,10 +36,10 @@ const (
 	TestRunning TestStatus = "RUNNING"
 
 	// TestPassed passed
-	TestPassed  TestStatus = "PASSED"
+	TestPassed TestStatus = "PASSED"
 
 	// TestFailed failed
-	TestFailed  TestStatus = "FAILED"
+	TestFailed TestStatus = "FAILED"
 )
 
 // TestRecord contains information about a test run


### PR DESCRIPTION
There are also gofmt warnnings for generated code and can be fixed but I assume we don't want to touch that code. 