### PR TITLE
Loading of ModelPlugins by default through Helm

### DIFF
--- a/deployments/helm/onos-config/templates/deployment.yaml
+++ b/deployments/helm/onos-config/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
             - "-deviceStore=/etc/onos-config/test-configs/deviceStore-sample.json"
             {{ end }}
             - "-networkStore=/etc/onos-config/test-configs/networkStore-sample.json"
+            {{- range $i, $plugin := .Values.plugins }}
+            - {{ printf "-modelPlugin=/usr/local/lib/%s" $plugin }}
+            {{- end }}
           ports:
             - name: grpc
               containerPort: 5150

--- a/deployments/helm/onos-config/values.yaml
+++ b/deployments/helm/onos-config/values.yaml
@@ -13,6 +13,8 @@ debug: false
 
 devices: []
 
+plugins: [devicesim.so.1.0.0,testdevice.so.1.0.0,testdevice.so.2.0.0]
+
 store:
   enabled: false
   controller: atomix-controller.kube-system.svc.cluster.local:5679


### PR DESCRIPTION
When the Model plugins are loaded at startup they check that the config loaded from stores is YANG valid