### PR TITLE
Unset current cluster after delete

### DIFF
--- a/test/cli/cli.go
+++ b/test/cli/cli.go
@@ -218,7 +218,9 @@ func getDeleteClusterCommand() *cobra.Command {
 			}
 
 			// Delete the cluster
-			if status := controller.DeleteCluster(clusterID); status.Failed() {
+			status := controller.DeleteCluster(clusterID)
+			setDefaultCluster("")
+			if status.Failed() {
 				exitStatus(status)
 			}
 		},


### PR DESCRIPTION
Fixes a bug: ensure the current cluster is forgotten after it's deleted.