### PR TITLE
Initialize config store when adding a device via northbound admin interface

### DIFF
--- a/pkg/northbound/admin/admin_devices.go
+++ b/pkg/northbound/admin/admin_devices.go
@@ -54,10 +54,10 @@ func (s Server) AddOrUpdateDevice(c context.Context, d *proto.DeviceInfo) (*prot
 	name := store.ConfigName(fmt.Sprintf("%s-%s", d.Id, d.Version))
 	if _, ok := configStore.Store[name]; !ok {
 		configStore.Store[name] = store.Configuration{
-			Name: name,
-			Device: d.Id,
+			Name:    name,
+			Device:  d.Id,
 			Version: d.Version,
-			Type: "Devicesim",
+			Type:    "Devicesim",
 			Created: time.Now(),
 			Updated: time.Now(),
 			Changes: []change.ID{},


### PR DESCRIPTION
When a device is added via the northbound interface, tests still fail due to the fact the config store has not been initialized with the device:
```
=== RUN   subscribe
--- FAIL: subscribe (0.08s)
    subscribetest.go:98:
                Error Trace:    subscribetest.go:98
                Error:          Received unexpected error:
                                rpc error: code = Internal desc = no configuration found matching 'device-3319802750'.Please specify version and device type in extensions 101 and 102 and model data in extensions 150-200 in name@ver@org format
                Test:           subscribe
    subscribetest.go:106:
                Error Trace:    subscribetest.go:106
                Error:          Expected Update Response
                Test:           subscribe
FAIL
```

This PR modifies the `AddOrUpdateDevice` endpoint to initialize the config store if necessary.

I'm not entirely sure if this is the right approach to take or if an event listener should initialize the config store. Need input from @Andrea-Campanella 