### PR TITLE
Query devices directly to make sure that changes were applied

### DIFF
--- a/test/env/env.go
+++ b/test/env/env.go
@@ -29,6 +29,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 )
 
 const (
@@ -63,6 +64,7 @@ func GetCredentials() (*tls.Config, error) {
 	return &tls.Config{
 		RootCAs:      certPool,
 		Certificates: []tls.Certificate{cert},
+		InsecureSkipVerify: true,
 	}, nil
 }
 
@@ -76,12 +78,36 @@ func GetDestination(target string) (client.Destination, error) {
 		Addrs:  []string{address},
 		Target: target,
 		TLS:    tlsConfig,
+		Timeout:  10 * time.Second,
+	}, nil
+}
+
+// GetDestinationForDevice returns a gNMI client destination for the test environment
+func GetDestinationForDevice(addr string, target string) (client.Destination, error) {
+	tlsConfig, err := GetCredentials()
+	if err != nil {
+		return client.Destination{}, err
+	}
+	return client.Destination{
+		Addrs:  []string{addr},
+		Target: target,
+		TLS:    tlsConfig,
+		Timeout:  10 * time.Second,
 	}, nil
 }
 
 // NewGnmiClient returns a new gNMI client for the test environment
 func NewGnmiClient(ctx context.Context, target string) (client.Impl, error) {
 	dest, err := GetDestination(target)
+	if err != nil {
+		return nil, err
+	}
+	return gnmi.New(ctx, dest)
+}
+
+// NewGnmiClientForDevice returns a new gNMI client for the test environment
+func NewGnmiClientForDevice(ctx context.Context, address string, target string) (client.Impl, error) {
+	dest, err := GetDestinationForDevice(address, target)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -19,6 +19,7 @@ import (
 	admin "github.com/onosproject/onos-config/pkg/northbound/proto"
 	"github.com/onosproject/onos-config/test/env"
 	"github.com/onosproject/onos-config/test/runner"
+	"github.com/openconfig/gnmi/client"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -39,52 +40,83 @@ func init() {
 	Registry.RegisterTest("transaction", TestTransaction, []*runner.TestSuite{AllTests,SomeTests,IntegrationTests})
 }
 
-func getDevicePaths(device string, paths []string) []DevicePath {
-	var devicePaths = make([]DevicePath, len(paths))
-	for pathIndex, path := range paths {
-		devicePaths[pathIndex].deviceName = device
-		devicePaths[pathIndex].path = path
+func getDevicePaths(devices []string, paths []string) []DevicePath {
+	var devicePaths = make([]DevicePath, len(paths) * len(devices))
+	pathIndex := 0
+	for _, device := range devices {
+		for _, path := range paths {
+			devicePaths[pathIndex].deviceName = device
+			devicePaths[pathIndex].path = path
+			pathIndex++
+		}
 	}
 	return devicePaths
 }
 
-func getDevicePathsWithValues(device string, paths []string, values[]string) []DevicePath {
-	var devicePaths = getDevicePaths(device, paths)
-	for valueIndex, value := range values {
-		devicePaths[valueIndex].value = value
+func getDevicePathsWithValues(devices []string, paths []string, values[]string) []DevicePath {
+	var devicePaths = getDevicePaths(devices, paths)
+	valueIndex := 0
+	for range devices {
+		for _, value := range values {
+			devicePaths[valueIndex].value = value
+			valueIndex++
+		}
 	}
 	return devicePaths
+}
+
+func checkDeviceValue(t *testing.T, deviceGnmiClient client.Impl, devicePaths []DevicePath, expectedValue string) {
+	deviceValues, deviceValuesError := GNMIGet(MakeContext(), deviceGnmiClient, devicePaths)
+	assert.NoError(t, deviceValuesError, "GNMI get operation to device returned an error")
+	assert.Equal(t, expectedValue, deviceValues[0].value, "Query after set returned the wrong value: %s\n", expectedValue)
+}
+
+func getDeviceGNMIClient(t *testing.T, device string) client.Impl {
+	deviceGnmiClient, deviceGnmiClientError := env.NewGnmiClientForDevice(MakeContext(), device + ":10161", "gnmi")
+	assert.NoError(t, deviceGnmiClientError)
+	assert.True(t, deviceGnmiClient != nil, "Fetching device client returned nil")
+	return deviceGnmiClient
 }
 
 // TestTransaction tests setting multiple paths in a single request and rolling it back
 func TestTransaction(t *testing.T) {
-	// Get the first configured device from the environment.
-	device := env.GetDevices()[0]
+	// Get the configured devices from the environment.
+	device1 := env.GetDevices()[0]
+	device2 := env.GetDevices()[1]
+	devices := make([]string, 2)
+	devices[0] = device1
+	devices[1] = device2
 
 	// Make a GNMI client to use for requests
-	gnmiClient, gnmiClientError := env.NewGnmiClient(MakeContext(), "")
+	gnmiClient, gnmiClientError := env.NewGnmiClient(MakeContext(), "gnmi")
 	assert.NoError(t, gnmiClientError)
 	assert.True(t, gnmiClient != nil, "Fetching client returned nil")
 
 	// Set values
-	var devicePathsForSet = getDevicePathsWithValues(device, paths, values)
-
+	var devicePathsForSet = getDevicePathsWithValues(devices, paths, values)
 	changeID, errorSet := GNMISet(MakeContext(), gnmiClient, devicePathsForSet)
 	assert.NoError(t, errorSet)
 	assert.True(t, changeID != "")
 
-	var devicePathsForGet = getDevicePaths(device, paths)
-
 	// Check that the values were set correctly
+	var devicePathsForGet = getDevicePaths(devices, paths)
 	getValuesAfterSet, getValueAfterSetError := GNMIGet(MakeContext(), gnmiClient, devicePathsForGet)
-	assert.NoError(t, getValueAfterSetError, "GNMI set operation returned an error")
+	assert.NoError(t, getValueAfterSetError, "GNMI get operation returned an error")
 	assert.NotEqual(t, "", getValuesAfterSet, "Query after set returned an error: %s\n", getValueAfterSetError)
 	assert.Equal(t, value1, getValuesAfterSet[0].value, "Query after set returned the wrong value: %s\n", getValuesAfterSet)
 	assert.Equal(t, value2, getValuesAfterSet[1].value, "Query after set 2 returned the wrong value: %s\n", getValuesAfterSet)
 
+	// Check that the values are set on the devices
+	device1GnmiClient := getDeviceGNMIClient(t, device1)
+	device2GnmiClient := getDeviceGNMIClient(t, device2)
+
+	checkDeviceValue(t, device1GnmiClient, devicePathsForGet[0:1], value1)
+	checkDeviceValue(t, device1GnmiClient, devicePathsForGet[1:2], value2)
+	checkDeviceValue(t, device2GnmiClient, devicePathsForGet[2:3], value1)
+	checkDeviceValue(t, device2GnmiClient, devicePathsForGet[3:4], value2)
+
 	// Now rollback the change
 	_, adminClient := env.GetAdminClient()
-
 	rollbackResponse, rollbackError := adminClient.RollbackNetworkChange(
 		context.Background(), &admin.RollbackRequest{Name: changeID})
 


### PR DESCRIPTION
After setting paths through the GNMI onos-config interface, check that the devices were updated.