### PR TITLE
Apply unconfined seccomp profile to debug containers run by onit

### DIFF
--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -293,6 +293,7 @@ func (c *ClusterController) removeNetworkFromPod(name string, pod corev1.Pod) er
 // createOnosConfigDeployment creates an onos-config Deployment
 func (c *ClusterController) createOnosConfigDeployment() error {
 	nodes := int32(c.config.Nodes)
+	zero := int64(0)
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "onos-config",
@@ -393,6 +394,9 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 								},
 							},
 						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: &zero,
 					},
 					Volumes: []corev1.Volume{
 						{

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -311,6 +311,9 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 						"app":      "onos-config",
 						"resource": "onos-config",
 					},
+					Annotations: map[string]string{
+						"seccomp.security.alpha.kubernetes.io/pod": "unconfined",
+					},
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{


### PR DESCRIPTION
#481 

This PR applies the `unconfined` seccomp profile to debug containers to ensure they can be run with microk8s. I'm not entirely sure this will work, but based on the original proposals for seccomp support it is the best attempt I could come up with.