### PR TITLE
Ensure 'onit delete cluster' can delete multiple test clusters

### DIFF
--- a/test/runner/atomix.go
+++ b/test/runner/atomix.go
@@ -196,7 +196,7 @@ func (c *ClusterController) createAtomixClusterRole() error {
 func (c *ClusterController) createAtomixClusterRoleBinding() error {
 	roleBinding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "atomix-controller",
+			Name:      c.clusterID,
 			Namespace: c.clusterID,
 		},
 		Subjects: []rbacv1.Subject{

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -268,7 +268,7 @@ func (c *ClusterController) PortForward(resourceID string, localPort int, remote
 func (c *ClusterController) RemoveSimulator(name string) console.ErrorStatus {
 	c.status.Start("Tearing down simulator")
 	if err := c.teardownSimulator(name); err != nil {
-		return c.status.Fail(err)
+		c.status.Fail(err)
 	}
 	c.status.Start("Reconfiguring onos-config nodes")
 	if err := c.removeSimulatorFromConfig(name); err != nil {

--- a/test/runner/controller.go
+++ b/test/runner/controller.go
@@ -170,8 +170,8 @@ func (c *OnitController) GetCluster(clusterID string) (*ClusterController, error
 // DeleteCluster deletes a cluster controller
 func (c *OnitController) DeleteCluster(clusterID string) console.ErrorStatus {
 	c.status.Start("Deleting cluster namespace")
-	if err := c.kubeclient.RbacV1().ClusterRoleBindings().Delete("atomix-controller", &metav1.DeleteOptions{}); err != nil {
-		return c.status.Fail(err)
+	if err := c.kubeclient.RbacV1().ClusterRoleBindings().Delete(clusterID, &metav1.DeleteOptions{}); err != nil {
+		c.status.Fail(err)
 	}
 	if err := c.kubeclient.CoreV1().Namespaces().Delete(clusterID, &metav1.DeleteOptions{}); err != nil {
 		return c.status.Fail(err)

--- a/test/runner/simulator.go
+++ b/test/runner/simulator.go
@@ -185,16 +185,17 @@ func (c *ClusterController) awaitSimulatorReady(name string) error {
 
 // teardownSimulator tears down a simulator by name
 func (c *ClusterController) teardownSimulator(name string) error {
-	if err := c.deleteSimulatorPod(name); err != nil {
-		return err
+	var err error
+	if e := c.deleteSimulatorPod(name); e != nil {
+		err = e
 	}
-	if err := c.deleteSimulatorService(name); err != nil {
-		return err
+	if e := c.deleteSimulatorService(name); e != nil {
+		err = e
 	}
-	if err := c.deleteSimulatorConfigMap(name); err != nil {
-		return err
+	if e := c.deleteSimulatorConfigMap(name); e != nil {
+		err = e
 	}
-	return nil
+	return err
 }
 
 // deleteSimulatorConfigMap deletes a simulator ConfigMap by name


### PR DESCRIPTION
This PR fixes a bug in the `onit delete cluster` command. When multiple clusters are deleted, all attempts after the first `delete` fail since all clusters share the same `ClusterRoleBinding`. This change creates a separate `ClusterRoleBinding` per cluster.