### PR TITLE
Ignore plugin compile failures on certain OSes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ build:
 	CGO_ENABLED=1 go build -gcflags "all=-N -l" -o build/_output/onos-config-debug ./cmd/onos-config
 	go build -o build/_output/onos ./cmd/onos
 	go build -o build/_output/onit ./test/cmd/onit
-	CGO_ENABLED=1 go build -o build/_output/testdevice.so.1.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/TestDevice-1.0.0
-	CGO_ENABLED=1 go build -o build/_output/testdevice.so.2.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/TestDevice-2.0.0
-	CGO_ENABLED=1 go build -o build/_output/devicesim.so.1.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/Devicesim-1.0.0
+	-CGO_ENABLED=1 go build -o build/_output/testdevice.so.1.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/TestDevice-1.0.0
+	-CGO_ENABLED=1 go build -o build/_output/testdevice.so.2.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/TestDevice-2.0.0
+	-CGO_ENABLED=1 go build -o build/_output/devicesim.so.1.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/Devicesim-1.0.0
 
 test: # @HELP run the unit tests and source code validation
 test: build deps lint vet license_check gofmt


### PR DESCRIPTION
This PR fixes a bug that can occur on OSes that do not support the `plugin` build mode:
```
-buildmode=plugin not supported on windows/amd64
```
This change ignores errors to ensure `make images` can progress and build the plugins inside a Docker container.