### PR TITLE
Added checking of readonly types during Set

### DIFF
--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -111,9 +111,12 @@ SetRequest() with the 100 extension at the end of the -proto section like:
 > The corresponding -get for this require using the -proto
 > "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>"
 
-> Currently (May '19) no checking of the contents is enforced when doing a Set operation
-> and the config is forwarded down to the southbound layer only if a device is registered
-> in the topocache (currently in the deviceStore)
+> Currently (Jul '19) checking of the contents done only when a Model Plugin is
+> loaded for the device type. 2 checks are done 1) that a attempt is not being
+> made to change a readonly attribute and 2) that valid data types and values are
+> being used.
+> The config is only forwarded down to the southbound layer only if the config is
+> correct and the device is registered in the topocache (currently in the deviceStore)
 
 If the `target` device is not currently known to `onos-config` the system will store the configuration internally and apply
 it to the `target` device when/if it becomes available.  

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -42,6 +42,7 @@ type Manager struct {
 	SouthboundErrorChan     chan events.DeviceResponse
 	Dispatcher              dispatcher.Dispatcher
 	ModelRegistry           map[string]ModelPlugin
+	ModelReadOnlyPaths      map[string][]string
 }
 
 // NewManager initializes the network config manager subsystem.
@@ -59,6 +60,7 @@ func NewManager(configs *store.ConfigurationStore, changes *store.ChangeStore, d
 		SouthboundErrorChan:     make(chan events.DeviceResponse, 10),
 		Dispatcher:              dispatcher.NewDispatcher(),
 		ModelRegistry:           make(map[string]ModelPlugin),
+		ModelReadOnlyPaths:      make(map[string][]string),
 	}
 
 	changeIds := make([]string, 0)

--- a/pkg/manager/modelregistry.go
+++ b/pkg/manager/modelregistry.go
@@ -21,6 +21,8 @@ import (
 	"github.com/openconfig/ygot/ygot"
 	log "k8s.io/klog"
 	"plugin"
+	"regexp"
+	"strings"
 )
 
 // ModelPlugin is a set of methods that each model plugin should implement
@@ -48,12 +50,22 @@ func (m *Manager) RegisterModelPlugin(moduleName string) (string, string, error)
 	modelPlugin, ok := symbolMP.(ModelPlugin)
 	if !ok {
 		log.Warning("Unable to use ModelPlugin in ", moduleName)
-		return "", "", fmt.Errorf("Symbol loaded from module %s is not a ModelPlugin",
+		return "", "", fmt.Errorf("symbol loaded from module %s is not a ModelPlugin",
 			moduleName)
 	}
 	name, version, _, _ := modelPlugin.ModelData()
-	modelName := toModelName(name, version)
+	modelName := ToModelName(name, version)
 	m.ModelRegistry[modelName] = modelPlugin
+	modelschema, err := modelPlugin.Schema()
+	if err != nil {
+		log.Warning("Error loading schema from model plugin", modelName, err)
+		return "", "", err
+	}
+
+	m.ModelReadOnlyPaths[modelName] = extractReadOnlyPaths(modelschema["Device"],
+		yang.TSUnset, "", "")
+	log.Infof("Model %s %s loaded. %d read only paths", name, version,
+		len(m.ModelReadOnlyPaths[modelName]))
 	return name, version, nil
 }
 
@@ -65,7 +77,7 @@ func (m *Manager) Capabilities() []*gnmi.ModelData {
 	for _, model := range m.ModelRegistry {
 		_, _, modelItem, _ := model.ModelData()
 		for _, mi := range modelItem {
-			modelName := toModelName(mi.Name, mi.Version)
+			modelName := ToModelName(mi.Name, mi.Version)
 			modelMap[modelName] = mi
 		}
 	}
@@ -79,6 +91,75 @@ func (m *Manager) Capabilities() []*gnmi.ModelData {
 	return outputList
 }
 
-func toModelName(name string, version string) string {
+// extractReadOnlyPaths is a recursive function to extract a list of read only paths from a YGOT schema
+func extractReadOnlyPaths(deviceEntry *yang.Entry, parentState yang.TriState, parentPrefix string, parentPath string) []string {
+	readOnlyPaths := make([]string, 0)
+
+	for _, dirEntry := range deviceEntry.Dir {
+		prefix := ""
+		if dirEntry.Prefix != nil {
+			prefix = dirEntry.Prefix.Name
+		}
+		itemPath := formatName(dirEntry, false, parentPrefix, parentPath)
+		if dirEntry.IsLeaf() {
+			// No need to recurse
+			if dirEntry.Config == yang.TSFalse || parentState == yang.TSFalse {
+				readOnlyPaths = append(readOnlyPaths, itemPath)
+			}
+		} else if dirEntry.IsContainer() {
+			if dirEntry.Config == yang.TSFalse || parentState == yang.TSFalse {
+				readOnlyPaths = append(readOnlyPaths, itemPath)
+			}
+			newPaths := extractReadOnlyPaths(dirEntry, dirEntry.Config, prefix, itemPath)
+			for _, newPath := range newPaths {
+				readOnlyPaths = append(readOnlyPaths, newPath)
+			}
+		} else if dirEntry.IsList() {
+			itemPath = formatName(dirEntry, true, parentPrefix, parentPath)
+			if dirEntry.Config == yang.TSFalse || parentState == yang.TSFalse {
+				readOnlyPaths = append(readOnlyPaths, itemPath)
+			}
+			newPaths := extractReadOnlyPaths(dirEntry, dirEntry.Config, prefix, itemPath)
+			for _, newPath := range newPaths {
+				readOnlyPaths = append(readOnlyPaths, newPath)
+			}
+		}
+	}
+
+	return readOnlyPaths
+}
+
+// ToModelName simply joins together model name and version in a consistent way
+func ToModelName(name string, version string) string {
 	return fmt.Sprintf("%s-%s", name, version)
+}
+
+// RemovePathIndices removes the index value from a path to allow it to be compared to a model path
+func RemovePathIndices(path string) string {
+	const indexPattern = `=.*?]`
+	rname := regexp.MustCompile(indexPattern)
+	indices := rname.FindAllStringSubmatch(path, -1)
+	for _, i := range indices {
+		path = strings.Replace(path, i[0], "=*]", 1)
+	}
+	return path
+}
+
+func formatName(dirEntry *yang.Entry, isList bool, parentPrefix string, parentPath string) string {
+	prefix := ""
+	if dirEntry.Prefix != nil {
+		prefix = dirEntry.Prefix.Name
+	}
+	var name string
+	if prefix == parentPrefix && isList {
+		name = fmt.Sprintf("%s/%s[%s=*]", parentPath, dirEntry.Name, dirEntry.Key)
+	} else if isList {
+		name = fmt.Sprintf("%s/%s:%s[%s=*]", parentPath, prefix, dirEntry.Name, dirEntry.Key)
+	} else if prefix == parentPrefix {
+		name = fmt.Sprintf("%s/%s", parentPath, dirEntry.Name)
+	} else {
+		name = fmt.Sprintf("%s/%s:%s", parentPath, prefix, dirEntry.Name)
+	}
+
+	return name
 }

--- a/pkg/manager/modelregistry_test.go
+++ b/pkg/manager/modelregistry_test.go
@@ -1,0 +1,138 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manager
+
+import (
+	"fmt"
+	td1 "github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+	"gotest.tools/assert"
+	"testing"
+)
+
+type modelPluginTest string
+
+const modelTypeTest = "TestModel"
+const modelVersionTest = "0.0.1"
+const moduleNameTest = "testmodel.so.1.0.0"
+
+var modelData = []*gnmi.ModelData{
+	{Name: "testmodel", Organization: "Open Networking Lab", Version: "2019-07-10"},
+}
+
+func (m modelPluginTest) ModelData() (string, string, []*gnmi.ModelData, string) {
+	return modelTypeTest, modelVersionTest, modelData, moduleNameTest
+}
+
+// UnmarshalConfigValues uses the `generated.go` of the TestDevice1 plugin module
+func (m modelPluginTest) UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoStruct, error) {
+	device := &td1.Device{}
+	vgs := ygot.ValidatedGoStruct(device)
+
+	if err := td1.Unmarshal([]byte(jsonTree), device); err != nil {
+		return nil, err
+	}
+
+	return &vgs, nil
+}
+
+// Validate uses the `generated.go` of the TestDevice1 plugin module
+func (m modelPluginTest) Validate(ygotModel *ygot.ValidatedGoStruct, opts ...ygot.ValidationOption) error {
+	deviceDeref := *ygotModel
+	device, ok := deviceDeref.(*td1.Device)
+	if !ok {
+		return fmt.Errorf("unable to convert model in to testdevice_1_0_0")
+	}
+	return device.Validate()
+}
+
+// Schema uses the `generated.go` of the TestDevice1 plugin module
+func (m modelPluginTest) Schema() (map[string]*yang.Entry, error) {
+	return td1.UnzipSchema()
+}
+
+func Test_CastModelPlugin(t *testing.T) {
+	var modelPluginTest modelPluginTest
+	mpt := interface{}(modelPluginTest)
+
+	modelPlugin, ok := mpt.(ModelPlugin)
+	assert.Assert(t, ok, "Testing cast of model plugin")
+	name, version, _, _ := modelPlugin.ModelData()
+	assert.Equal(t, name, modelTypeTest)
+	assert.Equal(t, version, modelVersionTest)
+
+}
+
+func Test_Schema(t *testing.T) {
+	var modelPluginTest modelPluginTest
+
+	td1Schema, err := modelPluginTest.Schema()
+	assert.NilError(t, err)
+	assert.Equal(t, len(td1Schema), 6)
+
+	readOnlyPaths := extractReadOnlyPaths(td1Schema["Device"], yang.TSUnset, "", "")
+	assert.Equal(t, len(readOnlyPaths), 6)
+	// Can be in any order
+	for _, p := range readOnlyPaths {
+		switch p {
+		case "/test1:cont1a/cont2a/leaf2c",
+			"/test1:cont1b-state",
+			"/test1:cont1b-state/leaf2d",
+			"/test1:cont1b-state/list2b[index=*]",
+			"/test1:cont1b-state/list2b[index=*]/index",
+			"/test1:cont1b-state/list2b[index=*]/leaf3c":
+		default:
+			t.Fatal("Unexpected readOnlyPath", p)
+		}
+	}
+}
+
+func Test_RemovePathIndices(t *testing.T) {
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state"),
+		"/test1:cont1b-state")
+
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state/list2b[index=test1]/index"),
+		"/test1:cont1b-state/list2b[index=*]/index")
+
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state/list2b[index=test1,test2]/index"),
+		"/test1:cont1b-state/list2b[index=*]/index")
+
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state/list2b[index=test1]/index/t3[name=5]"),
+		"/test1:cont1b-state/list2b[index=*]/index/t3[name=*]")
+
+}
+
+func Test_formatName1(t *testing.T) {
+	dirEntry1 := yang.Entry{
+		Name:   "testname",
+		Prefix: &yang.Value{Name: "pfx1"},
+	}
+	assert.Equal(t, formatName(&dirEntry1, false, "pfx1", "/pfx1:testpath/testpath2"), "/pfx1:testpath/testpath2/testname")
+}
+
+func Test_formatName2(t *testing.T) {
+	dirEntry1 := yang.Entry{
+		Name:   "testname",
+		Key:    "name",
+		Prefix: &yang.Value{Name: "pfx1"},
+	}
+	assert.Equal(t, formatName(&dirEntry1, true, "pfx1", "/pfx1:testpath/testpath2"), "/pfx1:testpath/testpath2/testname[name=*]")
+}

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -60,8 +60,7 @@ func (m *Manager) SetNetworkConfig(configName store.ConfigName, updates map[stri
 				configName, conv(similarDevices))
 		} else {
 			return nil, configName, fmt.Errorf("no configuration found matching '%s'."+
-				"Please specify version and device type in extensions 101 and 102 "+
-				"and model data in extensions 150-200 in name@ver@org format", configName)
+				"Please specify version and device type in extensions 101 and 102", configName)
 			// FIXME add in handler for actually dealing with getting version and type and modeldata
 		}
 	}


### PR DESCRIPTION
Should cause a set of a readonly value (e.g. leaf2c) to fail:
```
gnmi_cli -address localhost:5150 -set \
-proto "update: <path: <target: 'Device1', elem: <name: 'test1:cont1a'> elem: <name: 'cont2a'> elem: <name: 'leaf2c'>> val: <string_val: 'not allowed'>>" \
-timeout 5s -alsologtostderr \
-client_crt pkg/southbound/testdata/client1.crt \
-client_key pkg/southbound/testdata/client1.key \
-ca_crt pkg/southbound/testdata/onfca.crt
```