### PR TITLE
Load generated deviceStore.json even if empty

### DIFF
--- a/deployments/helm/onos-config/templates/deployment.yaml
+++ b/deployments/helm/onos-config/templates/deployment.yaml
@@ -50,11 +50,7 @@ spec:
             - "-certPath=/etc/onos-config/certs/tls.crt"
             - "-configStore=/etc/onos-config/test-configs/configStore-sample.json"
             - "-changeStore=/etc/onos-config/test-configs/changeStore-sample.json"
-            {{ if .Values.devices }}
             - "-deviceStore=/etc/onos-config/test-configs/deviceStore.json"
-            {{ else }}
-            - "-deviceStore=/etc/onos-config/test-configs/deviceStore-sample.json"
-            {{ end }}
             - "-networkStore=/etc/onos-config/test-configs/networkStore-sample.json"
           ports:
             - name: grpc


### PR DESCRIPTION
Previously if no **devices** were given in the **values.yaml** file it tried to load **deviceStore-sample.json** instead but this is file is removed and it was pointless anyway - better to deal with empty store. Devices can be added with argument to ** helm install like:
**--set devices='{device-1-device-simulator}'**
