### PR TITLE
Rollback method and usage

### DIFF
--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 )
 
-// GetNetworkConfig returns a set of change values given a target, a configuration name, a path and a layer.
+// GetTargetConfig returns a set of change values given a target, a configuration name, a path and a layer.
 // The layer is the numbers of config changes we want to go back in time for. 0 is the latest
-func (m *Manager) GetNetworkConfig(target string, configname string, path string, layer int) ([]*change.ConfigValue, error) {
+func (m *Manager) GetTargetConfig(target string, configname string, path string, layer int) ([]*change.ConfigValue, error) {
 	log.Info("Getting config for ", target, path)
 	//TODO the key of the config store should be a tuple of (devicename, configname) use the param
 	var config store.Configuration

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -356,33 +356,6 @@ func TestManager_GetManager(t *testing.T) {
 	assert.Equal(t, mgrTest, GetManager())
 }
 
-func TestManager_ComputeRollback(t *testing.T) {
-	mgrTest, _, _ := setUp()
-
-	updates := make(map[string]string)
-	deletes := make([]string, 0)
-
-	updates[Test1Cont1ACont2ALeaf2B] = ValueLeaf2B159
-
-	_, _, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
-
-	assert.NilError(t, err, "Can't create change")
-
-	updates[Test1Cont1ACont2ALeaf2B] = ValueLeaf2B314
-
-	changeID, configName, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
-
-	assert.NilError(t, err, "Can't create change")
-
-	changes, deletes, errRoll := computeRollback(mgrTest, "Device1", string(configName))
-	assert.Check(t, len(deletes) == 0, "no path should be deleted")
-	assert.NilError(t, errRoll, "Can't ExecuteRollback")
-	config := mgrTest.ConfigStore.Store[configName]
-	assert.Check(t, !bytes.Equal(config.Changes[len(config.Changes)-1], changeID), "Did not remove last change")
-	assert.Check(t, changes[Test1Cont1ACont2ALeaf2B] == ValueLeaf2B159, "Wrong value to set after rollback")
-
-}
-
 func TestManager_ComputeRollbackDelete(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
@@ -403,7 +376,7 @@ func TestManager_ComputeRollbackDelete(t *testing.T) {
 
 	assert.NilError(t, err, "Can't create change")
 
-	changes, deletesRoll, errRoll := computeRollback(mgrTest, "Device1", string(configName))
+	_, changes, deletesRoll, errRoll := computeRollback(mgrTest, "Device1", string(configName))
 	assert.NilError(t, errRoll, "Can't ExecuteRollback", errRoll)
 	config := mgrTest.ConfigStore.Store[configName]
 	assert.Check(t, !bytes.Equal(config.Changes[len(config.Changes)-1], changeID), "Did not remove last change")

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -374,7 +374,7 @@ func TestManager_ComputeRollback(t *testing.T) {
 
 	assert.NilError(t, err, "Can't create change")
 
-	changes, deletes, errRoll := computeRollback(mgrTest, "Device1", string(configName), changeID)
+	changes, deletes, errRoll := computeRollback(mgrTest, "Device1", string(configName))
 	assert.Check(t, len(deletes) == 0, "no path should be deleted")
 	assert.NilError(t, errRoll, "Can't ExecuteRollback")
 	config := mgrTest.ConfigStore.Store[configName]
@@ -403,7 +403,7 @@ func TestManager_ComputeRollbackDelete(t *testing.T) {
 
 	assert.NilError(t, err, "Can't create change")
 
-	changes, deletesRoll, errRoll := computeRollback(mgrTest, "Device1", string(configName), changeID)
+	changes, deletesRoll, errRoll := computeRollback(mgrTest, "Device1", string(configName))
 	assert.NilError(t, errRoll, "Can't ExecuteRollback", errRoll)
 	config := mgrTest.ConfigStore.Store[configName]
 	assert.Check(t, !bytes.Equal(config.Changes[len(config.Changes)-1], changeID), "Did not remove last change")

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -15,6 +15,7 @@
 package manager
 
 import (
+	"bytes"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
@@ -32,12 +33,15 @@ const (
 	Test1Cont1ACont2ALeaf2A = "/test1:cont1a/cont2a/leaf2a"
 	Test1Cont1ACont2ALeaf2B = "/test1:cont1a/cont2a/leaf2b"
 	Test1Cont1ACont2ALeaf2C = "/test1:cont1a/cont2a/leaf2c"
+	Test1Cont1ACont2ALeaf2D = "/test1:cont1a/cont2a/leaf2d"
 )
 
 const (
 	ValueEmpty     = ""
 	ValueLeaf2A13  = "13"
 	ValueLeaf2B159 = "1.579"
+	ValueLeaf2B314 = "3.14"
+	ValueLeaf2D314 = "3.14"
 )
 
 // TestMain should only contain static data.
@@ -177,8 +181,8 @@ func Test_GetNetworkConfig(t *testing.T) {
 
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetNetworkConfig("Device1", "Running", "/*", 0)
-	assert.NilError(t, err, "GetNetworkConfig error")
+	result, err := mgrTest.GetTargetConfig("Device1", "Running", "/*", 0)
+	assert.NilError(t, err, "GetTargetConfig error")
 
 	assert.Equal(t, len(result), 3, "Unexpected result element count")
 
@@ -197,7 +201,7 @@ func Test_SetNetworkConfig(t *testing.T) {
 	deletes = append(deletes, Test1Cont1ACont2ALeaf2C)
 
 	changeID, configName, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
-	assert.NilError(t, err, "GetNetworkConfig error")
+	assert.NilError(t, err, "GetTargetConfig error")
 	testUpdate := configurationStoreTest["Device1-1.0.0"]
 	changeIDTest := testUpdate.Changes[len(testUpdate.Changes)-1]
 	assert.Equal(t, store.B64(changeID), store.B64(changeIDTest), "Change Ids should correspond")
@@ -303,7 +307,7 @@ func TestManager_GetAllDeviceIds(t *testing.T) {
 func TestManager_GetNoConfig(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetNetworkConfig("No Such Device", "Running", "/*", 0)
+	result, err := mgrTest.GetTargetConfig("No Such Device", "Running", "/*", 0)
 	assert.Assert(t, len(result) == 0, "Get of bad device does not return empty array")
 	assert.ErrorContains(t, err, "No Configuration found")
 }
@@ -320,7 +324,7 @@ func networkConfigContainsPath(configs []*change.ConfigValue, whichOne string) b
 func TestManager_GetAllConfig(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetNetworkConfig("Device1", "Running", "/*", 0)
+	result, err := mgrTest.GetTargetConfig("Device1", "Running", "/*", 0)
 	assert.Assert(t, len(result) == 3, "Get of device all paths does not return proper array")
 	assert.NilError(t, err, "Configuration not found")
 	assert.Assert(t, networkConfigContainsPath(result, "/test1:cont1a"), "/test1:cont1a not found")
@@ -331,7 +335,7 @@ func TestManager_GetAllConfig(t *testing.T) {
 func TestManager_GetOneConfig(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetNetworkConfig("Device1", "Running", "/test1:cont1a/cont2a/leaf2a", 0)
+	result, err := mgrTest.GetTargetConfig("Device1", "Running", "/test1:cont1a/cont2a/leaf2a", 0)
 	assert.Assert(t, len(result) == 1, "Get of device one path does not return proper array")
 	assert.NilError(t, err, "Configuration not found")
 	assert.Assert(t, networkConfigContainsPath(result, "/test1:cont1a/cont2a/leaf2a"), "/test1:cont1a/cont2a/leaf2a not found")
@@ -340,7 +344,7 @@ func TestManager_GetOneConfig(t *testing.T) {
 func TestManager_GetConfigNoTarget(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetNetworkConfig("", "Running", "/test1:cont1a/cont2a/leaf2a", 0)
+	result, err := mgrTest.GetTargetConfig("", "Running", "/test1:cont1a/cont2a/leaf2a", 0)
 	assert.Assert(t, len(result) == 0, "Get of device one path does not return proper array")
 	assert.ErrorContains(t, err, "No Configuration found for Running")
 }
@@ -350,4 +354,61 @@ func TestManager_GetManager(t *testing.T) {
 	assert.Equal(t, mgrTest, GetManager())
 	GetManager().Close()
 	assert.Equal(t, mgrTest, GetManager())
+}
+
+func TestManager_ComputeRollback(t *testing.T) {
+	mgrTest, _, _ := setUp()
+
+	updates := make(map[string]string)
+	deletes := make([]string, 0)
+
+	updates[Test1Cont1ACont2ALeaf2B] = ValueLeaf2B159
+
+	_, _, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
+
+	assert.NilError(t, err, "Can't create change")
+
+	updates[Test1Cont1ACont2ALeaf2B] = ValueLeaf2B314
+
+	changeID, configName, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
+
+	assert.NilError(t, err, "Can't create change")
+
+	changes, deletes, errRoll := computeRollback(mgrTest, "Device1", string(configName), changeID)
+	assert.Check(t, len(deletes) == 0, "no path should be deleted")
+	assert.NilError(t, errRoll, "Can't ExecuteRollback")
+	config := mgrTest.ConfigStore.Store[configName]
+	assert.Check(t, !bytes.Equal(config.Changes[len(config.Changes)-1], changeID), "Did not remove last change")
+	assert.Check(t, changes[Test1Cont1ACont2ALeaf2B] == ValueLeaf2B159, "Wrong value to set after rollback")
+
+}
+
+func TestManager_ComputeRollbackDelete(t *testing.T) {
+	mgrTest, _, _ := setUp()
+
+	updates := make(map[string]string)
+	deletes := make([]string, 0)
+
+	updates[Test1Cont1ACont2ALeaf2B] = ValueLeaf2B159
+
+	_, _, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
+
+	assert.NilError(t, err, "Can't create change", err)
+
+	updates[Test1Cont1ACont2ALeaf2B] = ValueLeaf2B314
+	updates[Test1Cont1ACont2ALeaf2D] = ValueLeaf2D314
+	deletes = append(deletes, Test1Cont1ACont2ALeaf2A)
+
+	changeID, configName, err := mgrTest.SetNetworkConfig("Device1-1.0.0", updates, deletes)
+
+	assert.NilError(t, err, "Can't create change")
+
+	changes, deletesRoll, errRoll := computeRollback(mgrTest, "Device1", string(configName), changeID)
+	assert.NilError(t, errRoll, "Can't ExecuteRollback", errRoll)
+	config := mgrTest.ConfigStore.Store[configName]
+	assert.Check(t, !bytes.Equal(config.Changes[len(config.Changes)-1], changeID), "Did not remove last change")
+	assert.Check(t, changes[Test1Cont1ACont2ALeaf2B] == ValueLeaf2B159, "Wrong value to set after rollback")
+	assert.Check(t, changes[Test1Cont1ACont2ALeaf2A] == ValueLeaf2A13, "Wrong value to set after rollback")
+	assert.Check(t, deletesRoll[0] == Test1Cont1ACont2ALeaf2D, "Path should be deleted")
+
 }

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -23,9 +23,9 @@ import (
 
 // RollbackTargetConfig rollbacks the last change for a given configuration on the target. Only the last one is
 // restored to the previous state. Going back n changes in time requires n sequential calls of this method.
-func (m *Manager) RollbackTargetConfig(target string, configname string, id change.ID) error {
-	log.Infof("Rolling back %s on config %s for target %s", id, configname, target)
-	updates, deletes, err := computeRollback(m, target, configname, id)
+func (m *Manager) RollbackTargetConfig(target string, configname string) error {
+	log.Infof("Rolling back last change on config %s for target %s", configname, target)
+	updates, deletes, err := computeRollback(m, target, configname)
 	if err != nil {
 		return err
 	}
@@ -34,8 +34,8 @@ func (m *Manager) RollbackTargetConfig(target string, configname string, id chan
 	return errSet
 }
 
-func computeRollback(m *Manager, target string, configname string, id change.ID) (map[string]string, []string, error) {
-	err := m.ConfigStore.RemoveLastChangeEntry(store.ConfigName(configname))
+func computeRollback(m *Manager, target string, configname string) (map[string]string, []string, error) {
+	id, err := m.ConfigStore.RemoveLastChangeEntry(store.ConfigName(configname))
 	if err != nil {
 		return nil, nil, fmt.Errorf(fmt.Sprintf("Can't remove last entry for %s", configname), err)
 	}

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -23,9 +23,10 @@ import (
 
 // RollbackTargetConfig rollbacks the last change for a given configuration on the target. Only the last one is
 // restored to the previous state. Going back n changes in time requires n sequential calls of this method.
-func (m *Manager) RollbackTargetConfig(target string, configname string) error {
-	log.Infof("Rolling back last change on config %s for target %s", configname, target)
-	updates, deletes, err := computeRollback(m, target, configname)
+func (m *Manager) RollbackTargetConfig(configname string) error {
+	targetID := m.ConfigStore.Store[store.ConfigName(configname)].Device
+	log.Infof("Rolling back last change on config %s for target %s", configname, targetID)
+	updates, deletes, err := computeRollback(m, targetID, configname)
 	if err != nil {
 		return err
 	}
@@ -48,7 +49,7 @@ func computeRollback(m *Manager, target string, configname string) (map[string]s
 			return nil, nil, fmt.Errorf("Can't get last config for path %s on config %s for target %s",
 				valueColl.Path, configname, err)
 		}
-		//Previously there was no such value configured, deletring from device
+		//Previously there was no such value configured, deleting from device
 		if len(value) == 0 {
 			deletes = append(deletes, valueColl.Path)
 		} else {

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -1,0 +1,63 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"fmt"
+	"github.com/onosproject/onos-config/pkg/store"
+	"github.com/onosproject/onos-config/pkg/store/change"
+	log "k8s.io/klog"
+)
+
+// RollbackTargetConfig rollbacks the last change for a given configuration on the target. Only the last one is
+// restored to the previous state. Going back n changes in time requires n sequential calls of this method.
+func (m *Manager) RollbackTargetConfig(target string, configname string, id change.ID) error {
+	log.Infof("Rolling back %s on config %s for target %s", id, configname, target)
+	updates, deletes, err := computeRollback(m, target, configname, id)
+	if err != nil {
+		return err
+	}
+	_, _, errSet := m.SetNetworkConfig(store.ConfigName(configname), updates, deletes)
+	//TODO if error we might want to take further action
+	return errSet
+}
+
+func computeRollback(m *Manager, target string, configname string, id change.ID) (map[string]string, []string, error) {
+	err := m.ConfigStore.RemoveLastChangeEntry(store.ConfigName(configname))
+	if err != nil {
+		return nil, nil, fmt.Errorf(fmt.Sprintf("Can't remove last entry for %s", configname), err)
+	}
+	previousValues := make([]*change.ConfigValue, 0)
+	deletes := make([]string, 0)
+	rollbackChange := m.ChangeStore.Store[store.B64(id)]
+	for _, valueColl := range rollbackChange.Config {
+		value, err := m.GetTargetConfig(target, configname, valueColl.Path, 0)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Can't get last config for path %s on config %s for target %s",
+				valueColl.Path, configname, err)
+		}
+		//Previously there was no such value configured, deletring from device
+		if len(value) == 0 {
+			deletes = append(deletes, valueColl.Path)
+		} else {
+			previousValues = append(previousValues, value[0])
+		}
+	}
+	updates := make(map[string]string)
+	for _, changeVal := range previousValues {
+		updates[changeVal.Path] = changeVal.Value
+	}
+	return updates, deletes, nil
+}

--- a/pkg/northbound/admin/admin.go
+++ b/pkg/northbound/admin/admin.go
@@ -24,7 +24,6 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/proto"
 	"github.com/onosproject/onos-config/pkg/store"
 	"google.golang.org/grpc"
-	"strings"
 )
 
 // Service is a Service implementation for administration.
@@ -135,7 +134,7 @@ func (s Server) RollbackNetworkChange(
 		}
 	}
 
-	configNames := make([]string, 0)
+	configNames := make(map[string][]string, 0)
 	// Check all are valid before we delete anything
 	for configName, changeID := range networkConfig.ConfigurationChanges {
 		configChangeIds := manager.GetManager().ConfigStore.Store[configName].Changes
@@ -144,7 +143,9 @@ func (s Server) RollbackNetworkChange(
 				"the last change on %s is not %s as expected. Was %s",
 				configName, changeID, store.B64(configChangeIds[len(configChangeIds)-1]))
 		}
-		err := manager.GetManager().RollbackTargetConfig(string(configName))
+		changeID, err := manager.GetManager().RollbackTargetConfig(string(configName))
+		rollbackIDs := configNames[string(configName)]
+		configNames[string(configName)] = append(rollbackIDs, store.B64(changeID))
 		if err != nil {
 			return nil, err
 		}
@@ -153,6 +154,6 @@ func (s Server) RollbackNetworkChange(
 
 	return &proto.RollbackResponse{
 		Message: fmt.Sprintf("Rolled back change '%s' Updated configs %s",
-			networkConfig.Name, strings.Join(configNames, ",")),
+			networkConfig.Name, configNames),
 	}, nil
 }

--- a/pkg/northbound/admin/admin.go
+++ b/pkg/northbound/admin/admin.go
@@ -144,8 +144,7 @@ func (s Server) RollbackNetworkChange(
 				"the last change on %s is not %s as expected. Was %s",
 				configName, changeID, store.B64(configChangeIds[len(configChangeIds)-1]))
 		}
-		targetID := manager.GetManager().ConfigStore.Store[configName].Device
-		err := manager.GetManager().RollbackTargetConfig(targetID, string(configName))
+		err := manager.GetManager().RollbackTargetConfig(string(configName))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -108,7 +108,7 @@ func getUpdate(prefix *gnmi.Path, path *gnmi.Path) (*gnmi.Update, error) {
 	if prefix != nil && prefix.Elem != nil {
 		pathAsString = utils.StrPath(prefix) + pathAsString
 	}
-	configValues, err := manager.GetManager().GetNetworkConfig(target, "",
+	configValues, err := manager.GetManager().GetTargetConfig(target, "",
 		pathAsString, 0)
 	if err != nil {
 		return nil, err

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -240,6 +240,7 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config
 			for t := range changes {
+				//TODO call new method herew
 				err := mgr.ConfigStore.RemoveLastChangeEntry(t)
 				if err != nil {
 					log.Error("Can't remove last entry for ", t, err)

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -239,18 +239,22 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 			return nil
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config
+			rolledbackIDs := make([]string, 0)
 			for configName := range changes {
-				err := mgr.RollbackTargetConfig(string(configName))
+				changeID, err := mgr.RollbackTargetConfig(string(configName))
 				if err != nil {
 					log.Error("Can'configName remove last entry for ", target, err)
 				}
+				rolledbackIDs = append(rolledbackIDs, store.B64(changeID))
 			}
 			//Removing the failed target
-			err := mgr.RollbackTargetConfig(string(name))
+			changeID, err := mgr.RollbackTargetConfig(string(name))
 			if err != nil {
 				log.Error("Can'configName remove last entry for ", target, err)
 			}
-			return response.Error()
+			rolledbackIDs = append(rolledbackIDs, store.B64(changeID))
+			return fmt.Errorf("Issue in setting config %s, rolling back changes %s",
+				response.Error().Error(), rolledbackIDs)
 		default:
 			return fmt.Errorf("undhandled Error Type")
 

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -240,15 +240,13 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config
 			for t := range changes {
-				//TODO call new method herew
-				err := mgr.ConfigStore.RemoveLastChangeEntry(t)
+				err := mgr.RollbackTargetConfig(target, string(t))
 				if err != nil {
-					log.Error("Can't remove last entry for ", t, err)
+					log.Error("Can't remove last entry for ", target, err)
 				}
-				//TODO calculate the reverse and send down.
 			}
 			//Removing the failed target
-			err := mgr.ConfigStore.RemoveLastChangeEntry(name)
+			err := mgr.RollbackTargetConfig(target, string(name))
 			if err != nil {
 				log.Error("Can't remove last entry for ", target, err)
 			}

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -239,16 +239,16 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 			return nil
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config
-			for t := range changes {
-				err := mgr.RollbackTargetConfig(target, string(t))
+			for configName := range changes {
+				err := mgr.RollbackTargetConfig(string(configName))
 				if err != nil {
-					log.Error("Can't remove last entry for ", target, err)
+					log.Error("Can'configName remove last entry for ", target, err)
 				}
 			}
 			//Removing the failed target
-			err := mgr.RollbackTargetConfig(target, string(name))
+			err := mgr.RollbackTargetConfig(string(name))
 			if err != nil {
-				log.Error("Can't remove last entry for ", target, err)
+				log.Error("Can'configName remove last entry for ", target, err)
 			}
 			return response.Error()
 		default:

--- a/pkg/store/stores.go
+++ b/pkg/store/stores.go
@@ -68,22 +68,24 @@ func (s *ConfigurationStore) RemoveEntry(name ConfigName) {
 }
 
 // RemoveLastChangeEntry removes a change entry from a named Configuration
-func (s *ConfigurationStore) RemoveLastChangeEntry(name ConfigName) error {
+func (s *ConfigurationStore) RemoveLastChangeEntry(name ConfigName) (change.ID, error) {
 
 	// If it has only 1 entry remove it altogether
 	if len(s.Store[name].Changes) == 1 {
+		changeID := s.Store[name].Changes[0]
 		delete(s.Store, name)
-		return nil
+		return changeID, nil
 	}
 
+	changeID := s.Store[name].Changes[len(s.Store[name].Changes)-1]
 	newConf, err := CreateConfiguration(s.Store[name].Device, s.Store[name].Version, s.Store[name].Type,
 		s.Store[name].Changes[:len(s.Store[name].Changes)-1])
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.Store[name] = *newConf
-	return nil
+	return changeID, nil
 }
 
 // ChangeStore is the model of the Change store


### PR DESCRIPTION
Introduce a new rollback method on the Manager to enable:
- remove of last change in a configuration for a given target
- delta creation against configuration previous to the removed change
- (re)set of configuration on device according to rollback states

fixes #460 