### PR TITLE
Temporarily disable the subscription test. It is causing failures

### DIFF
--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -35,7 +35,7 @@ const (
 
 func init() {
 	//example of registering groups
-	Registry.RegisterTest("subscribe", TestSubscribe, []*runner.TestSuite{AllTests,SomeTests,IntegrationTests})
+	Registry.RegisterTest("subscribe", TestSubscribe, []*runner.TestSuite{AllTests,SomeTests})
 }
 
 // TestSubscribe tests a stream subscription to updates to a device


### PR DESCRIPTION
The subscription integration test is failing a lot when the load on Travis is high. Disabling it for now, until we can revisit the failures.