### PR TITLE
Add an integration test for stratum switches (WIP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ onos-config-it-docker: onos-config-base-docker # @HELP build onos-config-integra
 integration: kind
 	onit create cluster
 	onit add simulator
+	onit add network stratum 
 	onit run suite integration-tests
 
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -16,15 +16,16 @@ package manager
 
 import (
 	"bytes"
+	"os"
+	"strings"
+	"testing"
+
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"gotest.tools/assert"
 	log "k8s.io/klog"
-	"os"
-	"strings"
-	"testing"
 )
 
 const (

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -17,10 +17,11 @@ package gnmi
 import (
 	"testing"
 
+	"strings"
+
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"gotest.tools/assert"
-	"strings"
 )
 
 // See also the Test_getWithPrefixNoOtherPathsNoTarget below where the Target

--- a/test/configs/store/default.json
+++ b/test/configs/store/default.json
@@ -2,12 +2,92 @@
   "changeStore": {
     "Version": "1.0.0",
     "Storetype": "change",
-    "Store": {}
+    "Store": {
+      "J+CUGSfjr0npwzDN29ftbzXSG3o=": {
+        "ID": "J+CUGSfjr0npwzDN29ftbzXSG3o=",
+        "Description": "Initial configuration of Stratum Simulator",
+        "Created": "2019-06-05T12:03:17Z",
+        "Config": [
+          {
+            "Path": "/interfaces/interface[name=s1-eth1]/config/enabled",
+            "Value": "AA==",
+            "Type": 4
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth1]/config/health-indicator",
+            "Value": "R09PRA==",
+            "Type": 1
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth1]/ethernet/config/auto-negotiate",
+            "Value": "AQ==",
+            "Type": 4
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth1]/ethernet/config/forwarding-viable",
+            "Value": "AQ==",
+            "Type": 4
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth1]/ethernet/config/mac-address",
+            "Value": "MTE6MjI6MzM6NDQ6NTU6NjY=",
+            "Type": 1
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth1]/ethernet/config/port-speed",
+            "Value": "U1BFRURfMTBHQg==",
+            "Type": 1
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth2]/config/enabled",
+            "Value": "AA==",
+            "Type": 4
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth2]/config/health-indicator",
+            "Value": "R09PRA==",
+            "Type": 1
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth2]/ethernet/config/auto-negotiate",
+            "Value": "AQ==",
+            "Type": 4
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth2]/ethernet/config/forwarding-viable",
+            "Value": "AQ==",
+            "Type": 4
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth2]/ethernet/config/mac-address",
+            "Value": "MTE6MjI6MzM6NDQ6NTU6NjY=",
+            "Type": 1
+          },
+          {
+            "Path": "/interfaces/interface[name=s1-eth2]/ethernet/config/port-speed",
+            "Value": "U1BFRURfMTBHQg==",
+            "Type": 1
+          }
+        ]
+      }
+    }
   },
   "configStore": {
     "Version": "1.0.0",
     "Storetype": "config",
-    "Store": {}
+    "Store": {
+      "stratum-1-s0-1.0.0": {
+        "Name": "stratum-s0-1.0.0",
+        "Device": "stratum-s0",
+        "Version": "1.0.0",
+        "Type": "Stratum",
+        "Created": "2019-06-05T10:03:17Z",
+        "Updated": "2019-06-05T10:03:17Z",
+        "Changes": [
+          "J+CUGSfjr0npwzDN29ftbzXSG3o="
+        ]
+      }
+    }
   },
   "networkStore": {
     "Version": "1.0.0",
@@ -17,6 +97,14 @@
   "deviceStore": {
     "Version": "1.0.0",
     "Storetype": "device",
-    "Store": {}
+    "Store": {
+      "stratum-s0": {
+        "ID": "stratum-s0",
+        "Addr": "localhost:50001",
+        "SoftwareVersion": "1.0.0",
+        "Plain": true,
+        "Timeout": 5
+      }
+    }
   }
 }

--- a/test/integration/gnmiutils.go
+++ b/test/integration/gnmiutils.go
@@ -17,12 +17,13 @@ package integration
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/client"
 	gclient "github.com/openconfig/gnmi/client/gnmi"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
-	"strings"
 )
 
 // DevicePath describes the results of a get operation for a single path

--- a/test/integration/stratumsinglepathtest.go
+++ b/test/integration/stratumsinglepathtest.go
@@ -1,0 +1,48 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/onosproject/onos-config/test/env"
+	"github.com/onosproject/onos-config/test/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	stratumPath = "/interfaces/"
+)
+
+// TestStratumSinglePath tests query/set/delete of a single GNMI path to a stratum device
+func TestStratumSinglePath(t *testing.T) {
+	// Get the first stratum configured device from the environment.
+	device := env.GetDevices()[0]
+
+	// Make a GNMI client to use for requests
+	c, err := env.NewGnmiClient(MakeContext(), "")
+	assert.NoError(t, err)
+	assert.True(t, c != nil, "Fetching client returned nil")
+
+	devicePath, err := GNMIGet(MakeContext(), c, makeDevicePath(device, stratumPath))
+	fmt.Println(devicePath, err)
+
+}
+
+func init() {
+	Registry.RegisterTest("stratum-single-path", TestStratumSinglePath, []*runner.TestSuite{AllTests})
+
+}

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -229,7 +229,7 @@ func (c *ClusterController) addSimulatorToPod(name string, pod corev1.Pod) error
 
 // addNetworkToPod adds the given network to the given pod's configuration
 func (c *ClusterController) addNetworkToPod(name string, port int, pod corev1.Pod) error {
-	command := fmt.Sprintf("onos devices add \"id: '%s', address: '%s:%s' version: '1.0.0', devicetype: 'Stratum'\" --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/tls.key --certPath /etc/onos-config/certs/tls.crt", name, name, strconv.Itoa(port))
+	command := fmt.Sprintf("onos devices add \"id: '%s', address: '%s:%s' version: '1.0.0', devicetype: 'Stratum', plain:true\" --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/tls.key --certPath /etc/onos-config/certs/tls.crt", name, name, strconv.Itoa(port))
 	return c.execute(pod, []string{"/bin/bash", "-c", command})
 }
 


### PR DESCRIPTION
@kuujo @Andrea-Campanella @ray-milkey 
This is a WIP PR. The main goal is to add an integration test for stratum switches as a base that we can use that later for new integration tests. Please add WIP and DO_NOT_MERGE labels until I update this comment.  #461 

1- List of devices stored in an environment variable called `TestDevicesEnv`. The first question that we should answer is: do we want to keep stratum devices separate than device simulators by defining a new env variable or do we want to append stratum switches into `TestDevicesEnv` as well. The advantage of the first one is that we don't need to worry about the indexing when we want to get a device simulator or stratum switch in an integration test. 
