### PR TITLE
Test time-out increase. Fixes #512

### DIFF
--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -381,7 +381,7 @@ func assertSyncResponse(responsesChan chan *gnmi.SubscribeResponse, t *testing.T
 	case response := <-responsesChan:
 		log.Info("response ", response)
 		assert.Equal(t, response.GetSyncResponse(), true, "Sync should be true")
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		log.Error("Expected Sync Response")
 		t.FailNow()
 	}
@@ -404,7 +404,7 @@ func assertUpdateResponse(t *testing.T, responsesChan chan *gnmi.SubscribeRespon
 		assert.Equal(t, pathResponse.Elem[1].Name, path2)
 		assert.Equal(t, pathResponse.Elem[2].Name, path3)
 		assert.Equal(t, response.GetUpdate().GetUpdate()[0].Val.GetUintVal(), uint64(value))
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		log.Error("Expected Update Response")
 		t.FailNow()
 	}
@@ -428,7 +428,7 @@ func assertDeleteResponse(t *testing.T, responsesChan chan *gnmi.SubscribeRespon
 		assert.Equal(t, pathResponse.Elem[0].Name, path1)
 		assert.Equal(t, pathResponse.Elem[1].Name, path2)
 		assert.Equal(t, pathResponse.Elem[2].Name, path3)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		log.Error("Expected Update Response")
 		t.FailNow()
 	}

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -107,7 +107,7 @@ func TestSubscribe(t *testing.T) {
 	select {
 	case response = <-respChan:
 		valiedateResponse(t, response, device, false)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		assert.FailNow(t, "Expected Update Response")
 	}
 
@@ -115,7 +115,7 @@ func TestSubscribe(t *testing.T) {
 	select {
 	case response = <-respChan:
 		valiedateResponse(t, response, device, false)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		assert.FailNow(t, "Expected Sync Response")
 	}
 
@@ -134,7 +134,7 @@ func TestSubscribe(t *testing.T) {
 	select {
 	case response = <-respChan:
 		valiedateResponse(t, response, device, true)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		assert.FailNow(t, "Expected Delete Response")
 	}
 
@@ -142,7 +142,7 @@ func TestSubscribe(t *testing.T) {
 	select {
 	case response = <-respChan:
 		valiedateResponse(t, response, device, false)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(1 * time.Second):
 		assert.FailNow(t, "Expected Sync Response")
 	}
 
@@ -178,7 +178,7 @@ func buildRequest(path *gnmi.Path, mode gnmi.SubscriptionList_Mode) (*gnmi.Subsc
 	return request, nil
 }
 
-func valiedateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string, delete bool) error {
+func valiedateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string, delete bool) {
 	switch v := resp.Response.(type) {
 	default:
 		assert.Fail(t, "Unknown type", v)
@@ -193,7 +193,6 @@ func valiedateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string
 			assertUpdateResponse(t, v, device)
 		}
 	}
-	return nil
 }
 
 func assertUpdateResponse(t *testing.T, response *gnmi.SubscribeResponse_Update, device string) {


### PR DESCRIPTION
Increasing timeout for reply in subscribe to allow for slow systems to run tests. 

Fixes #512