### PR TITLE
Check for duplicate against just the last change ID. Fixes: #511

### DIFF
--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -46,7 +46,8 @@ func (m *Manager) RollbackTargetConfig(configname string) (change.ID, error) {
 func computeRollback(m *Manager, target string, configname string) (change.ID, map[string]*change.TypedValue, []string, error) {
 	id, err := m.ConfigStore.RemoveLastChangeEntry(store.ConfigName(configname))
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("Can't remove last entry for %s, %s", configname, err.Error())
+		return nil, nil, nil, fmt.Errorf("Can't remove last entry on target %s in config %s, %s",
+			target, configname, err.Error())
 	}
 	previousValues := make([]*change.ConfigValue, 0)
 	deletes := make([]string, 0)

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -31,6 +31,7 @@ func (m *Manager) RollbackTargetConfig(configname string) (change.ID, error) {
 	log.Infof("Rolling back last change on config %s for target %s", configname, targetID)
 	id, updates, deletes, err := computeRollback(m, targetID, configname)
 	if err != nil {
+		log.Errorf("Error on rollback: %s", err.Error())
 		return nil, err
 	}
 	changeID, err := m.computeAndStoreChange(updates, deletes)
@@ -45,7 +46,7 @@ func (m *Manager) RollbackTargetConfig(configname string) (change.ID, error) {
 func computeRollback(m *Manager, target string, configname string) (change.ID, map[string]*change.TypedValue, []string, error) {
 	id, err := m.ConfigStore.RemoveLastChangeEntry(store.ConfigName(configname))
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf(fmt.Sprintf("Can't remove last entry for %s", configname), err)
+		return nil, nil, nil, fmt.Errorf("Can't remove last entry for %s, %s", configname, err.Error())
 	}
 	previousValues := make([]*change.ConfigValue, 0)
 	deletes := make([]string, 0)

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -244,7 +244,7 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 	mgr := manager.GetManager()
 	respChan, ok := mgr.Dispatcher.GetResponseListener(topocache.ID(target))
 	if !ok {
-		log.Infof("Device %s not properly registered, not waiting for southbound confirmation", target)
+		log.Infof("Device %s not properly registered, not waiting for southbound confirmation ", target)
 		return nil
 	}
 	//blocking until we receive something from the channel or for 5 seconds, whatever comes first.
@@ -252,7 +252,7 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 	case response := <-respChan:
 		switch eventType := response.EventType(); eventType {
 		case events.EventTypeAchievedSetConfig:
-			log.Info("Set is properly configured", response.ChangeID())
+			log.Info("Set is properly configured ", response.ChangeID())
 			return nil
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config

--- a/pkg/store/configuration.go
+++ b/pkg/store/configuration.go
@@ -128,14 +128,13 @@ func CreateConfiguration(deviceName string, version string, deviceType string,
 	configName := deviceName + "-" + version
 
 	//Look for duplicates in the changeId - do not sort
-	changesStrings := make([]string, len(changes))
-	for idx, c := range changes {
-		prevCh := strings.Join(changesStrings, ",")
-		if strings.Contains(prevCh, B64(c)) {
-			return nil, fmt.Errorf("Duplicate change ID '%s' in config",
-				c)
+	var previousChange string
+	for _, c := range changes {
+		if previousChange == B64(c) {
+			return nil, fmt.Errorf("Duplicate last change ID '%s' in config", B64(c))
+
 		}
-		changesStrings[idx] = B64(c)
+		previousChange = B64(c)
 	}
 
 	deviceConfig := Configuration{


### PR DESCRIPTION
while Create a new configuration we were checking that there was no duplication of changes in the whole array, this is not a valid case as for example a set(v), delete(v), set(v), delete(v) is a valid operation.
Now checking that we are not setting the same value twice in a row. 

Fixes #511 