### PR TITLE
Use admin interface to add devices to nodes in onit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ onos-config-docker: onos-config-base-docker # @HELP build onos-config Docker ima
 onos-config-debug-docker: onos-config-base-docker # @HELP build onos-config Docker debug image
 	docker build . -f build/onos-config-debug/Dockerfile \
 		--build-arg ONOS_CONFIG_BASE_VERSION=${ONOS_CONFIG_VERSION} \
-		-t onosproject/onos-config-debug:${ONOS_CONFIG_VERSION}
+		-t onosproject/onos-config:${ONOS_CONFIG_DEBUG_VERSION}
 
 onos-cli-docker: onos-config-base-docker # @HELP build onos-cli Docker image
 	docker build . -f build/onos-cli/Dockerfile \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ onos-config-docker: onos-config-base-docker # @HELP build onos-config Docker ima
 onos-config-debug-docker: onos-config-base-docker # @HELP build onos-config Docker debug image
 	docker build . -f build/onos-config-debug/Dockerfile \
 		--build-arg ONOS_CONFIG_BASE_VERSION=${ONOS_CONFIG_VERSION} \
-		-t onosproject/onos-config:${ONOS_CONFIG_DEBUG_VERSION}
+		-t onosproject/onos-config-debug:${ONOS_CONFIG_VERSION}
 
 onos-cli-docker: onos-config-base-docker # @HELP build onos-cli Docker image
 	docker build . -f build/onos-cli/Dockerfile \
@@ -86,9 +86,11 @@ images: # @HELP build all Docker images
 images: build onos-config-docker onos-config-debug-docker onos-cli-docker onos-config-it-docker
 
 kind: # @HELP build onos-config and onos-config-integration-tests images and add them to a kind cluster
-kind: onos-config-docker onos-config-it-docker
+kind: images
 	@if [[ ! `kind get clusters` ]]; then echo "no kind cluster found" && exit 1; fi
+	kind load docker-image onosproject/onos-cli:${ONOS_CONFIG_VERSION}
 	kind load docker-image onosproject/onos-config:${ONOS_CONFIG_VERSION}
+	kind load docker-image onosproject/onos-config:${ONOS_CONFIG_DEBUG_VERSION}
 	kind load docker-image onosproject/onos-config-integration-tests:${ONOS_CONFIG_VERSION}
 
 all: build images

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -7,9 +7,10 @@ FROM golang:1.12.6-alpine3.9 as debugBuilder
 RUN apk upgrade --update --no-cache && apk add git && go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM alpine:3.9
-RUN apk add libc6-compat
+RUN apk upgrade --update --no-cache && apk add bash bash-completion libc6-compat
 
-COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos-config-debug /usr/local/bin/onos-config-debug
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos /usr/local/bin/onos
+COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos-config-debug /usr/local/bin/onos-config
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.1.0.0 /usr/local/lib/testdevice.so.1.0.0
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
@@ -22,5 +23,11 @@ RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
 RUN addgroup -S onos-config && adduser -S -G onos-config onos-config
 USER onos-config
 WORKDIR /home/onos-config
+
+RUN onos init && \
+    cp /etc/profile /home/onos-config/.bashrc && \
+    onos completion bash > /home/onos-config/.onos/bash_completion.sh && \
+    onos config set address onos-config-onos-config:5150 && \
+    echo "source /home/onos-config/.onos/bash_completion.sh" >> /home/onos-config/.bashrc
 
 ENTRYPOINT ["onos-config-debug"]

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96 h1:cenwrSVm+Z7QLSV/BsnenAOcDXdX4cMv4wP0B/5QbPg=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/test/runner/client.go
+++ b/test/runner/client.go
@@ -16,16 +16,14 @@ package runner
 
 import (
 	"errors"
-	atomixk8s "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
-	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"path/filepath"
 )
 
-// newKubeClient returns a new Kubernetes client from the environment
-func newKubeClient() (*kubernetes.Clientset, error) {
+// getRestConfig returns the k8s rest configuration from the environment
+func getRestConfig() (*rest.Config, error) {
 	kubeconfig := os.Getenv("KUBECONFIG")
 	if kubeconfig == "" {
 		home := homeDir()
@@ -36,55 +34,7 @@ func newKubeClient() (*kubernetes.Clientset, error) {
 	}
 
 	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the clientset
-	return kubernetes.NewForConfig(config)
-}
-
-// newExtensionsKubeClient returns a new extensions API server Kubernetes client from the environment
-func newExtensionsKubeClient() (*apiextension.Clientset, error) {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		home := homeDir()
-		if home == "" {
-			return nil, errors.New("no home directory configured")
-		}
-		kubeconfig = filepath.Join(home, ".kube", "config")
-	}
-
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the clientset
-	return apiextension.NewForConfig(config)
-}
-
-// newAtomixKubeClient returns a new Atomix Kubernetes client from the environment
-func newAtomixKubeClient() (*atomixk8s.Clientset, error) {
-	kubeconfig := os.Getenv("KUBECONFIG")
-	if kubeconfig == "" {
-		home := homeDir()
-		if home == "" {
-			return nil, errors.New("no home directory configured")
-		}
-		kubeconfig = filepath.Join(home, ".kube", "config")
-	}
-
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
-	// create the clientset
-	return atomixk8s.NewForConfig(config)
+	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
 
 // homeDir returns the user's home directory if defined by environment variables

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -284,7 +284,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 					Containers: []corev1.Container{
 						{
 							Name:            "onos-config",
-							Image:           "onosproject/onos-config-debug:latest",
+							Image:           "onosproject/onos-config:debug",
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         []string{"onos-config"},
 							Env: []corev1.EnvVar{

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -204,7 +204,9 @@ func (c *ClusterController) addSimulatorToPod(name string, pod corev1.Pod) error
 
 // removeSimulatorFromConfig removes a simulator from the onos-config configuration
 func (c *ClusterController) removeSimulatorFromConfig(name string) error {
-	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{})
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: "app=onos-config",
+	})
 	if err != nil {
 		return err
 	}

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -15,6 +15,7 @@
 package runner
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -22,6 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
 	log "k8s.io/klog"
 	"os"
 	"path/filepath"
@@ -148,59 +151,14 @@ func (c *ClusterController) createOnosConfigConfigMap() error {
 		return err
 	}
 
-	// If a device store was provided, serialize the device store configuration.
-	// Otherwise, create a device store configuration from simulators.
-	deviceStoreObj, ok := config["deviceStore"].(map[string]interface{})
-	if !ok {
-		deviceStoreObj = make(map[string]interface{})
-	}
-	configStoreObj, ok := config["configStore"].(map[string]interface{})
-	if !ok {
-		configStoreObj = make(map[string]interface{})
-	}
-	deviceStoreMap, ok := deviceStoreObj["Store"].(map[string]interface{})
-	if !ok {
-		deviceStoreMap = make(map[string]interface{})
-	}
-	configStoreMap, ok := configStoreObj["Store"].(map[string]interface{})
-	if !ok {
-		configStoreMap = make(map[string]interface{})
-	}
-
-	// Get a list of simulators deployed in the cluster
-	simulators, err := c.GetSimulators()
-	if err != nil {
-		return err
-	}
-
-	// Add each simulator to the device and config stores
-	for _, name := range simulators {
-		deviceMap := make(map[string]interface{})
-		deviceMap["ID"] = name
-		deviceMap["Addr"] = fmt.Sprintf("%s:10161", name)
-		deviceMap["SoftwareVersion"] = "1.0.0"
-		deviceMap["Timeout"] = 5
-		deviceStoreMap[name] = deviceMap
-
-		configMap := make(map[string]interface{})
-		configMap["Name"] = name + "-1.0.0"
-		configMap["Device"] = name
-		configMap["Version"] = "1.0.0"
-		configMap["Type"] = "Devicesim"
-		configMap["Created"] = "2019-05-09T16:24:17Z"
-		configMap["Updated"] = "2019-05-09T16:24:17Z"
-		configMap["Changes"] = []string{}
-		configStoreMap[name+"-1.0.0"] = configMap
-	}
-
 	// Serialize the device store configuration
-	deviceStore, err := json.Marshal(deviceStoreObj)
+	deviceStore, err := json.Marshal(config["deviceStore"])
 	if err != nil {
 		return err
 	}
 
 	// Serialize the config store configuration
-	configStore, err := json.Marshal(configStoreObj)
+	configStore, err := json.Marshal(config["configStore"])
 	if err != nil {
 		return err
 	}
@@ -218,6 +176,85 @@ func (c *ClusterController) createOnosConfigConfigMap() error {
 		},
 	}
 	_, err = c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
+	return err
+}
+
+// addSimulatorToConfig adds a simulator to the onos-config configuration
+func (c *ClusterController) addSimulatorToConfig(name string) error {
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: "app=onos-config",
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		if err = c.addSimulatorToPod(name, pod); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addSimulatorToPod adds the given simulator to the given pod's configuration
+func (c *ClusterController) addSimulatorToPod(name string, pod corev1.Pod) error {
+	command := fmt.Sprintf("onos devices add \"id: '%s', address: '%s:10161' version: '1.0.0'\" --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/tls.key --certPath /etc/onos-config/certs/tls.crt", name, name)
+	return c.execute(pod, []string{"/bin/bash", "-c", command})
+}
+
+// removeSimulatorFromConfig removes a simulator from the onos-config configuration
+func (c *ClusterController) removeSimulatorFromConfig(name string) error {
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		if err = c.removeSimulatorFromPod(name, pod); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeSimulatorFromPod removes the given simulator from the given pod
+func (c *ClusterController) removeSimulatorFromPod(name string, pod corev1.Pod) error {
+	command := fmt.Sprintf("onos devices remove %s --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/tls.key --certPath /etc/onos-config/certs/tls.crt", name)
+	return c.execute(pod, []string{"/bin/bash", "-c", command})
+}
+
+// execute executes a command in the given pod
+func (c *ClusterController) execute(pod corev1.Pod, command []string) error {
+	container := pod.Spec.Containers[0]
+	req := c.kubeclient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		Param("container", container.Name)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container.Name,
+		Command:   command,
+		Stdout:    true,
+		Stderr:    true,
+		Stdin:     false,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(c.restconfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		print(stdout.String())
+		print(stderr.String())
+	}
 	return err
 }
 
@@ -247,8 +284,9 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 					Containers: []corev1.Container{
 						{
 							Name:            "onos-config",
-							Image:           "onosproject/onos-config:latest",
+							Image:           "onosproject/onos-config-debug:latest",
 							ImagePullPolicy: corev1.PullIfNotPresent,
+							Command:         []string{"onos-config"},
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ATOMIX_CONTROLLER",
@@ -374,36 +412,4 @@ func (c *ClusterController) awaitOnosConfigDeploymentReady() error {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-}
-
-// teardownOnosConfig tears down the onos-config deployment
-func (c *ClusterController) redeployOnosConfig() error {
-	log.Infof("Redeploying onos-config cluster onos-config/%s", c.clusterID)
-	if err := c.deleteOnosConfigDeployment(); err != nil {
-		return err
-	}
-	if err := c.deleteOnosConfigConfigMap(); err != nil {
-		return err
-	}
-	if err := c.createOnosConfigConfigMap(); err != nil {
-		return err
-	}
-	if err := c.createOnosConfigDeployment(); err != nil {
-		return err
-	}
-	log.Infof("Waiting for onos-config cluster onos-config/%s to become ready", c.clusterID)
-	if err := c.awaitOnosConfigDeploymentReady(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// deleteOnosConfigConfigMap deletes the onos-config ConfigMap
-func (c *ClusterController) deleteOnosConfigConfigMap() error {
-	return c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Delete("onos-config", &metav1.DeleteOptions{})
-}
-
-// deleteOnosConfigDeployment deletes the onos-config Deployment
-func (c *ClusterController) deleteOnosConfigDeployment() error {
-	return c.kubeclient.AppsV1().Deployments(c.clusterID).Delete("onos-config", &metav1.DeleteOptions{})
 }


### PR DESCRIPTION
#417 

This PR modifies the process used by onit to add devices to onos-config nodes after bootstrapping a new simulator. To add a device, we need to use the admin interface. But because it's almost impossible to connect to a specific pod in a `Deployment` from outside the k8s cluster, this PR executes the `onos` command _inside_ the pod to add the device to the node.

This PR also changes the default `onit` image to `onosproject/onos-config:debug` and adds bash and the `onos` CLI to the debug image. This will aid in future tools for debugging onos-config via onit.