### PR TITLE
Provide progress report in console output when managing cluster resources with onit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68
 	github.com/docker/docker v1.13.1
+	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/gofrs/flock v0.7.1
@@ -14,6 +15,7 @@ require (
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029
 	github.com/openconfig/goyang v0.0.0-20190408185115-e8b0ed2cbb0c

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/evanphx/json-patch v4.0.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.2.0+incompatible h1:fUDGZCv/7iAN7u0puUVhvKCcsR6vRfwrJatElLBEf0I=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
+github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -146,6 +148,10 @@ github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czP
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a h1:TpvdAwDAt1K4ANVOfcihouRdvP+MgAfDWwBuct4l6ZY=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -290,6 +296,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f h1:25KHgbfyiSm6vwQLbM3zZIe1v9p/3ea4Rz+nnM5K/i4=

--- a/test/console/spinner.go
+++ b/test/console/spinner.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Kubernetes Authors.
+// Copyright 2019-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,9 +49,7 @@ type Spinner struct {
 	ticker *time.Ticker
 	writer io.Writer
 	mu     *sync.Mutex
-	// protected by mu
-	prefix string
-	suffix string
+	message string
 }
 
 // newSpinner initializes and returns a new Spinner that will write to
@@ -65,22 +63,15 @@ func newSpinner(w io.Writer) *Spinner {
 	}
 }
 
-// SetPrefix sets the prefix to print before the spinner
-func (s *Spinner) SetPrefix(prefix string) {
+// SetMessage sets the message to print after the spinner
+func (s *Spinner) SetMessage(message string) {
 	s.mu.Lock()
-	s.prefix = prefix
+	s.message = message
 	s.mu.Unlock()
 }
 
-// SetSuffix sets the suffix to print after the spinner
-func (s *Spinner) SetSuffix(suffix string) {
-	s.mu.Lock()
-	s.suffix = suffix
-	s.mu.Unlock()
-}
-
-// Start starts the spinner running
-func (s *Spinner) Start() {
+// Spin starts the spinner running
+func (s *Spinner) Spin() {
 	go func() {
 		for {
 			for _, frame := range s.frames {
@@ -91,7 +82,7 @@ func (s *Spinner) Start() {
 					func() {
 						s.mu.Lock()
 						defer s.mu.Unlock()
-						fmt.Fprintf(s.writer, "\r%s%s%s", s.prefix, frame, s.suffix)
+						fmt.Fprintf(s.writer, "\r%s%s", frame, s.message)
 					}()
 				}
 			}

--- a/test/console/spinner.go
+++ b/test/console/spinner.go
@@ -1,0 +1,105 @@
+// Copyright 2018 The Kubernetes Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// custom CLI loading spinner for kind
+var spinnerFrames = []string{
+	"⠈⠁",
+	"⠈⠑",
+	"⠈⠱",
+	"⠈⡱",
+	"⢀⡱",
+	"⢄⡱",
+	"⢄⡱",
+	"⢆⡱",
+	"⢎⡱",
+	"⢎⡰",
+	"⢎⡠",
+	"⢎⡀",
+	"⢎⠁",
+	"⠎⠁",
+	"⠊⠁",
+}
+
+// Spinner is a simple and efficient CLI loading spinner used by kind
+// It is simplistic and assumes that the line length will not change.
+// It is best used indirectly via log.Status (see parent package)
+type Spinner struct {
+	frames []string
+	stop   chan struct{}
+	ticker *time.Ticker
+	writer io.Writer
+	mu     *sync.Mutex
+	// protected by mu
+	prefix string
+	suffix string
+}
+
+// newSpinner initializes and returns a new Spinner that will write to
+func newSpinner(w io.Writer) *Spinner {
+	return &Spinner{
+		frames: spinnerFrames,
+		stop:   make(chan struct{}, 1),
+		ticker: time.NewTicker(time.Millisecond * 100),
+		mu:     &sync.Mutex{},
+		writer: w,
+	}
+}
+
+// SetPrefix sets the prefix to print before the spinner
+func (s *Spinner) SetPrefix(prefix string) {
+	s.mu.Lock()
+	s.prefix = prefix
+	s.mu.Unlock()
+}
+
+// SetSuffix sets the suffix to print after the spinner
+func (s *Spinner) SetSuffix(suffix string) {
+	s.mu.Lock()
+	s.suffix = suffix
+	s.mu.Unlock()
+}
+
+// Start starts the spinner running
+func (s *Spinner) Start() {
+	go func() {
+		for {
+			for _, frame := range s.frames {
+				select {
+				case <-s.stop:
+					return
+				case <-s.ticker.C:
+					func() {
+						s.mu.Lock()
+						defer s.mu.Unlock()
+						fmt.Fprintf(s.writer, "\r%s%s%s", s.prefix, frame, s.suffix)
+					}()
+				}
+			}
+		}
+	}()
+}
+
+// Stop signals the spinner to stop
+func (s *Spinner) Stop() {
+	s.stop <- struct{}{}
+}

--- a/test/console/status.go
+++ b/test/console/status.go
@@ -35,7 +35,7 @@ type ErrorStatus interface {
 	Errors() []error
 }
 
-// Status provides real-time status output during onit setup operations
+// StatusWriter provides real-time status output during onit setup operations
 type StatusWriter struct {
 	ErrorStatus
 	spinner *Spinner
@@ -47,9 +47,9 @@ type StatusWriter struct {
 // NewStatusWriter creates a new default StatusWriter
 func NewStatusWriter() *StatusWriter {
 	writer := os.Stdout
-	spin := newSpinner(writer)
+	spinner := newSpinner(writer)
 	s := &StatusWriter{
-		spinner: spin,
+		spinner: spinner,
 		writer:  writer,
 		errors:  []error{},
 	}
@@ -58,22 +58,22 @@ func NewStatusWriter() *StatusWriter {
 
 // Start starts a new status and begins a loading spinner
 func (s *StatusWriter) Start(status string) {
-	s.Succeed("")
+	s.Succeed()
 	// set new status
 	s.status = status
-	s.spinner.SetSuffix(fmt.Sprintf(" %s ", s.status))
-	s.spinner.Start()
+	s.spinner.SetMessage(fmt.Sprintf(" %s ", s.status))
+	s.spinner.Spin()
 }
 
 // Succeed completes the current status successfully
-func (s *StatusWriter) Succeed(resource string) *StatusWriter {
+func (s *StatusWriter) Succeed() *StatusWriter {
 	if s.status == "" {
 		return s
 	}
 
 	s.spinner.Stop()
 	fmt.Fprint(s.writer, "\r")
-	fmt.Fprintf(s.writer, " %s %-40s %s\n", success, s.status, resource)
+	fmt.Fprintf(s.writer, " %s %s\n", success, s.status)
 
 	s.status = ""
 	return s

--- a/test/console/status.go
+++ b/test/console/status.go
@@ -1,0 +1,105 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package console
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"io"
+	"os"
+)
+
+var (
+	success = color.GreenString("✓")
+	failure = color.RedString("✗")
+)
+
+// ErrorStatus tracks the errors that occurred for a long-running operation
+type ErrorStatus interface {
+	// Failed returns a boolean indicating whether any failures have occurred
+	Failed() bool
+
+	// Errors returns a list of errors that occurred
+	Errors() []error
+}
+
+// Status provides real-time status output during onit setup operations
+type StatusWriter struct {
+	ErrorStatus
+	spinner *Spinner
+	status  string
+	writer  io.Writer
+	errors  []error
+}
+
+// NewStatusWriter creates a new default StatusWriter
+func NewStatusWriter() *StatusWriter {
+	writer := os.Stdout
+	spin := newSpinner(writer)
+	s := &StatusWriter{
+		spinner: spin,
+		writer:  writer,
+		errors:  []error{},
+	}
+	return s
+}
+
+// Start starts a new status and begins a loading spinner
+func (s *StatusWriter) Start(status string) {
+	s.Succeed("")
+	// set new status
+	s.status = status
+	s.spinner.SetSuffix(fmt.Sprintf(" %s ", s.status))
+	s.spinner.Start()
+}
+
+// Succeed completes the current status successfully
+func (s *StatusWriter) Succeed(resource string) *StatusWriter {
+	if s.status == "" {
+		return s
+	}
+
+	s.spinner.Stop()
+	fmt.Fprint(s.writer, "\r")
+	fmt.Fprintf(s.writer, " %s %-40s %s\n", success, s.status, resource)
+
+	s.status = ""
+	return s
+}
+
+// Fail fails the current status
+func (s *StatusWriter) Fail(err error) *StatusWriter {
+	if s.status == "" {
+		return s
+	}
+
+	s.spinner.Stop()
+	fmt.Fprint(s.writer, "\r")
+	fmt.Fprintf(s.writer, " %s %-40s %s\n", failure, s.status, err)
+
+	s.status = ""
+	s.errors = append(s.errors, err)
+	return s
+}
+
+// Failed returns a boolean indicating whether errors occurred
+func (s *StatusWriter) Failed() bool {
+	return len(s.errors) > 0
+}
+
+// Errors returns a list of errors that occurred
+func (s *StatusWriter) Errors() []error {
+	return s.errors
+}

--- a/test/runner/atomix.go
+++ b/test/runner/atomix.go
@@ -21,13 +21,11 @@ import (
 	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	log "k8s.io/klog"
 	"time"
 )
 
 // setupAtomixController sets up the Atomix controller and associated resources
 func (c *ClusterController) setupAtomixController() error {
-	log.Infof("Setting up Atomix controller atomix-controller/%s", c.clusterID)
 	if err := c.createAtomixPartitionSetResource(); err != nil {
 		return err
 	}
@@ -49,8 +47,6 @@ func (c *ClusterController) setupAtomixController() error {
 	if err := c.createAtomixService(); err != nil {
 		return err
 	}
-
-	log.Infof("Waiting for Atomix controller atomix-controller/%s to become ready", c.clusterID)
 	if err := c.awaitAtomixControllerReady(); err != nil {
 		return err
 	}

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -51,17 +51,17 @@ func (c *ClusterController) Setup() console.ErrorStatus {
 	if err := c.setupAtomixController(); err != nil {
 		return c.status.Fail(err)
 	}
-	c.status.Succeed(fmt.Sprintf("atomix-controller/%s", c.clusterID))
+	c.status.Succeed()
 	c.status.Start("Starting Raft partitions")
 	if err := c.setupPartitions(); err != nil {
 		return c.status.Fail(err)
 	}
-	c.status.Succeed(fmt.Sprintf("raft/%s", c.clusterID))
+	c.status.Succeed()
 	c.status.Start("Bootstrapping onos-config cluster")
 	if err := c.setupOnosConfig(); err != nil {
 		return c.status.Fail(err)
 	}
-	return c.status.Succeed(fmt.Sprintf("onos-config/%s", c.clusterID))
+	return c.status.Succeed()
 }
 
 // AddSimulator adds a device simulator with the given configuration
@@ -74,7 +74,7 @@ func (c *ClusterController) AddSimulator(name string, config *SimulatorConfig) c
 	if err := c.addSimulatorToConfig(name); err != nil {
 		return c.status.Fail(err)
 	}
-	return c.status.Succeed(fmt.Sprintf("%s/%s", name, c.clusterID))
+	return c.status.Succeed()
 }
 
 // RunTests runs the given tests on Kubernetes
@@ -90,7 +90,7 @@ func (c *ClusterController) RunTests(testID string, tests []string, timeout time
 	if err != nil {
 		return "", 0, c.status.Fail(err)
 	}
-	c.status.Succeed(fmt.Sprintf("%s/%s", testID, c.clusterID))
+	c.status.Succeed()
 
 	// Get the stream of logs for the pod
 	reader, err := c.streamLogs(pod)
@@ -190,7 +190,7 @@ func (c *ClusterController) DownloadLogs(resourceID string, path string) console
 	if err := c.downloadLogs(*pod, path); err != nil {
 		return c.status.Fail(err)
 	}
-	return c.status.Succeed(resourceID)
+	return c.status.Succeed()
 }
 
 // downloadLogs downloads the logs from the given pod to the given path
@@ -266,5 +266,5 @@ func (c *ClusterController) RemoveSimulator(name string) console.ErrorStatus {
 	if err := c.removeSimulatorFromConfig(name); err != nil {
 		return c.status.Fail(err)
 	}
-	return c.status.Succeed("")
+	return c.status.Succeed()
 }

--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -136,7 +136,7 @@ func (c *OnitController) NewCluster(clusterID string, config *ClusterConfig) (*C
 		extensionsclient: c.extensionsclient,
 		config:           config,
 		status:           c.status,
-	}, c.status.Succeed(clusterID)
+	}, c.status.Succeed()
 }
 
 // GetCluster returns a cluster controller
@@ -176,5 +176,5 @@ func (c *OnitController) DeleteCluster(clusterID string) console.ErrorStatus {
 	if err := c.kubeclient.CoreV1().Namespaces().Delete(clusterID, &metav1.DeleteOptions{}); err != nil {
 		return c.status.Fail(err)
 	}
-	return c.status.Succeed("")
+	return c.status.Succeed()
 }

--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -16,6 +16,7 @@ package runner
 
 import (
 	atomixk8s "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
+	"github.com/onosproject/onos-config/test/console"
 	"gopkg.in/yaml.v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -51,6 +52,7 @@ func NewController() (*OnitController, error) {
 		kubeclient:       kubeclient,
 		atomixclient:     atomixclient,
 		extensionsclient: extensionsclient,
+		status:           console.NewStatusWriter(),
 	}, nil
 }
 
@@ -60,6 +62,7 @@ type OnitController struct {
 	kubeclient       *kubernetes.Clientset
 	atomixclient     *atomixk8s.Clientset
 	extensionsclient *apiextension.Clientset
+	status           *console.StatusWriter
 }
 
 // GetClusters returns a list of onit clusters
@@ -91,7 +94,8 @@ func (c *OnitController) GetClusters() (map[string]*ClusterConfig, error) {
 }
 
 // NewCluster creates a new cluster controller
-func (c *OnitController) NewCluster(clusterID string, config *ClusterConfig) (*ClusterController, error) {
+func (c *OnitController) NewCluster(clusterID string, config *ClusterConfig) (*ClusterController, console.ErrorStatus) {
+	c.status.Start("Creating cluster namespace")
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: clusterID,
@@ -102,12 +106,12 @@ func (c *OnitController) NewCluster(clusterID string, config *ClusterConfig) (*C
 	}
 	_, err := c.kubeclient.CoreV1().Namespaces().Create(ns)
 	if err != nil {
-		return nil, err
+		return nil, c.status.Fail(err)
 	}
 
 	configString, err := yaml.Marshal(config)
 	if err != nil {
-		return nil, err
+		return nil, c.status.Fail(err)
 	}
 
 	cm := &corev1.ConfigMap{
@@ -121,7 +125,7 @@ func (c *OnitController) NewCluster(clusterID string, config *ClusterConfig) (*C
 	}
 	_, err = c.kubeclient.CoreV1().ConfigMaps(clusterID).Create(cm)
 	if err != nil {
-		return nil, err
+		return nil, c.status.Fail(err)
 	}
 
 	return &ClusterController{
@@ -131,7 +135,8 @@ func (c *OnitController) NewCluster(clusterID string, config *ClusterConfig) (*C
 		atomixclient:     c.atomixclient,
 		extensionsclient: c.extensionsclient,
 		config:           config,
-	}, nil
+		status:           c.status,
+	}, c.status.Succeed(clusterID)
 }
 
 // GetCluster returns a cluster controller
@@ -158,16 +163,18 @@ func (c *OnitController) GetCluster(clusterID string) (*ClusterController, error
 		atomixclient:     c.atomixclient,
 		extensionsclient: c.extensionsclient,
 		config:           config,
+		status:           c.status,
 	}, nil
 }
 
 // DeleteCluster deletes a cluster controller
-func (c *OnitController) DeleteCluster(clusterID string) error {
+func (c *OnitController) DeleteCluster(clusterID string) console.ErrorStatus {
+	c.status.Start("Deleting cluster namespace")
 	if err := c.kubeclient.RbacV1().ClusterRoleBindings().Delete("atomix-controller", &metav1.DeleteOptions{}); err != nil {
-		return err
+		return c.status.Fail(err)
 	}
 	if err := c.kubeclient.CoreV1().Namespaces().Delete(clusterID, &metav1.DeleteOptions{}); err != nil {
-		return err
+		return c.status.Fail(err)
 	}
-	return nil
+	return c.status.Succeed("")
 }

--- a/test/runner/partitions.go
+++ b/test/runner/partitions.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	log "k8s.io/klog"
 	"strconv"
 	"time"
 )
@@ -94,12 +93,9 @@ func (c *ClusterController) GetPartitionNodes(partition int) ([]NodeInfo, error)
 
 // setupPartitions creates a Raft partition set
 func (c *ClusterController) setupPartitions() error {
-	log.Infof("Setting up partitions raft/%s", c.clusterID)
 	if err := c.createPartitionSet(); err != nil {
 		return err
 	}
-
-	log.Infof("Waiting for partitions raft/%s to become ready", c.clusterID)
 	if err := c.awaitPartitionsReady(); err != nil {
 		return err
 	}

--- a/test/runner/simulator.go
+++ b/test/runner/simulator.go
@@ -49,6 +49,9 @@ func (c *ClusterController) setupSimulator(name string, config *SimulatorConfig)
 	if err := c.createSimulatorService(name); err != nil {
 		return err
 	}
+	if err := c.awaitSimulatorReady(name); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR is, uhh, totally unnecessary but... it improves the output of `onit` commands that manage the cluster, e.g. printing each step as well as a success/fail message while setting up the cluster.