### PR TITLE
Ensure onit completion works in zsh and add completion for various arguments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-playground/overalls v0.0.0-20180201144345-22ec1a223b7c // indirect
-	github.com/gofrs/flock v0.7.1
+	github.com/gofrs/flock v0.7.1 // indirect
 	github.com/golang/protobuf v1.3.1
 	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.0 // indirect

--- a/test/cli/cli.go
+++ b/test/cli/cli.go
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runner
+package cli
 
 import (
-	"errors"
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/onosproject/onos-config/test/console"
+	"github.com/onosproject/onos-config/test/runner"
 	"github.com/spf13/cobra"
 	"io"
 	"os"
@@ -30,16 +30,17 @@ import (
 )
 
 // GetCommand returns a Cobra command for tests in the given test registry
-func GetCommand(registry *TestRegistry) *cobra.Command {
+func GetCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "onit {create,add,remove,delete,get,set,run} [args]",
-		Short: "Run onos-config integration tests on Kubernetes",
+		Use:                    "onit {create,add,remove,delete,get,set,run} [args]",
+		Short:                  "Run onos-config integration tests on Kubernetes",
+		BashCompletionFunction: bashCompletion,
 	}
 	cmd.AddCommand(getCreateCommand())
 	cmd.AddCommand(getAddCommand())
 	cmd.AddCommand(getRemoveCommand())
 	cmd.AddCommand(getDeleteCommand())
-	cmd.AddCommand(getRunCommand())
+	cmd.AddCommand(getRunCommand(registry))
 	cmd.AddCommand(getGetCommand(registry))
 	cmd.AddCommand(getSetCommand())
 	cmd.AddCommand(getDebugCommand())
@@ -47,39 +48,6 @@ func GetCommand(registry *TestRegistry) *cobra.Command {
 	cmd.AddCommand(getTestCommand(registry))
 	cmd.AddCommand(getCompletionCommand())
 	return cmd
-}
-
-func getCompletionCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:       "completion <shell>",
-		Short:     "Generated bash or zsh auto-completion script",
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{"bash", "zsh"},
-		Run:       runCompletionCommand,
-	}
-}
-
-func runCompletionCommand(cmd *cobra.Command, args []string) {
-	if args[0] == "bash" {
-		if err := runCompletionBash(os.Stdout, cmd.Parent()); err != nil {
-			ExitWithError(ExitError, err)
-		}
-	} else if args[0] == "zsh" {
-		if err := runCompletionZsh(os.Stdout, cmd.Parent()); err != nil {
-			ExitWithError(ExitError, err)
-		}
-
-	} else {
-		ExitWithError(ExitError, errors.New("unsupported shell type "+args[0]))
-	}
-}
-
-func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
-	return cmd.GenBashCompletion(out)
-}
-
-func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
-	return cmd.GenZshCompletion(out)
 }
 
 // getCreateCommand returns a cobra "setup" command for setting up resources
@@ -105,7 +73,7 @@ func getCreateClusterCommand() *cobra.Command {
 			configName, _ := cmd.Flags().GetString("config")
 
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -119,7 +87,7 @@ func getCreateClusterCommand() *cobra.Command {
 			}
 
 			// Create the cluster configuration
-			config := &ClusterConfig{
+			config := &runner.ClusterConfig{
 				Preset:        configName,
 				Nodes:         nodes,
 				Partitions:    partitions,
@@ -179,7 +147,7 @@ func getAddSimulatorCommand() *cobra.Command {
 			configName, _ := cmd.Flags().GetString("preset")
 
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -197,7 +165,7 @@ func getAddSimulatorCommand() *cobra.Command {
 			}
 
 			// Create the simulator configuration
-			config := &SimulatorConfig{
+			config := &runner.SimulatorConfig{
 				Config: configName,
 			}
 
@@ -211,6 +179,9 @@ func getAddSimulatorCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to which to add the simulator")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	cmd.Flags().StringP("preset", "p", "default", "simulator preset to apply")
 	return cmd
 }
@@ -228,12 +199,13 @@ func getDeleteCommand() *cobra.Command {
 // getDeleteClusterCommand returns a cobra "teardown" command for tearing down a test cluster
 func getDeleteClusterCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cluster [id]",
-		Short: "Delete a test cluster on Kubernetes",
-		Args:  cobra.MaximumNArgs(1),
+		Use:       "cluster [id]",
+		Short:     "Delete a test cluster on Kubernetes",
+		Args:      cobra.MaximumNArgs(1),
+		ValidArgs: getClusterIDs(),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -268,14 +240,15 @@ func getRemoveCommand() *cobra.Command {
 // getRemoveSimulatorCommand returns a cobra command for tearing down a device simulator
 func getRemoveSimulatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "simulator <name>",
-		Short: "Remove a device simulator from the cluster",
-		Args:  cobra.ExactArgs(1),
+		Use:       "simulator <name>",
+		Short:     "Remove a device simulator from the cluster",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: getSimulatorIDs(),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -300,11 +273,14 @@ func getRemoveSimulatorCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to which to add the simulator")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
 // getGetCommand returns a cobra "get" command to read test configurations
-func getGetCommand(registry *TestRegistry) *cobra.Command {
+func getGetCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get {cluster,clusters,simulators,device-presets,store-presets,tests}",
 		Short: "Get test configurations",
@@ -341,7 +317,7 @@ func getGetSimulatorsCommand() *cobra.Command {
 		Short: "Get the currently configured cluster's simulators",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -371,17 +347,20 @@ func getGetSimulatorsCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to query")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
 // getGetClustersCommand returns a cobra command to get a list of available test clusters
 func getGetClustersCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "clusters",
 		Short: "Get a list of all deployed clusters",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -391,16 +370,21 @@ func getGetClustersCommand() *cobra.Command {
 			if err != nil {
 				exitError(err)
 			} else {
-				printClusters(clusters)
+				noHeaders, _ := cmd.Flags().GetBool("no-headers")
+				printClusters(clusters, !noHeaders)
 			}
 		},
 	}
+	cmd.Flags().Bool("no-headers", false, "whether to print column headers")
+	return cmd
 }
 
-func printClusters(clusters map[string]*ClusterConfig) {
+func printClusters(clusters map[string]*runner.ClusterConfig, includeHeaders bool) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
-	fmt.Fprintln(writer, "ID\tSIZE\tPARTITIONS")
+	if includeHeaders {
+		fmt.Fprintln(writer, "ID\tSIZE\tPARTITIONS")
+	}
 	for id, config := range clusters {
 		fmt.Fprintln(writer, fmt.Sprintf("%s\t%d\t%d", id, config.Nodes, config.Partitions))
 	}
@@ -440,7 +424,7 @@ func getGetPartitionsCommand() *cobra.Command {
 		Short: "Get a list of partitions in the cluster",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -467,10 +451,13 @@ func getGetPartitionsCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to query")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
-func printPartitions(partitions []PartitionInfo) {
+func printPartitions(partitions []runner.PartitionInfo) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
 	fmt.Fprintln(writer, "ID\tGROUP\tNODES")
@@ -488,7 +475,7 @@ func getGetPartitionCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -521,17 +508,21 @@ func getGetPartitionCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to query")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
 // getGetNodesCommand returns a cobra command to get a list of onos-config nodes in the cluster
 func getGetNodesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "nodes",
-		Short: "Get a list of nodes in the cluster",
+		Use:       "nodes",
+		Short:     "Get a list of nodes in the cluster",
+		ValidArgs: getNodeIDs(),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -558,10 +549,13 @@ func getGetNodesCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to query")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
-func printNodes(nodes []NodeInfo) {
+func printNodes(nodes []runner.NodeInfo) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
 	fmt.Fprintln(writer, "ID\tSTATUS")
@@ -572,7 +566,7 @@ func printNodes(nodes []NodeInfo) {
 }
 
 // getGetTestsCommand returns a cobra command to get a list of available tests
-func getGetTestsCommand(registry *TestRegistry) *cobra.Command {
+func getGetTestsCommand(registry *runner.TestRegistry) *cobra.Command {
 	return &cobra.Command{
 		Use:   "tests",
 		Short: "Get a list of integration tests",
@@ -591,7 +585,7 @@ func getGetHistoryCommand() *cobra.Command {
 		Short: "Get the history of test runs",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -619,11 +613,14 @@ func getGetHistoryCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to load the history")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
 // printHistory prints a test history in table format
-func printHistory(records []TestRecord) {
+func printHistory(records []runner.TestRecord) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
 	fmt.Fprintln(writer, "ID\tTESTS\tSTATUS\tEXIT CODE\tMESSAGE")
@@ -647,12 +644,13 @@ func getGetLogsCommand() *cobra.Command {
 		Long: `Outputs the complete logs for any test resource.
 To output the logs from an onos-config node, get the node ID via 'onit get nodes'
 To output the logs from a test, get the test ID from the test run or from 'onit get history'`,
-		Args: cobra.ExactArgs(1),
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: getNodeIDs(),
 		Run: func(cmd *cobra.Command, args []string) {
 			stream, _ := cmd.Flags().GetBool("stream")
 
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -702,6 +700,9 @@ To output the logs from a test, get the test ID from the test run or from 'onit 
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to load the history")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	cmd.Flags().BoolP("stream", "s", false, "stream logs to stdout")
 	return cmd
 }
@@ -735,12 +736,13 @@ func getFetchCommand() *cobra.Command {
 // getFetchLogsCommand returns a cobra command for downloading the logs from a node
 func getFetchLogsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "logs [node]",
-		Short: "Download logs from a node",
-		Args:  cobra.MaximumNArgs(1),
+		Use:       "logs [node]",
+		Short:     "Download logs from a node",
+		Args:      cobra.MaximumNArgs(1),
+		ValidArgs: getNodeIDs(),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -794,6 +796,9 @@ func getFetchLogsCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to load the history")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	cmd.Flags().StringP("destination", "d", ".", "the destination to which to write the logs")
 	return cmd
 }
@@ -801,12 +806,13 @@ func getFetchLogsCommand() *cobra.Command {
 // getDebugCommand returns a cobra "debug" command to open a debugger port to the given resource
 func getDebugCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "debug <resource>",
-		Short: "Open a debugger port to the given resource",
-		Args:  cobra.ExactArgs(1),
+		Use:       "debug <resource>",
+		Short:     "Open a debugger port to the given resource",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: getNodeIDs(),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -832,6 +838,9 @@ func getDebugCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to load the history")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	cmd.Flags().IntP("port", "p", 40000, "the local port to forward to the given resource")
 	return cmd
 }
@@ -849,14 +858,15 @@ func getSetCommand() *cobra.Command {
 // getSetClusterCommand returns a cobra command for setting the cluster context
 func getSetClusterCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "cluster <name>",
-		Args:  cobra.ExactArgs(1),
-		Short: "Set cluster context",
+		Use:       "cluster <name>",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: getClusterIDs(),
+		Short:     "Set cluster context",
 		Run: func(cmd *cobra.Command, args []string) {
 			clusterID := args[0]
 
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -878,15 +888,16 @@ func getSetClusterCommand() *cobra.Command {
 }
 
 // getRunCommand returns a cobra "run" command
-func getRunCommand() *cobra.Command {
+func getRunCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run [tests]",
-		Short: "Run integration tests on Kubernetes",
+		Use:       "run [tests]",
+		Short:     "Run integration tests on Kubernetes",
+		ValidArgs: registry.GetNames(),
 		Run: func(cmd *cobra.Command, args []string) {
 			testID := fmt.Sprintf("test-%d", newUUIDInt())
 
 			// Get the onit controller
-			controller, err := NewController()
+			controller, err := runner.NewController()
 			if err != nil {
 				exitError(err)
 			}
@@ -915,17 +926,20 @@ func getRunCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster on which to run the test")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	cmd.Flags().IntP("timeout", "t", 60*10, "test timeout in seconds")
 	return cmd
 }
 
 // getTestCommand returns a cobra "test" command for tests in the given registry
-func getTestCommand(registry *TestRegistry) *cobra.Command {
+func getTestCommand(registry *runner.TestRegistry) *cobra.Command {
 	return &cobra.Command{
 		Use:   "test [tests]",
 		Short: "Run integration tests",
 		Run: func(cmd *cobra.Command, args []string) {
-			runner := &TestRunner{
+			runner := &runner.TestRunner{
 				Registry: registry,
 			}
 			err := runner.RunTests(args)

--- a/test/cli/cli.go
+++ b/test/cli/cli.go
@@ -32,7 +32,7 @@ import (
 // GetCommand returns a Cobra command for tests in the given test registry
 func GetCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                    "onit {create,add,remove,delete,get,set,run} [args]",
+		Use:                    "onit",
 		Short:                  "Run onos-config integration tests on Kubernetes",
 		BashCompletionFunction: bashCompletion,
 	}
@@ -199,10 +199,9 @@ func getDeleteCommand() *cobra.Command {
 // getDeleteClusterCommand returns a cobra "teardown" command for tearing down a test cluster
 func getDeleteClusterCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       "cluster [id]",
-		Short:     "Delete a test cluster on Kubernetes",
-		Args:      cobra.MaximumNArgs(1),
-		ValidArgs: getClusterIDs(),
+		Use:   "cluster [id]",
+		Short: "Delete a test cluster on Kubernetes",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Create the onit controller
 			controller, err := runner.NewController()
@@ -240,10 +239,9 @@ func getRemoveCommand() *cobra.Command {
 // getRemoveSimulatorCommand returns a cobra command for tearing down a device simulator
 func getRemoveSimulatorCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       "simulator <name>",
-		Short:     "Remove a device simulator from the cluster",
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: getSimulatorIDs(),
+		Use:   "simulator <name>",
+		Short: "Remove a device simulator from the cluster",
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			name := args[0]
 
@@ -503,7 +501,7 @@ func getGetPartitionCommand() *cobra.Command {
 			if err != nil {
 				exitError(err)
 			} else {
-				printNodes(nodes)
+				printNodes(nodes, true)
 			}
 		},
 	}
@@ -517,9 +515,8 @@ func getGetPartitionCommand() *cobra.Command {
 // getGetNodesCommand returns a cobra command to get a list of onos-config nodes in the cluster
 func getGetNodesCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       "nodes",
-		Short:     "Get a list of nodes in the cluster",
-		ValidArgs: getNodeIDs(),
+		Use:   "nodes",
+		Short: "Get a list of nodes in the cluster",
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
 			controller, err := runner.NewController()
@@ -544,7 +541,8 @@ func getGetNodesCommand() *cobra.Command {
 			if err != nil {
 				exitError(err)
 			} else {
-				printNodes(nodes)
+				noHeaders, _ := cmd.Flags().GetBool("no-headers")
+				printNodes(nodes, !noHeaders)
 			}
 		},
 	}
@@ -552,13 +550,16 @@ func getGetNodesCommand() *cobra.Command {
 	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
 		cobra.BashCompCustom: {"__onit_get_clusters"},
 	}
+	cmd.Flags().Bool("no-headers", false, "whether to print column headers")
 	return cmd
 }
 
-func printNodes(nodes []runner.NodeInfo) {
+func printNodes(nodes []runner.NodeInfo, includeHeaders bool) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
-	fmt.Fprintln(writer, "ID\tSTATUS")
+	if includeHeaders {
+		fmt.Fprintln(writer, "ID\tSTATUS")
+	}
 	for _, node := range nodes {
 		fmt.Fprintln(writer, fmt.Sprintf("%s\t%s", node.ID, node.Status))
 	}
@@ -644,8 +645,7 @@ func getGetLogsCommand() *cobra.Command {
 		Long: `Outputs the complete logs for any test resource.
 To output the logs from an onos-config node, get the node ID via 'onit get nodes'
 To output the logs from a test, get the test ID from the test run or from 'onit get history'`,
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: getNodeIDs(),
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			stream, _ := cmd.Flags().GetBool("stream")
 
@@ -736,10 +736,9 @@ func getFetchCommand() *cobra.Command {
 // getFetchLogsCommand returns a cobra command for downloading the logs from a node
 func getFetchLogsCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       "logs [node]",
-		Short:     "Download logs from a node",
-		Args:      cobra.MaximumNArgs(1),
-		ValidArgs: getNodeIDs(),
+		Use:   "logs [node]",
+		Short: "Download logs from a node",
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
 			controller, err := runner.NewController()
@@ -806,10 +805,9 @@ func getFetchLogsCommand() *cobra.Command {
 // getDebugCommand returns a cobra "debug" command to open a debugger port to the given resource
 func getDebugCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:       "debug <resource>",
-		Short:     "Open a debugger port to the given resource",
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: getNodeIDs(),
+		Use:   "debug <resource>",
+		Short: "Open a debugger port to the given resource",
+		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			// Get the onit controller
 			controller, err := runner.NewController()
@@ -858,10 +856,9 @@ func getSetCommand() *cobra.Command {
 // getSetClusterCommand returns a cobra command for setting the cluster context
 func getSetClusterCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:       "cluster <name>",
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: getClusterIDs(),
-		Short:     "Set cluster context",
+		Use:   "cluster <name>",
+		Args:  cobra.ExactArgs(1),
+		Short: "Set cluster context",
 		Run: func(cmd *cobra.Command, args []string) {
 			clusterID := args[0]
 

--- a/test/cli/completion.go
+++ b/test/cli/completion.go
@@ -63,11 +63,11 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 }
 
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
-	zsh_head := "#compdef onit\n"
+	header := "#compdef onit\n"
 
-	out.Write([]byte(zsh_head))
+	out.Write([]byte(header))
 
-	zsh_initialization := `
+	init := `
 __onit_bash_source() {
 	alias shopt=':'
 	alias _expand=_bash_expand
@@ -192,19 +192,19 @@ __onit_convert_bash_to_zsh() {
 	-e "s/\\\$(type${RWORD}/\$(__onit_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `
-	out.Write([]byte(zsh_initialization))
+	out.Write([]byte(init))
 
 	buf := new(bytes.Buffer)
 	cmd.GenBashCompletion(buf)
 	out.Write(buf.Bytes())
 
-	zsh_tail := `
+	tail := `
 BASH_COMPLETION_EOF
 }
 __onit_bash_source <(__onit_convert_bash_to_zsh)
 _complete onit 2>/dev/null
 `
-	out.Write([]byte(zsh_tail))
+	out.Write([]byte(tail))
 	return nil
 }
 
@@ -216,7 +216,7 @@ func getClusterIDs() []string {
 
 	clusters, err := controller.GetClusters()
 	clusterIDs := make([]string, 0, len(clusters))
-	for name, _ := range clusters {
+	for name := range clusters {
 		clusterIDs = append(clusterIDs, name)
 	}
 	return clusterIDs

--- a/test/cli/completion.go
+++ b/test/cli/completion.go
@@ -46,15 +46,21 @@ __onit_get_nodes() {
 __onit_custom_func() {
     case ${last_command} in
         onit_set_cluster | onit_delete_cluster)
-            __onit_get_clusters
+            if [[ ${#nouns[@]} -eq 0 ]]; then
+                __onit_get_clusters
+            fi
             return
             ;;
         onit_delete_simulator)
-            __onit_get_simulators
+            if [[ ${#nouns[@]} -eq 0 ]]; then
+                __onit_get_simulators
+            fi
             return
             ;;
         onit_get_logs | onit_fetch_logs | onit_debug)
-            __onit_get_nodes
+            if [[ ${#nouns[@]} -eq 0 ]]; then
+                __onit_get_nodes
+            fi
             return
             ;;
         *)

--- a/test/cli/completion.go
+++ b/test/cli/completion.go
@@ -1,0 +1,259 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"github.com/onosproject/onos-config/test/runner"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+)
+
+const bashCompletion = `
+__onit_get_clusters() {
+    local onit_output out
+    if onit_output=$(onit get clusters --no-headers 2>/dev/null); then
+        out=($(echo "${onit_output}" | awk '{print $1}'))
+        COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
+    fi
+}
+`
+
+func getCompletionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:       "completion <shell>",
+		Short:     "Generated bash or zsh auto-completion script",
+		Args:      cobra.ExactArgs(1),
+		ValidArgs: []string{"bash", "zsh"},
+		Run:       runCompletionCommand,
+	}
+}
+
+func runCompletionCommand(cmd *cobra.Command, args []string) {
+	if args[0] == "bash" {
+		if err := runCompletionBash(os.Stdout, cmd.Parent()); err != nil {
+			exitError(err)
+		}
+	} else if args[0] == "zsh" {
+		if err := runCompletionZsh(os.Stdout, cmd.Parent()); err != nil {
+			exitError(err)
+		}
+
+	} else {
+		exitError(errors.New("unsupported shell type "+args[0]))
+	}
+}
+
+func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
+	return cmd.GenBashCompletion(out)
+}
+
+func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
+	zsh_head := "#compdef onit\n"
+
+	out.Write([]byte(zsh_head))
+
+	zsh_initialization := `
+__onit_bash_source() {
+	alias shopt=':'
+	alias _expand=_bash_expand
+	alias _complete=_bash_comp
+	emulate -L sh
+	setopt kshglob noshglob braceexpand
+	source "$@"
+}
+__onit_type() {
+	# -t is not supported by zsh
+	if [ "$1" == "-t" ]; then
+		shift
+		# fake Bash 4 to disable "complete -o nospace". Instead
+		# "compopt +-o nospace" is used in the code to toggle trailing
+		# spaces. We don't support that, but leave trailing spaces on
+		# all the time
+		if [ "$1" = "__onit_compopt" ]; then
+			echo builtin
+			return 0
+		fi
+	fi
+	type "$@"
+}
+__onit_compgen() {
+	local completions w
+	completions=( $(compgen "$@") ) || return $?
+	# filter by given word as prefix
+	while [[ "$1" = -* && "$1" != -- ]]; do
+		shift
+		shift
+	done
+	if [[ "$1" == -- ]]; then
+		shift
+	fi
+	for w in "${completions[@]}"; do
+		if [[ "${w}" = "$1"* ]]; then
+			echo "${w}"
+		fi
+	done
+}
+__onit_compopt() {
+	true # don't do anything. Not supported by bashcompinit in zsh
+}
+__onit_ltrim_colon_completions()
+{
+	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+		# Remove colon-word prefix from COMPREPLY items
+		local colon_word=${1%${1##*:}}
+		local i=${#COMPREPLY[*]}
+		while [[ $((--i)) -ge 0 ]]; do
+			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+		done
+	fi
+}
+__onit_get_comp_words_by_ref() {
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
+	words=("${COMP_WORDS[@]}")
+	cword=("${COMP_CWORD[@]}")
+}
+__onit_filedir() {
+	local RET OLD_IFS w qw
+	__debug "_filedir $@ cur=$cur"
+	if [[ "$1" = \~* ]]; then
+		# somehow does not work. Maybe, zsh does not call this at all
+		eval echo "$1"
+		return 0
+	fi
+	OLD_IFS="$IFS"
+	IFS=$'\n'
+	if [ "$1" = "-d" ]; then
+		shift
+		RET=( $(compgen -d) )
+	else
+		RET=( $(compgen -f) )
+	fi
+	IFS="$OLD_IFS"
+	IFS="," __debug "RET=${RET[@]} len=${#RET[@]}"
+	for w in ${RET[@]}; do
+		if [[ ! "${w}" = "${cur}"* ]]; then
+			continue
+		fi
+		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+			qw="$(__onit_quote "${w}")"
+			if [ -d "${w}" ]; then
+				COMPREPLY+=("${qw}/")
+			else
+				COMPREPLY+=("${qw}")
+			fi
+		fi
+	done
+}
+__onit_quote() {
+    if [[ $1 == \'* || $1 == \"* ]]; then
+        # Leave out first character
+        printf %q "${1:1}"
+    else
+    	printf %q "$1"
+    fi
+}
+autoload -U +X bashcompinit && bashcompinit
+# use word boundary patterns for BSD or GNU sed
+LWORD='[[:<:]]'
+RWORD='[[:>:]]'
+if sed --help 2>&1 | grep -q GNU; then
+	LWORD='\<'
+	RWORD='\>'
+fi
+__onit_convert_bash_to_zsh() {
+	sed \
+	-e 's/declare -F/whence -w/' \
+	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
+	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
+	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
+	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
+	-e "s/${LWORD}_filedir${RWORD}/__onit_filedir/g" \
+	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__onit_get_comp_words_by_ref/g" \
+	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__onit_ltrim_colon_completions/g" \
+	-e "s/${LWORD}compgen${RWORD}/__onit_compgen/g" \
+	-e "s/${LWORD}compopt${RWORD}/__onit_compopt/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
+	-e "s/\\\$(type${RWORD}/\$(__onit_type/g" \
+	<<'BASH_COMPLETION_EOF'
+`
+	out.Write([]byte(zsh_initialization))
+
+	buf := new(bytes.Buffer)
+	cmd.GenBashCompletion(buf)
+	out.Write(buf.Bytes())
+
+	zsh_tail := `
+BASH_COMPLETION_EOF
+}
+__onit_bash_source <(__onit_convert_bash_to_zsh)
+_complete onit 2>/dev/null
+`
+	out.Write([]byte(zsh_tail))
+	return nil
+}
+
+func getClusterIDs() []string {
+	controller, err := runner.NewController()
+	if err != nil {
+		return []string{}
+	}
+
+	clusters, err := controller.GetClusters()
+	clusterIDs := make([]string, 0, len(clusters))
+	for name, _ := range clusters {
+		clusterIDs = append(clusterIDs, name)
+	}
+	return clusterIDs
+}
+
+func getSimulatorIDs() []string {
+	controller, err := runner.NewController()
+	if err != nil {
+		return []string{}
+	}
+	cluster, err := controller.GetCluster(getDefaultCluster())
+	if err != nil {
+		return []string{}
+	}
+	simulatorIDs, err := cluster.GetSimulators()
+	if err != nil {
+		return []string{}
+	}
+	return simulatorIDs
+}
+
+func getNodeIDs() []string {
+	controller, err := runner.NewController()
+	if err != nil {
+		return []string{}
+	}
+	cluster, err := controller.GetCluster(getDefaultCluster())
+	if err != nil {
+		return []string{}
+	}
+	nodes, err := cluster.GetNodes()
+	if err != nil {
+		return []string{}
+	}
+	nodeIDs := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		nodeIDs = append(nodeIDs, node.ID)
+	}
+	return nodeIDs
+}

--- a/test/cli/config.go
+++ b/test/cli/config.go
@@ -1,0 +1,117 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	_, path, _, _     = runtime.Caller(0)
+	deviceConfigsPath = filepath.Join(filepath.Join(filepath.Dir(filepath.Dir(path)), "configs"), "device")
+	storeConfigsPath  = filepath.Join(filepath.Join(filepath.Dir(filepath.Dir(path)), "configs"), "store")
+)
+
+// getSimulatorPresets returns a list of store configurations from the configs/store directory
+func getSimulatorPresets() []string {
+	configs := []string{}
+	filepath.Walk(deviceConfigsPath, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(info.Name())
+		if ext == ".json" {
+			configs = append(configs, info.Name()[:len(info.Name())-len(ext)])
+		}
+		return nil
+	})
+	return configs
+}
+
+// getStorePresets returns a list of store configurations from the configs/store directory
+func getStorePresets() []string {
+	configs := []string{}
+	filepath.Walk(storeConfigsPath, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		ext := filepath.Ext(info.Name())
+		if ext == ".json" {
+			configs = append(configs, info.Name()[:len(info.Name())-len(ext)])
+		}
+		return nil
+	})
+	return configs
+}
+
+// setDefaultCluster sets the default cluster
+func setDefaultCluster(clusterID string) error {
+	if err := initConfig(); err != nil {
+		return err
+	}
+	viper.Set("cluster", clusterID)
+	return viper.WriteConfig()
+}
+
+// getDefaultCluster returns the default cluster
+func getDefaultCluster() string {
+	return viper.GetString("cluster")
+}
+
+func initConfig() error {
+	// If the configuration file is not found, initialize a configuration in the home dir.
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(*viper.ConfigFileNotFoundError); !ok {
+			home, err := homedir.Dir()
+			if err != nil {
+				return err
+			}
+
+			err = os.MkdirAll(home+"/.onos", 0777)
+			if err != nil {
+				return err
+			}
+
+			f, err := os.Create(home + "/.onos/onit.yaml")
+			if err != nil {
+				return err
+			}
+			f.Close()
+		} else {
+			return err
+		}
+	}
+	return nil
+}
+
+func init() {
+	home, err := homedir.Dir()
+	if err != nil {
+		exitError(err)
+	}
+
+	viper.SetConfigName("onit")
+	viper.AddConfigPath(home + "/.onos")
+	viper.AddConfigPath("/etc/onos")
+	viper.AddConfigPath(".")
+
+	viper.ReadInConfig()
+}

--- a/test/cmd/onit/main.go
+++ b/test/cmd/onit/main.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-config/test/cli"
 	"github.com/onosproject/onos-config/test/integration"
-	"github.com/onosproject/onos-config/test/runner"
 	"os"
 )
 
 func main() {
-	cmd := runner.GetCommand(integration.Registry)
+	cmd := cli.GetCommand(integration.Registry)
 	if err := cmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -100,8 +100,16 @@ func (c *ClusterController) RunTests(testID string, tests []string, timeout time
 	defer reader.Close()
 
 	// Stream the logs to stdout
-	if err = printStream(reader); err != nil {
-		return "", 0, c.status
+	buf := make([]byte, 1024)
+	for {
+		n, err := reader.Read(buf)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", 0, c.status
+		}
+		fmt.Print(string(buf[:n]))
 	}
 
 	// Get the exit message and code

--- a/test/runner/config.go
+++ b/test/runner/config.go
@@ -1,24 +1,7 @@
-// Copyright 2019-present Open Networking Foundation.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package runner
 
 import (
 	"encoding/json"
-	"github.com/gofrs/flock"
-	"github.com/mitchellh/go-homedir"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,58 +14,6 @@ var (
 	deviceConfigsPath = filepath.Join(filepath.Join(filepath.Dir(filepath.Dir(path)), "configs"), "device")
 	storeConfigsPath  = filepath.Join(filepath.Join(filepath.Dir(filepath.Dir(path)), "configs"), "store")
 )
-
-var (
-	configLock *flock.Flock
-)
-
-// getSimulatorPresets returns a list of store configurations from the configs/store directory
-func getSimulatorPresets() []string {
-	configs := []string{}
-	filepath.Walk(deviceConfigsPath, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			return nil
-		}
-
-		ext := filepath.Ext(info.Name())
-		if ext == ".json" {
-			configs = append(configs, info.Name()[:len(info.Name())-len(ext)])
-		}
-		return nil
-	})
-	return configs
-}
-
-// getStorePresets returns a list of store configurations from the configs/store directory
-func getStorePresets() []string {
-	configs := []string{}
-	filepath.Walk(storeConfigsPath, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			return nil
-		}
-
-		ext := filepath.Ext(info.Name())
-		if ext == ".json" {
-			configs = append(configs, info.Name()[:len(info.Name())-len(ext)])
-		}
-		return nil
-	})
-	return configs
-}
-
-// setDefaultCluster sets the default cluster
-func setDefaultCluster(clusterID string) error {
-	if err := initConfig(); err != nil {
-		return err
-	}
-	viper.Set("cluster", clusterID)
-	return viper.WriteConfig()
-}
-
-// getDefaultCluster returns the default cluster
-func getDefaultCluster() string {
-	return viper.GetString("cluster")
-}
 
 // ClusterConfig provides the configuration for the Kubernetes test cluster
 type ClusterConfig struct {
@@ -134,44 +65,4 @@ func (c *SimulatorConfig) load() (map[string]interface{}, error) {
 	var jsonObj map[string]interface{}
 	err = json.Unmarshal(jsonBytes, &jsonObj)
 	return jsonObj, err
-}
-
-func initConfig() error {
-	// If the configuration file is not found, initialize a configuration in the home dir.
-	if err := viper.ReadInConfig(); err != nil {
-		if _, ok := err.(*viper.ConfigFileNotFoundError); !ok {
-			home, err := homedir.Dir()
-			if err != nil {
-				return err
-			}
-
-			err = os.MkdirAll(home+"/.onos", 0777)
-			if err != nil {
-				return err
-			}
-
-			f, err := os.Create(home + "/.onos/onit.yaml")
-			if err != nil {
-				return err
-			}
-			f.Close()
-		} else {
-			return err
-		}
-	}
-	return nil
-}
-
-func init() {
-	home, err := homedir.Dir()
-	if err != nil {
-		exitError(err)
-	}
-
-	viper.SetConfigName("onit")
-	viper.AddConfigPath(home + "/.onos")
-	viper.AddConfigPath("/etc/onos")
-	viper.AddConfigPath(".")
-
-	viper.ReadInConfig()
 }

--- a/test/runner/config.go
+++ b/test/runner/config.go
@@ -1,3 +1,17 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runner
 
 import (


### PR DESCRIPTION
This PR improves autocompletion in onit. Cobra's completion for zsh doesn't actually work without some modifications. This PR ensures zsh completion works correctly and adds support for completing various arguments like cluster IDs, node IDs, device IDs, etc.