### PR TITLE
No Duplicate changes in device config

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -215,7 +215,7 @@ func listenOnResponseChannel(respChan chan events.DeviceResponse) {
 }
 
 func (m *Manager) computeAndStoreChange(updates map[string]*change.TypedValue,
-	deletes []string) (*change.Change, error) {
+	deletes []string) (change.ID, error) {
 	var newChanges = make([]*change.Value, 0)
 	//updates
 	for path, value := range updates {
@@ -238,5 +238,5 @@ func (m *Manager) computeAndStoreChange(updates map[string]*change.TypedValue,
 		m.ChangeStore.Store[store.B64(configChange.ID)] = configChange
 		log.Info("Added change ", store.B64(configChange.ID), " to ChangeStore (in memory)")
 	}
-	return configChange, nil
+	return configChange.ID, nil
 }

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -33,12 +33,12 @@ func (m *Manager) RollbackTargetConfig(configname string) (change.ID, error) {
 	if err != nil {
 		return nil, err
 	}
-	configChange, err := m.computeAndStoreChange(updates, deletes)
+	changeID, err := m.computeAndStoreChange(updates, deletes)
 	if err != nil {
 		return id, err
 	}
 	m.ChangesChannel <- events.CreateConfigEvent(targetID,
-		configChange.ID, true)
+		changeID, true)
 	return id, listenForDeviceResponse(m, targetID)
 }
 

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -16,9 +16,12 @@ package manager
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/events"
+	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	log "k8s.io/klog"
+	"time"
 )
 
 // RollbackTargetConfig rollbacks the last change for a given configuration on the target. Only the last one is
@@ -30,9 +33,13 @@ func (m *Manager) RollbackTargetConfig(configname string) (change.ID, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, _, errSet := m.SetNetworkConfig(store.ConfigName(configname), updates, deletes)
-	//TODO if error we might want to take further action
-	return id, errSet
+	configChange, err := m.computeAndStoreChange(updates, deletes)
+	if err != nil {
+		return id, err
+	}
+	m.ChangesChannel <- events.CreateConfigEvent(targetID,
+		configChange.ID, true)
+	return id, listenForDeviceResponse(m, targetID)
 }
 
 func computeRollback(m *Manager, target string, configname string) (change.ID, map[string]*change.TypedValue, []string, error) {
@@ -61,4 +68,31 @@ func computeRollback(m *Manager, target string, configname string) (change.ID, m
 		updates[changeVal.Path] = &changeVal.TypedValue
 	}
 	return id, updates, deletes, nil
+}
+
+func listenForDeviceResponse(mgr *Manager, target string) error {
+	respChan, ok := mgr.Dispatcher.GetResponseListener(topocache.ID(target))
+	if !ok {
+		log.Infof("Device %s not properly registered, not waiting for southbound confirmation", target)
+		return nil
+	}
+	//blocking until we receive something from the channel or for 5 seconds, whatever comes first.
+	select {
+	case response := <-respChan:
+		switch eventType := response.EventType(); eventType {
+		case events.EventTypeAchievedSetConfig:
+			log.Infof("Rollback succeeded on %s ", target)
+			return nil
+		case events.EventTypeErrorSetConfig:
+			//TODO if the device gives an error during this rollback we currently do nothing
+			return fmt.Errorf("Rollback thrown error %s, system is in inconsistent state for device %s ",
+				response.Error().Error(), target)
+
+		default:
+			return fmt.Errorf("undhandled Error Type")
+
+		}
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("Timeout on waiting for device reply %s", target)
+	}
 }

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -66,30 +66,9 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 		}
 	}
 
-	var newChanges = make([]*change.Value, 0)
-	//updates
-	for path, value := range updates {
-		changeValue, _ := change.CreateChangeValue(path, value, false)
-		newChanges = append(newChanges, changeValue)
-	}
-
-	//deletes
-	for _, path := range deletes {
-		changeValue, _ := change.CreateChangeValue(path, change.CreateTypedValueEmpty(), true)
-		newChanges = append(newChanges, changeValue)
-	}
-
-	configChange, err := change.CreateChange(newChanges,
-		fmt.Sprintf("Created at %s", time.Now().Format(time.RFC3339)))
+	configChange, err := m.computeAndStoreChange(updates, deletes)
 	if err != nil {
 		return nil, configName, err
-	}
-
-	if m.ChangeStore.Store[store.B64(configChange.ID)] != nil {
-		log.Info("Change ID = ", store.B64(configChange.ID), " already exists - not overwriting")
-	} else {
-		m.ChangeStore.Store[store.B64(configChange.ID)] = configChange
-		log.Info("Added change ", store.B64(configChange.ID), " to ChangeStore (in memory)")
 	}
 
 	// If the last change applied to deviceConfig is the same as this one then don't apply it again

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -66,21 +66,21 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 		}
 	}
 
-	configChange, err := m.computeAndStoreChange(updates, deletes)
+	changeID, err := m.computeAndStoreChange(updates, deletes)
 	if err != nil {
 		return nil, configName, err
 	}
 
 	// If the last change applied to deviceConfig is the same as this one then don't apply it again
 	if len(deviceConfig.Changes) > 0 &&
-		store.B64(deviceConfig.Changes[len(deviceConfig.Changes)-1]) == store.B64(configChange.ID) {
-		log.Info("Change ", store.B64(configChange.ID),
+		store.B64(deviceConfig.Changes[len(deviceConfig.Changes)-1]) == store.B64(changeID) {
+		log.Info("Change ", store.B64(changeID),
 			"has already been applied to", configName, "Ignoring")
-		return configChange.ID, configName, fmt.Errorf("%s %s",
-			SetConfigAlreadyApplied, store.B64(configChange.ID))
+		return changeID, configName, fmt.Errorf("%s %s",
+			SetConfigAlreadyApplied, store.B64(changeID))
 	}
 	//FIXME this needs to hold off until the device replies with an ok message for the change.
-	deviceConfig.Changes = append(deviceConfig.Changes, configChange.ID)
+	deviceConfig.Changes = append(deviceConfig.Changes, changeID)
 	deviceConfig.Updated = time.Now()
 	m.ConfigStore.Store[configName] = deviceConfig
 
@@ -104,7 +104,7 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 				return nil, configName, err
 			}
 			log.Info("Configuration is Valid according to model",
-				modelName, "after adding change", store.B64(configChange.ID))
+				modelName, "after adding change", store.B64(changeID))
 		}
 	}
 
@@ -112,7 +112,7 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 	//  2) Do a precheck that the device is reachable
 	//  3) Check that the caller is authorized to make the change
 	m.ChangesChannel <- events.CreateConfigEvent(deviceConfig.Device,
-		configChange.ID, true)
+		changeID, true)
 
-	return configChange.ID, configName, nil
+	return changeID, configName, nil
 }


### PR DESCRIPTION
When doing rollback we do not set a copy of the previous change but instead leave the set of changes as it was prior to the last set and rollback operation. 
Refactored also a common method.
We also listen for errors during the set request for rollback