### PR TITLE
State and Operational paths from model

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -186,8 +186,9 @@ func (m *Manager) Run() {
 	go m.Dispatcher.ListenOperationalState(m.OperationalStateChannel)
 	// Listening for errors in the Southbound
 	go listenOnResponseChannel(m.SouthboundErrorChan)
+	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
 	go synchronizer.Factory(m.ChangeStore, m.ConfigStore, m.DeviceStore, m.TopoChannel,
-		m.OperationalStateChannel, m.SouthboundErrorChan, &m.Dispatcher)
+		m.OperationalStateChannel, m.SouthboundErrorChan, &m.Dispatcher, m.ModelReadOnlyPaths)
 }
 
 //Close kills the channels and manager related objects

--- a/pkg/manager/modelregistry.go
+++ b/pkg/manager/modelregistry.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -54,7 +55,7 @@ func (m *Manager) RegisterModelPlugin(moduleName string) (string, string, error)
 			moduleName)
 	}
 	name, version, _, _ := modelPlugin.ModelData()
-	modelName := ToModelName(name, version)
+	modelName := utils.ToModelName(name, version)
 	m.ModelRegistry[modelName] = modelPlugin
 	modelschema, err := modelPlugin.Schema()
 	if err != nil {
@@ -77,7 +78,7 @@ func (m *Manager) Capabilities() []*gnmi.ModelData {
 	for _, model := range m.ModelRegistry {
 		_, _, modelItem, _ := model.ModelData()
 		for _, mi := range modelItem {
-			modelName := ToModelName(mi.Name, mi.Version)
+			modelName := utils.ToModelName(mi.Name, mi.Version)
 			modelMap[modelName] = mi
 		}
 	}
@@ -127,11 +128,6 @@ func extractReadOnlyPaths(deviceEntry *yang.Entry, parentState yang.TriState, pa
 	}
 
 	return readOnlyPaths
-}
-
-// ToModelName simply joins together model name and version in a consistent way
-func ToModelName(name string, version string) string {
-	return fmt.Sprintf("%s-%s", name, version)
 }
 
 // RemovePathIndices removes the index value from a path to allow it to be compared to a model path

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -189,7 +189,7 @@ func (s *Server) checkForReadOnly(deviceType string, version string, targetUpdat
 		}
 		for _, config := range configs {
 			if config.Device == t {
-				m, ok := manager.GetManager().ModelReadOnlyPaths[manager.ToModelName(config.Type, config.Version)]
+				m, ok := manager.GetManager().ModelReadOnlyPaths[utils.ToModelName(config.Type, config.Version)]
 				if !ok {
 					log.Warningf("Cannot check for Read Only paths for %s %s because "+
 						"Model Plugin not available - continuing", config.Type, config.Version)
@@ -205,7 +205,7 @@ func (s *Server) checkForReadOnly(deviceType string, version string, targetUpdat
 		}
 		for _, config := range configs {
 			if config.Device == t {
-				m, ok := manager.GetManager().ModelReadOnlyPaths[manager.ToModelName(config.Type, config.Version)]
+				m, ok := manager.GetManager().ModelReadOnlyPaths[utils.ToModelName(config.Type, config.Version)]
 				if !ok {
 					log.Warningf("Cannot check for Read Only paths for %s %s because "+
 						"Model Plugin not available - continuing", config.Type, config.Version)

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
+	"github.com/onosproject/onos-config/pkg/utils"
 	log "k8s.io/klog"
 )
 
@@ -38,8 +39,11 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 			}
 			device := deviceStore.Store[topocache.ID(deviceName)]
 			ctx := context.Background()
+			completeID := utils.ToConfigName(deviceName, device.SoftwareVersion)
+			cfg := configStore.Store[store.ConfigName(completeID)]
+			mReadOnlyPaths, _ := modelReadOnlyPaths[utils.ToModelName(cfg.Type, device.SoftwareVersion)]
 			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan,
-				errChan, modelReadOnlyPaths)
+				errChan, mReadOnlyPaths)
 			if err != nil {
 				log.Error("Error in connecting to client: ", err)
 				errChan <- events.CreateErrorEventNoChangeID(events.EventTypeErrorDeviceConnect,

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -41,7 +41,11 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 			ctx := context.Background()
 			completeID := utils.ToConfigName(deviceName, device.SoftwareVersion)
 			cfg := configStore.Store[store.ConfigName(completeID)]
-			mReadOnlyPaths, _ := modelReadOnlyPaths[utils.ToModelName(cfg.Type, device.SoftwareVersion)]
+			mReadOnlyPaths, ok := modelReadOnlyPaths[utils.ToModelName(cfg.Type, device.SoftwareVersion)]
+			if !ok {
+				log.Warningf("Cannot check for read only paths for target %s with %s because "+
+					"Model Plugin not available - continuing", deviceName, device.SoftwareVersion)
+			}
 			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan,
 				errChan, mReadOnlyPaths)
 			if err != nil {

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -28,7 +28,7 @@ import (
 // These synchronizers then listen out for configEvents relative to a device and
 func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationStore, deviceStore *topocache.DeviceStore,
 	topoChannel <-chan events.TopoEvent, opStateChan chan<- events.OperationalStateEvent,
-	errChan chan<- events.DeviceResponse, dispatcher *dispatcher.Dispatcher) {
+	errChan chan<- events.DeviceResponse, dispatcher *dispatcher.Dispatcher, modelReadOnlyPaths map[string][]string) {
 	for topoEvent := range topoChannel {
 		deviceName := topocache.ID(events.Event(topoEvent).Subject())
 		if !dispatcher.HasListener(deviceName) && topoEvent.Connect() {
@@ -38,7 +38,8 @@ func Factory(changeStore *store.ChangeStore, configStore *store.ConfigurationSto
 			}
 			device := deviceStore.Store[topocache.ID(deviceName)]
 			ctx := context.Background()
-			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan, errChan)
+			sync, err := New(ctx, changeStore, configStore, &device, configChan, opStateChan,
+				errChan, modelReadOnlyPaths)
 			if err != nil {
 				log.Error("Error in connecting to client: ", err)
 				errChan <- events.CreateErrorEventNoChangeID(events.EventTypeErrorDeviceConnect,

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -180,29 +180,29 @@ func (sync Synchronizer) syncOperationalState(errChan chan<- events.DeviceRespon
 
 	notifications := make([]*gnmi.Notification, 0)
 
-	//requestState := &gnmi.GetRequest{
-	//	Type: gnmi.GetRequest_STATE,
-	//}
-	//
-	//responseState, errState := target.Get(target.Ctx, requestState)
-	//
-	//if errState != nil {
-	//	log.Warning("Can't request read-only state paths to target ", sync.key, errState)
-	//} else {
-	//	notifications = append(notifications, responseState.Notification...)
-	//}
-	//
-	//requestOperational := &gnmi.GetRequest{
-	//	Type: gnmi.GetRequest_OPERATIONAL,
-	//}
-	//
-	//responseOperational, errOp := target.Get(target.Ctx, requestOperational)
-	//
-	//if errOp != nil {
-	//	log.Warning("Can't request read-only operational paths to target ", sync.key, errOp)
-	//} else {
-	//	notifications = append(notifications, responseOperational.Notification...)
-	//}
+	requestState := &gnmi.GetRequest{
+		Type: gnmi.GetRequest_STATE,
+	}
+
+	responseState, errState := target.Get(target.Ctx, requestState)
+
+	if errState != nil {
+		log.Warning("Can't request read-only state paths to target ", sync.key, errState)
+	} else {
+		notifications = append(notifications, responseState.Notification...)
+	}
+
+	requestOperational := &gnmi.GetRequest{
+		Type: gnmi.GetRequest_OPERATIONAL,
+	}
+
+	responseOperational, errOp := target.Get(target.Ctx, requestOperational)
+
+	if errOp != nil {
+		log.Warning("Can't request read-only operational paths to target ", sync.key, errOp)
+	} else {
+		notifications = append(notifications, responseOperational.Notification...)
+	}
 
 	subscribePaths := make([][]string, 0)
 

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -44,12 +44,13 @@ type Synchronizer struct {
 	key                  southbound.DeviceID
 	query                client.Query
 	operationalCache     map[string]string
+	modelReadOnlyPaths   map[string][]string
 }
 
 // New Build a new Synchronizer given the parameters, starts the connection with the device and polls the capabilities
 func New(context context.Context, changeStore *store.ChangeStore, configStore *store.ConfigurationStore,
-	device *topocache.Device, deviceCfgChan <-chan events.ConfigEvent,
-	opStateChan chan<- events.OperationalStateEvent, errChan chan<- events.DeviceResponse) (*Synchronizer, error) {
+	device *topocache.Device, deviceCfgChan <-chan events.ConfigEvent, opStateChan chan<- events.OperationalStateEvent,
+	errChan chan<- events.DeviceResponse, mReadOnlyPaths map[string][]string) (*Synchronizer, error) {
 	sync := &Synchronizer{
 		Context:              context,
 		ChangeStore:          changeStore,
@@ -58,6 +59,7 @@ func New(context context.Context, changeStore *store.ChangeStore, configStore *s
 		deviceConfigChan:     deviceCfgChan,
 		operationalStateChan: opStateChan,
 		operationalCache:     make(map[string]string),
+		modelReadOnlyPaths:   mReadOnlyPaths,
 	}
 	log.Info("Connecting to ", sync.Device.Addr, " over gNMI")
 	target := southbound.Target{}
@@ -215,26 +217,17 @@ func (sync Synchronizer) syncOperationalState(errChan chan<- events.DeviceRespon
 
 		}
 	} else {
-		//TODO implement getting paths here leaving commented for examples of what works.
-		//path := make([]string, 0)
-		//Stratum
-		//path = append(path, "interfaces")
-		//path = append(path, "interface[name=s1-eth1]")
-		//path = append(path, "state")
-		//path = append(path, "admin-status")
-		//path = append(path, "config")
-		//path = append(path, "enabled")
-
-		//Simulator
-		//path = append(path, "system")
-		//path = append(path, "openflow")
-		//path = append(path, "controllers")
-		//path = append(path, "controller[name=main]")
-		//path = append(path, "connections")
-		//path = append(path, "connection[aux-id=0]")
-		//path = append(path, "state")
-		//path = append(path, "address")
-		//subscribePaths = append(subscribePaths, path)
+		completeID := utils.ToConfigName(sync.ID, sync.SoftwareVersion)
+		cfg := sync.ConfigurationStore.Store[store.ConfigName(completeID)]
+		m, ok := sync.modelReadOnlyPaths[utils.ToModelName(cfg.Type, sync.Device.SoftwareVersion)]
+		if !ok {
+			log.Warningf("Cannot check for Read Only paths for %s %s because "+
+				"Model Plugin not available - continuing", cfg.Type, sync.Device.SoftwareVersion)
+		} else {
+			for _, path := range m {
+				subscribePaths = append(subscribePaths, utils.SplitPath(path))
+			}
+		}
 	}
 
 	if len(subscribePaths) == 0 {

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -216,15 +216,9 @@ func (sync Synchronizer) syncOperationalState(errChan chan<- events.DeviceRespon
 			}
 
 		}
-	} else {
-
-		if sync.modelReadOnlyPaths == nil {
-			log.Warningf("Cannot check for read only paths for target %s with %s because "+
-				"Model Plugin not available - continuing", sync.Device.ID, sync.Device.SoftwareVersion)
-		} else {
-			for _, path := range sync.modelReadOnlyPaths {
-				subscribePaths = append(subscribePaths, utils.SplitPath(path))
-			}
+	} else if sync.modelReadOnlyPaths != nil {
+		for _, path := range sync.modelReadOnlyPaths {
+			subscribePaths = append(subscribePaths, utils.SplitPath(path))
 		}
 	}
 

--- a/pkg/utils/idUtils.go
+++ b/pkg/utils/idUtils.go
@@ -25,7 +25,7 @@ func ToModelName(name string, version string) string {
 	return fmt.Sprintf("%s-%s", name, version)
 }
 
-// ToConfigName simply joins together model name and version in a consistent way
+// ToConfigName simply joins together device ID and version in a consistent way
 func ToConfigName(deviceID topocache.ID, version string) string {
 	return fmt.Sprintf("%s-%s", deviceID, version)
 }

--- a/pkg/utils/idUtils.go
+++ b/pkg/utils/idUtils.go
@@ -1,0 +1,31 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils implements various gNMI path manipulation facilities.
+package utils
+
+import (
+	"fmt"
+	"github.com/onosproject/onos-config/pkg/southbound/topocache"
+)
+
+// ToModelName simply joins together model name and version in a consistent way
+func ToModelName(name string, version string) string {
+	return fmt.Sprintf("%s-%s", name, version)
+}
+
+// ToConfigName simply joins together model name and version in a consistent way
+func ToConfigName(deviceID topocache.ID, version string) string {
+	return fmt.Sprintf("%s-%s", deviceID, version)
+}


### PR DESCRIPTION
Leveraging models to obtain state and operational paths to subscribe to in case the device does not give a reply to STATE or OPERATIONAL get requests. 