### PR TITLE
Southbound error channel

### DIFF
--- a/pkg/events/errorevent.go
+++ b/pkg/events/errorevent.go
@@ -1,0 +1,53 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/onosproject/onos-config/pkg/store/change"
+	"time"
+)
+
+// ErrorEvent a error event
+type ErrorEvent Event
+
+// ChangeID returns the changeId of the error event
+func (errEvent *ErrorEvent) ChangeID() string {
+	return errEvent.values[ChangeID]
+}
+
+// EventType returns the EventType of the error event
+func (errEvent *ErrorEvent) EventType() EventType {
+	return errEvent.eventtype
+}
+
+// Error returns the error of the error event
+func (errEvent *ErrorEvent) Error() error {
+	return fmt.Errorf(errEvent.values[Error])
+}
+
+// CreateErrorEvent creates a new error event object
+func CreateErrorEvent(eventType EventType, subject string, changeID change.ID, err error) ErrorEvent {
+	values := make(map[string]string)
+	values[ChangeID] = base64.StdEncoding.EncodeToString(changeID)
+	values[Error] = string(err.Error())
+	return ErrorEvent{
+		subject:   subject,
+		time:      time.Now(),
+		eventtype: eventType,
+		values:    values,
+	}
+}

--- a/pkg/events/errorevent.go
+++ b/pkg/events/errorevent.go
@@ -51,3 +51,16 @@ func CreateErrorEvent(eventType EventType, subject string, changeID change.ID, e
 		values:    values,
 	}
 }
+
+// CreateErrorEventNoChangeID creates a new error event object with no changeID attached
+func CreateErrorEventNoChangeID(eventType EventType, subject string, err error) ErrorEvent {
+	values := make(map[string]string)
+	values[ChangeID] = ""
+	values[Error] = string(err.Error())
+	return ErrorEvent{
+		subject:   subject,
+		time:      time.Now(),
+		eventtype: eventType,
+		values:    values,
+	}
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -34,6 +34,9 @@ const (
 
 	// Address :
 	Address = "Address"
+
+	//Error :
+	Error = "Error"
 )
 
 // EventType is an enumerated type
@@ -44,6 +47,13 @@ const ( // For event types
 	EventTypeConfiguration EventType = iota
 	EventTypeTopoCache
 	EventTypeOperationalState
+	EventTypeErrorSetConfig
+	EventTypeErrorParseConfig
+	EventTypeErrorSetInitialConfig
+	EventTypeErrorDeviceConnect
+	EventTypeErrorDeviceCapabilities
+	EventTypeErrorDeviceDisconnect
+	EventTypeErrorSubscribe
 )
 
 func (et EventType) String() string {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -37,7 +37,7 @@ type Manager struct {
 	TopoChannel             chan events.TopoEvent
 	ChangesChannel          chan events.ConfigEvent
 	OperationalStateChannel chan events.OperationalStateEvent
-	SouthboundErrorChan     chan error
+	SouthboundErrorChan     chan events.ErrorEvent
 	Dispatcher              dispatcher.Dispatcher
 	ModelRegistry           map[string]ModelPlugin
 }
@@ -54,7 +54,7 @@ func NewManager(configs *store.ConfigurationStore, changes *store.ChangeStore, d
 		TopoChannel:             topoCh,
 		ChangesChannel:          make(chan events.ConfigEvent, 10),
 		OperationalStateChannel: make(chan events.OperationalStateEvent, 10),
-		SouthboundErrorChan:     make(chan error, 10),
+		SouthboundErrorChan:     make(chan events.ErrorEvent, 10),
 		Dispatcher:              dispatcher.NewDispatcher(),
 		ModelRegistry:           make(map[string]ModelPlugin),
 	}
@@ -199,12 +199,12 @@ func GetManager() *Manager {
 	return &mgr
 }
 
-func listenOnErrorChannel(errChan chan error) {
-	//TODO evaluate moving this to a specific Error struct with a type and values
-	// for easiness of usage
+func listenOnErrorChannel(errChan chan events.ErrorEvent) {
 	log.Info("Listening for Errors in Manager")
 	for err := range errChan {
 		log.Error("Error reported to channel ", err)
 		//TODO handle errors accordingly
+		// e.g. initial set error, remove config for that device
+		// e.g. set error needs rollback of device and network change.
 	}
 }

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -47,7 +47,7 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 				unregErr := dispatcher.UnregisterDevice(deviceName)
 				if unregErr != nil {
 					errChan <- events.CreateErrorEvent(events.EventTypeErrorDeviceDisconnect,
-						string(deviceName), make([]byte, 0), err)
+						string(deviceName), make([]byte, 0), unregErr)
 				}
 			} else {
 				//spawning two go routines to propagate changes and to get operational state

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -27,7 +27,7 @@ import (
 // and deletion events and spawns Synchronizer threads for them
 // These synchronizers then listen out for configEvents relative to a device and
 func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationStore, deviceStore *topocache.DeviceStore,
-	topoChannel <-chan events.TopoEvent, opStateChan chan<- events.OperationalStateEvent,
+	topoChannel <-chan events.TopoEvent, opStateChan chan<- events.OperationalStateEvent, errChan chan<- error,
 	dispatcher *dispatcher.Dispatcher) {
 	for topoEvent := range topoChannel {
 		deviceName := topocache.ID(events.Event(topoEvent).Subject())
@@ -38,25 +38,26 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 			}
 			device := deviceStore.Store[topocache.ID(deviceName)]
 			ctx := context.Background()
-			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan)
+			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan, errChan)
 			if err != nil {
-				//TODO propagate the ERROR
 				log.Error("Error in connecting to client: ", err)
+				errChan <- err
 				//unregistering the listener for changes to the device
-				dispatcher.UnregisterDevice(deviceName)
+				unregErr := dispatcher.UnregisterDevice(deviceName)
+				if err != nil {
+					errChan <- unregErr
+				}
 			} else {
 				//spawning two go routines to propagate changes and to get operational state
-				go sync.syncConfigEventsToDevice()
-				//TODO error handling
-				log.Info("getting operational state")
-				go sync.syncOperationalState()
-				//TODO push configuration to the device if any was set before it's connection
+				go sync.syncConfigEventsToDevice(errChan)
+				go sync.syncOperationalState(errChan)
 			}
 		} else if dispatcher.HasListener(deviceName) && !topoEvent.Connect() {
 
 			err := dispatcher.UnregisterDevice(deviceName)
 			if err != nil {
 				log.Error(err)
+				errChan <- err
 			}
 		}
 	}

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -41,13 +41,13 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan, errChan)
 			if err != nil {
 				log.Error("Error in connecting to client: ", err)
-				errChan <- events.CreateErrorEvent(events.EventTypeErrorDeviceConnect,
-					string(deviceName), make([]byte, 0), err)
+				errChan <- events.CreateErrorEventNoChangeID(events.EventTypeErrorDeviceConnect,
+					string(deviceName), err)
 				//unregistering the listener for changes to the device
 				unregErr := dispatcher.UnregisterDevice(deviceName)
 				if unregErr != nil {
-					errChan <- events.CreateErrorEvent(events.EventTypeErrorDeviceDisconnect,
-						string(deviceName), make([]byte, 0), unregErr)
+					errChan <- events.CreateErrorEventNoChangeID(events.EventTypeErrorDeviceDisconnect,
+						string(deviceName), unregErr)
 				}
 			} else {
 				//spawning two go routines to propagate changes and to get operational state
@@ -59,8 +59,8 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 			err := dispatcher.UnregisterDevice(deviceName)
 			if err != nil {
 				log.Error(err)
-				errChan <- events.CreateErrorEvent(events.EventTypeErrorDeviceDisconnect,
-					string(deviceName), make([]byte, 0), err)
+				errChan <- events.CreateErrorEventNoChangeID(events.EventTypeErrorDeviceDisconnect,
+					string(deviceName), err)
 			}
 		}
 	}


### PR DESCRIPTION
WIP: Adding an error channel for the southbound and listening on the manager. Fixes #135

The Idea behind this work is that the Manager will then act upon the error accordingly, bringing the system back in an appropriate state. 
E.g. The device rejects a change the Manager needs to rollback that change in the store for that device and also rollback the network change it was part of. 

