### PR TITLE
Stratum integration testing (#461) 

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -204,6 +204,32 @@ Simulators can similarly be removed with the `remove simulator` command:
 As with the `add` command, removing a simulator requires that the onos-config cluster be reconfigured
 and redeployed.
 
+### Adding Networks
+To run some of the tests on stratum switches, we can create a network of stratum switches using Mininet. To create a network of stratum switches, we can use `onit add network [Name] [Mininet Options]` as follows: 
+
+* To create a single node network, simply run `onit add network`. This command creates a single node network and assigns a name to it automatically. 
+* To create a linear network topology with two switches and name it *stratum-linear*, simply run the following command:
+
+```bash
+$ onit add network stratum-linear -- --topo linear,2
+```
+
+When a network is added to the cluster, the cluster is reconfigured in two phases:
+* Bootstrap one or more than one new stratum switches with the provided configuration
+* Reconfigure and redeploy the onos-config cluster with the new switches in its stores
+
+Networks can be removed using `onit remove network` command. For example, to remove the linear topolog that is created using the above command, you should run the following command:
+```bash
+$ onit remove network stratum-linear
+```
+
+As with the `add` command, removing a network requires that the onos-config cluster be reconfigured and redeployed.
+
+**Note**: In the current implementation, we support the following network topologies:
+
+* A *Single* node network topology
+* A *Linear* network topology
+
 ### Running Tests
 
 Once the cluster has been setup for the test, to run a test simply use `onit run`:

--- a/test/cli/cli.go
+++ b/test/cli/cli.go
@@ -23,14 +23,24 @@ import (
 	"strings"
 	"text/tabwriter"
 	"time"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/onosproject/onos-config/test/console"
 	"github.com/onosproject/onos-config/test/runner"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-
 )
+
+// Contains tells whether array contains x.
+func Contains(array []string, elem string) bool {
+	for _, n := range array {
+		if elem == n {
+			return true
+		}
+	}
+	return false
+}
 
 // GetOnitCommand returns a Cobra command for tests in the given test registry
 func GetOnitCommand(registry *runner.TestRegistry) *cobra.Command {
@@ -56,8 +66,8 @@ func GetOnitCommand(registry *runner.TestRegistry) *cobra.Command {
 // GetOnitK8sCommand returns a Cobra command for running tests on k8s
 func GetOnitK8sCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                    "onit-k8s",
-		Short:                  "This command is only intended to be used in a k8s instance for running integration tests.",
+		Use:   "onit-k8s",
+		Short: "This command is only intended to be used in a k8s instance for running integration tests.",
 	}
 	cmd.AddCommand(getTestTestLocalCommand(registry))
 	cmd.AddCommand(getTestSuiteLocalCommand(registry))
@@ -139,6 +149,76 @@ func getAddCommand() *cobra.Command {
 		Short: "Add resources to the cluster",
 	}
 	cmd.AddCommand(getAddSimulatorCommand())
+	cmd.AddCommand(getAddNetworkCommand())
+	return cmd
+}
+
+// getAddNetworkCommand returns a cobra command for deploying a stratum network
+func getAddNetworkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "network [name]",
+		Short: "Add a stratum network to the test cluster",
+		Args:  cobra.MaximumNArgs(10),
+		Run: func(cmd *cobra.Command, args []string) {
+			// If a network name was not provided, generate one from a UUID.
+			var name string
+			if len(args) > 0 {
+				name = args[0]
+			} else {
+				name = fmt.Sprintf("network-%d", newUUIDInt())
+			}
+
+			// Create the simulator configuration from the configured preset
+			configName, _ := cmd.Flags().GetString("preset")
+
+			// Get the onit controller
+			controller, err := runner.NewController()
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster ID
+			clusterID, err := cmd.Flags().GetString("cluster")
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster controller
+			cluster, err := controller.GetCluster(clusterID)
+			if err != nil {
+				exitError(err)
+			}
+
+			// Create the network configuration
+
+			config := &runner.NetworkConfig{
+				Config: configName,
+			}
+			if len(args) > 1 {
+				config.MininetOptions = args[1:]
+			}
+
+			// Update number of devices in the network configuration
+			runner.ParseMininetOptions(config)
+
+			if err != nil {
+				exitError(err)
+			}
+
+			// Add the network to the cluster
+			if status := cluster.AddNetwork(name, config); status.Failed() {
+				exitStatus(status)
+			} else {
+				fmt.Println(name)
+			}
+		},
+	}
+
+	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to which to add the simulator")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	cmd.Flags().StringP("preset", "p", "default", "simulator preset to apply")
 	return cmd
 }
 
@@ -249,6 +329,56 @@ func getRemoveCommand() *cobra.Command {
 		Short: "Remove resources from the cluster",
 	}
 	cmd.AddCommand(getRemoveSimulatorCommand())
+	cmd.AddCommand(getRemoveNetworkCommand())
+	return cmd
+}
+
+// getRemoveNetworkCommand returns a cobra command for tearing down a stratum network
+func getRemoveNetworkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "network [name]",
+		Short: "Remove a stratum network from the cluster",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			name := args[0]
+
+			// Get the onit controller
+			controller, err := runner.NewController()
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster ID
+			clusterID, err := cmd.Flags().GetString("cluster")
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster controller
+			cluster, err := controller.GetCluster(clusterID)
+			if err != nil {
+				exitError(err)
+			}
+
+			networks, err := cluster.GetNetworks()
+			if err != nil {
+				exitError(err)
+			}
+			if Contains(networks, name) == false {
+				exitError(errors.New("The given network name does not exist"))
+			}
+
+			// Remove the network from the cluster
+			if status := cluster.RemoveNetwork(name); status.Failed() {
+				exitStatus(status)
+			}
+		},
+	}
+
+	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to which to add the network")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
 	return cmd
 }
 
@@ -279,6 +409,15 @@ func getRemoveSimulatorCommand() *cobra.Command {
 				exitError(err)
 			}
 
+			simulators, err := cluster.GetSimulators()
+			if err != nil {
+				exitError(err)
+			}
+
+			if Contains(simulators, name) == false {
+				exitError(errors.New("The given simulator name does not exist"))
+			}
+
 			// Remove the simulator from the cluster
 			if status := cluster.RemoveSimulator(name); status.Failed() {
 				exitStatus(status)
@@ -304,6 +443,7 @@ func getGetCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd.AddCommand(getGetPartitionsCommand())
 	cmd.AddCommand(getGetPartitionCommand())
 	cmd.AddCommand(getGetSimulatorsCommand())
+	cmd.AddCommand(getGetNetworksCommand())
 	cmd.AddCommand(getGetClustersCommand())
 	cmd.AddCommand(getGetDevicePresetsCommand())
 	cmd.AddCommand(getGetStorePresetsCommand())
@@ -323,6 +463,49 @@ func getGetClusterCommand() *cobra.Command {
 			fmt.Println(getDefaultCluster())
 		},
 	}
+}
+
+// getGetNetworksCommand returns a cobra command to get the list of networks deployed in the current cluster context
+func getGetNetworksCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "networks",
+		Short: "Get the currently configured cluster's networks",
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get the onit controller
+			controller, err := runner.NewController()
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster ID
+			clusterID, err := cmd.Flags().GetString("cluster")
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster controller
+			cluster, err := controller.GetCluster(clusterID)
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the list of networks and output
+			networks, err := cluster.GetNetworks()
+			if err != nil {
+				exitError(err)
+			} else {
+				for _, name := range networks {
+					fmt.Println(name)
+				}
+			}
+		},
+	}
+
+	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to query")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
 }
 
 // getGetSimulatorsCommand returns a cobra command to get the list of simulators deployed in the current cluster context
@@ -734,10 +917,10 @@ To output the logs from a test, get the test ID from the test run or from 'onit 
 		},
 	}
 
-	cmd.Flags().DurationP("since", "", -1, "Only return logs newer than a relative " +
+	cmd.Flags().DurationP("since", "", -1, "Only return logs newer than a relative "+
 		"duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used")
-	cmd.Flags().Int64P("tail", "t", -1, "If set, the number of bytes to read from the " +
-		"server before terminating the log output. This may not display a complete final line of logging, and may return " +
+	cmd.Flags().Int64P("tail", "t", -1, "If set, the number of bytes to read from the "+
+		"server before terminating the log output. This may not display a complete final line of logging, and may return "+
 		"slightly more or slightly less than the specified limit.")
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to load the history")
@@ -748,7 +931,7 @@ To output the logs from a test, get the test ID from the test run or from 'onit 
 	return cmd
 }
 
-func parseLogOptions(cmd *cobra.Command) corev1.PodLogOptions{
+func parseLogOptions(cmd *cobra.Command) corev1.PodLogOptions {
 	// Parse log options from CLI
 	options := corev1.PodLogOptions{}
 	since, err := cmd.Flags().GetDuration("since")
@@ -819,7 +1002,6 @@ func getFetchLogsCommand() *cobra.Command {
 
 			options := parseLogOptions(cmd)
 
-
 			destination, _ := cmd.Flags().GetString("destination")
 			if len(args) > 0 {
 				resourceID := args[0]
@@ -846,7 +1028,7 @@ func getFetchLogsCommand() *cobra.Command {
 				var status console.ErrorStatus
 				for _, node := range nodes {
 					path := filepath.Join(destination, fmt.Sprintf("%s.log", node.ID))
-					status = cluster.DownloadLogs(node.ID, path,options)
+					status = cluster.DownloadLogs(node.ID, path, options)
 				}
 
 				if status.Failed() {
@@ -856,10 +1038,10 @@ func getFetchLogsCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().DurationP("since", "", -1, "Only return logs newer than a relative " +
+	cmd.Flags().DurationP("since", "", -1, "Only return logs newer than a relative "+
 		"duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used")
-	cmd.Flags().Int64P("tail", "t", -1, "If set, the number of bytes to read from the " +
-		"server before terminating the log output. This may not display a complete final line of logging, and may return " +
+	cmd.Flags().Int64P("tail", "t", -1, "If set, the number of bytes to read from the "+
+		"server before terminating the log output. This may not display a complete final line of logging, and may return "+
 		"slightly more or slightly less than the specified limit.")
 
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to load the history")
@@ -969,7 +1151,7 @@ func getRunTestRemoteCommand() *cobra.Command {
 		Use:   "test [tests]",
 		Short: "Run integration tests on Kubernetes",
 		Run: func(cmd *cobra.Command, args []string) {
-			runTestsRemote(cmd,"test",args)
+			runTestsRemote(cmd, "test", args)
 		},
 	}
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster on which to run the test")
@@ -985,7 +1167,7 @@ func getRunSuiteRemoteCommand(registry *runner.TestRegistry) *cobra.Command {
 		Use:   "suite [suite]",
 		Short: "Run integration tests",
 		Run: func(cmd *cobra.Command, args []string) {
-			runTestsRemote(cmd,"suite",args)
+			runTestsRemote(cmd, "suite", args)
 		},
 	}
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster on which to run the test")
@@ -997,7 +1179,7 @@ func getRunSuiteRemoteCommand(registry *runner.TestRegistry) *cobra.Command {
 	return cmd
 }
 
-func runTestsRemote(cmd *cobra.Command, commandType string,tests []string){
+func runTestsRemote(cmd *cobra.Command, commandType string, tests []string) {
 	testID := fmt.Sprintf("test-%d", newUUIDInt())
 
 	// Get the onit controller

--- a/test/cli/completion.go
+++ b/test/cli/completion.go
@@ -17,9 +17,10 @@ package cli
 import (
 	"bytes"
 	"errors"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 const bashCompletion = `
@@ -30,9 +31,9 @@ __onit_get_clusters() {
         COMPREPLY=( $( compgen -W "${out[*]}" -- "$cur" ) )
     fi
 }
-__onit_get_simulators() {
+__onit_get_devices() {
     local onit_output
-    if onit_output=$(onit get simulators 2>/dev/null); then
+    if onit_output=$(onit get devices 2>/dev/null); then
         COMPREPLY=( $( compgen -W "${onit_output[*]}" -- "$cur" ) )
     fi
 }
@@ -51,9 +52,9 @@ __onit_custom_func() {
             fi
             return
             ;;
-        onit_delete_simulator)
+        onit_delete_device)
             if [[ ${#nouns[@]} -eq 0 ]]; then
-                __onit_get_simulators
+                __onit_get_devices
             fi
             return
             ;;
@@ -90,7 +91,7 @@ func runCompletionCommand(cmd *cobra.Command, args []string) {
 		}
 
 	} else {
-		exitError(errors.New("unsupported shell type "+args[0]))
+		exitError(errors.New("unsupported shell type " + args[0]))
 	}
 }
 

--- a/test/runner/config.go
+++ b/test/runner/config.go
@@ -63,6 +63,14 @@ type SimulatorConfig struct {
 	Config string `yaml:"config" mapstructure:"config"`
 }
 
+// NetworkConfig provides the configuration for a stratum network
+type NetworkConfig struct {
+	Config         string `yaml:"config" mapstructure:"config"`
+	MininetOptions []string
+	NumDevices     int
+	TopoType       TopoType
+}
+
 // load loads the simulator configuration
 func (c *SimulatorConfig) load() (map[string]interface{}, error) {
 	file, err := os.Open(filepath.Join(deviceConfigsPath, c.Config+".json"))

--- a/test/runner/network.go
+++ b/test/runner/network.go
@@ -1,0 +1,304 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"bytes"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	topoOption = "--topo"
+)
+
+// TopoType topology type
+type TopoType int
+
+const (
+	// Linear linear topology type
+	Linear TopoType = iota
+	// Tree tree topology type
+	Tree
+	// Single node topology
+	Single
+)
+
+func (d TopoType) String() string {
+	return [...]string{"linear", "tree", "single"}[d]
+}
+
+// GetNetworks returns a list of networks deployed in the cluster
+func (c *ClusterController) GetNetworks() ([]string, error) {
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: "type=network",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	networks := make([]string, len(pods.Items))
+	for i, pod := range pods.Items {
+		networks[i] = pod.Name
+	}
+	return networks, nil
+}
+
+// setupNetwork creates a network of stratum devices required for the test
+func (c *ClusterController) setupNetwork(name string, config *NetworkConfig) error {
+
+	if err := c.createNetworkConfigMap(name, config); err != nil {
+		return err
+	}
+	if err := c.createNetworkPod(name, config); err != nil {
+		return err
+	}
+	if err := c.createNetworkService(name, config); err != nil {
+		return err
+	}
+	if err := c.awaitNetworkReady(name); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createNetworkConfigMap creates a network configuration
+func (c *ClusterController) createNetworkConfigMap(name string, config *NetworkConfig) error {
+
+	configByte, err := yaml.Marshal(config)
+
+	if err != nil {
+		return err
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.clusterID,
+			Labels: map[string]string{
+				"network": name,
+			},
+		},
+
+		BinaryData: map[string][]byte{
+			"config": configByte,
+		},
+	}
+	_, err = c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+// createNetworkPod creates a stratum network pod
+func (c *ClusterController) createNetworkPod(name string, config *NetworkConfig) error {
+
+	var isPrivileged = true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.clusterID,
+			Labels: map[string]string{
+				"type":    "network",
+				"network": name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "stratum-simulator",
+					Image:           "opennetworking/mn-stratum",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Stdin:           true,
+					Args:            config.MininetOptions,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "stratum",
+							ContainerPort: 50001,
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromInt(50001),
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       10,
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromInt(50001),
+							},
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       20,
+					},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &isPrivileged,
+					},
+
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "config",
+							MountPath: "/etc/simulator/configs",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: name,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := c.kubeclient.CoreV1().Pods(c.clusterID).Create(pod)
+	return err
+}
+
+// awaitSimulatorReady waits for the given simulator to complete startup
+func (c *ClusterController) awaitNetworkReady(name string) error {
+	for {
+		pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		} else if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+			return nil
+		} else {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// ParseMininetOptions parses mininet options and initialize the network configuration accordingly
+func ParseMininetOptions(config *NetworkConfig) {
+	mininetOptions := config.MininetOptions
+
+	if len(mininetOptions) != 0 {
+		if strings.Compare(mininetOptions[0], topoOption) == 0 {
+			topoType := strings.Split(mininetOptions[1], ",")
+			if strings.Compare(topoType[0], Linear.String()) == 0 {
+
+				config.NumDevices, _ = strconv.Atoi(topoType[1])
+				config.TopoType = Linear
+			}
+		}
+	} else {
+		config.NumDevices = 1
+		config.TopoType = Single
+
+	}
+}
+
+// createNetworkService creates a network service
+func (c *ClusterController) createNetworkService(name string, config *NetworkConfig) error {
+
+	var port int32 = 50001
+
+	for i := 0; i < config.NumDevices; i++ {
+		var buf bytes.Buffer
+		buf.WriteString(name)
+		buf.WriteString("-s")
+		buf.WriteString(strconv.Itoa(i))
+		serviceName := buf.String()
+
+		service := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: c.clusterID,
+				Labels:    map[string]string{"network": name},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"network": name,
+				},
+				Ports: []corev1.ServicePort{
+					{
+						Name: serviceName,
+						Port: port,
+					},
+				},
+			},
+		}
+		_, err := c.kubeclient.CoreV1().Services(c.clusterID).Create(service)
+		if err != nil {
+			return err
+		}
+		port = port + 1
+	}
+
+	return nil
+}
+
+// teardownNetwork tears down a network by name
+func (c *ClusterController) teardownNetwork(name string) error {
+	var err error
+	if e := c.deleteNetworkPod(name); e != nil {
+		err = e
+	}
+	if e := c.deleteNetworkService(name); e != nil {
+		err = e
+	}
+	if e := c.deleteNetworkConfigMap(name); e != nil {
+		err = e
+	}
+	return err
+}
+
+// deleteNetworkConfigMap deletes a network ConfigMap by name
+func (c *ClusterController) deleteNetworkConfigMap(name string) error {
+	return c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Delete(name, &metav1.DeleteOptions{})
+}
+
+// deleteNetworkPod deletes a network Pod by name
+func (c *ClusterController) deleteNetworkPod(name string) error {
+	return c.kubeclient.CoreV1().Pods(c.clusterID).Delete(name, &metav1.DeleteOptions{})
+}
+
+// deleteNetworkService deletes all network Service by name
+func (c *ClusterController) deleteNetworkService(name string) error {
+	label := "network=" + name
+	serviceList, _ := c.kubeclient.CoreV1().Services(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: label,
+	})
+
+	for _, svc := range serviceList.Items {
+		err := c.kubeclient.CoreV1().Services(c.clusterID).Delete(svc.Name, &metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/runner/simulator.go
+++ b/test/runner/simulator.go
@@ -16,10 +16,11 @@ package runner
 
 import (
 	"encoding/json"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
 )
 
 // GetSimulators returns a list of simulators deployed in the cluster
@@ -27,6 +28,7 @@ func (c *ClusterController) GetSimulators() ([]string, error) {
 	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
 		LabelSelector: "type=simulator",
 	})
+
 	if err != nil {
 		return nil, err
 	}
@@ -80,6 +82,7 @@ func (c *ClusterController) createSimulatorConfigMap(name string, config *Simula
 
 // createSimulatorPod creates a simulator pod
 func (c *ClusterController) createSimulatorPod(name string) error {
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -92,7 +95,7 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:            "device-simulator",
+					Name:            "onos-device-simulator",
 					Image:           "onosproject/device-simulator:latest",
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Ports: []corev1.ContainerPort{
@@ -142,12 +145,14 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 			},
 		},
 	}
+
 	_, err := c.kubeclient.CoreV1().Pods(c.clusterID).Create(pod)
 	return err
 }
 
 // createSimulatorService creates a simulator service
 func (c *ClusterController) createSimulatorService(name string) error {
+
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -165,6 +170,7 @@ func (c *ClusterController) createSimulatorService(name string) error {
 			},
 		},
 	}
+
 	_, err := c.kubeclient.CoreV1().Services(c.clusterID).Create(service)
 	return err
 }

--- a/test/runner/test.go
+++ b/test/runner/test.go
@@ -16,12 +16,13 @@ package runner
 
 import (
 	"errors"
+	"strings"
+	"time"
+
 	"github.com/onosproject/onos-config/test/env"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
-	"time"
 )
 
 // TestStatus test status
@@ -262,7 +263,7 @@ func (c *ClusterController) getDeviceIds() ([]string, error) {
 		}
 	}
 
-	// Get a list of simulators deployed in the cluster
+	// Get a list of devices deployed in the cluster
 	simulators, err := c.GetSimulators()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR integrates stratum image with `onit`. For the implementation, we should keep `add`/`remove` `simulator` and add `add`/`remove` `network`. The two need to be handled pretty differently. The Mininet pod needs to be added with those ports exposed, and then we should add a _separate_ service per device so the devices each have a separate host. That will preserve the separate host:port pattern for devices. Then they all have to be added to the stores. So we should create a separate `network.go` and new subcommand for the Mininet stuff

This PR supports a single node and linear topologies for now. The reason for is that we need to know how many devices will be emulated that we can create a Kubernetes service for each node in the network and expose its port.  