### PR TITLE
Add Atomix CLI to debug image

### DIFF
--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -4,7 +4,9 @@ FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
 
 FROM golang:1.12.6-alpine3.9 as debugBuilder
 
-RUN apk upgrade --update --no-cache && apk add git && go get -u github.com/go-delve/delve/cmd/dlv
+RUN apk upgrade --update --no-cache && apk add git && \
+    go get -u github.com/go-delve/delve/cmd/dlv && \
+    go get -u github.com/atomix/atomix-cli/cmd/atomix
 
 FROM alpine:3.9
 
@@ -16,8 +18,11 @@ COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testde
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/testdevice.so.2.0.0 /usr/local/lib/testdevice.so.2.0.0
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/devicesim.so.1.0.0 /usr/local/lib/devicesim.so.1.0.0
 COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
+COPY --from=debugBuilder /go/bin/atomix /usr/local/bin/atomix
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
+    echo "atomix controller set \$ATOMIX_CONTROLLER" >> /usr/local/bin/onos-config-debug && \
+    echo "atomix config set namespace \$ATOMIX_NAMESPACE" >> /usr/local/bin/onos-config-debug && \
     echo "dlv --listen=:40000 --headless=true --accept-multiclient=true --api-version=2 exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
     chmod +x /usr/local/bin/onos-config-debug
 
@@ -25,10 +30,16 @@ RUN addgroup -S onos-config && adduser -S -G onos-config onos-config
 USER onos-config
 WORKDIR /home/onos-config
 
+ENV ATOMIX_CONTROLLER=atomix-controller.kube-system.svc.cluster.local:5679
+ENV ATOMIX_NAMESPACE=default
+
 RUN onos init && \
     cp /etc/profile /home/onos-config/.bashrc && \
     onos completion bash > /home/onos-config/.onos/bash_completion.sh && \
+    echo "source /home/onos-config/.onos/bash_completion.sh" >> /home/onos-config/.bashrc && \
     onos config set address 127.0.0.1:5150 && \
-    echo "source /home/onos-config/.onos/bash_completion.sh" >> /home/onos-config/.bashrc
+    atomix init && \
+    atomix completion bash > /home/onos-config/.atomix/bash_completion.sh && \
+    echo "source /home/onos-config/.atomix/bash_completion.sh" >> /home/onos-config/.bashrc
 
 ENTRYPOINT ["onos-config-debug"]

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=debugBuilder /go/bin/atomix /usr/local/bin/atomix
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
     echo "atomix controller set \$ATOMIX_CONTROLLER" >> /usr/local/bin/onos-config-debug && \
     echo "atomix config set namespace \$ATOMIX_NAMESPACE" >> /usr/local/bin/onos-config-debug && \
+    echo "atomix config set app \$ATOMIX_APP" >> /usr/local/bin/onos-config-debug && \
     echo "dlv --listen=:40000 --headless=true --accept-multiclient=true --api-version=2 exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
     chmod +x /usr/local/bin/onos-config-debug
 


### PR DESCRIPTION
This PR adds the `atomix` CLI to the debug image for debugging inside k8s with onit. Users can now use the `atomix` command in addition to `onos` to inspect stores:

```
> kubectl exec -it -n $(onit get cluster) $(onit get nodes --no-headers | awk '{print $1}') -- /bin/bash
onos-config-75dc64d77c-7hhc5:~$ atomix map keys device-store
...
```

The Atomix CLI is configured to use the `$ATOMIX_CONTROLLER` and `$ATOMIX_NAMESPACE` inside Kubernetes.