### PR TITLE
Extracting model registry as first entity object

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/events"
+	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/southbound/synchronizer"
 	"github.com/onosproject/onos-config/pkg/southbound/topocache"
 	"github.com/onosproject/onos-config/pkg/store"
@@ -36,31 +37,41 @@ type Manager struct {
 	ChangeStore             *store.ChangeStore
 	DeviceStore             *topocache.DeviceStore
 	NetworkStore            *store.NetworkStore
+	ModelRegistryObj        *modelregistry.ModelRegistry
 	TopoChannel             chan events.TopoEvent
 	ChangesChannel          chan events.ConfigEvent
 	OperationalStateChannel chan events.OperationalStateEvent
 	SouthboundErrorChan     chan events.DeviceResponse
 	Dispatcher              dispatcher.Dispatcher
-	ModelRegistry           map[string]ModelPlugin
-	ModelReadOnlyPaths      map[string][]string
+	//TODO remove
+	ModelRegistry      map[string]ModelPlugin
+	ModelReadOnlyPaths map[string][]string
 }
 
 // NewManager initializes the network config manager subsystem.
 func NewManager(configs *store.ConfigurationStore, changes *store.ChangeStore, device *topocache.DeviceStore,
 	network *store.NetworkStore, topoCh chan events.TopoEvent) (*Manager, error) {
 	log.Info("Creating Manager")
+	modelReg := &modelregistry.ModelRegistry{
+		ModelPlugins:       make(map[string]modelregistry.ModelPlugin),
+		ModelReadOnlyPaths: make(map[string][]string),
+		LocationStore:      make(map[string]string),
+	}
+
 	mgr = Manager{
 		ConfigStore:             configs,
 		ChangeStore:             changes,
 		DeviceStore:             device,
 		NetworkStore:            network,
 		TopoChannel:             topoCh,
+		ModelRegistryObj:        modelReg,
 		ChangesChannel:          make(chan events.ConfigEvent, 10),
 		OperationalStateChannel: make(chan events.OperationalStateEvent, 10),
 		SouthboundErrorChan:     make(chan events.DeviceResponse, 10),
 		Dispatcher:              dispatcher.NewDispatcher(),
-		ModelRegistry:           make(map[string]ModelPlugin),
-		ModelReadOnlyPaths:      make(map[string][]string),
+		//TODO remove
+		ModelRegistry:      make(map[string]ModelPlugin),
+		ModelReadOnlyPaths: make(map[string][]string),
 	}
 
 	changeIds := make([]string, 0)

--- a/pkg/modelregistry/modelregistry.go
+++ b/pkg/modelregistry/modelregistry.go
@@ -1,0 +1,171 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelregistry
+
+import (
+	"fmt"
+	"github.com/onosproject/onos-config/pkg/utils"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+	log "k8s.io/klog"
+	"plugin"
+	"regexp"
+	"strings"
+)
+
+// ModelRegistry is the object for the saving information about device models
+type ModelRegistry struct {
+	ModelPlugins       map[string]ModelPlugin
+	ModelReadOnlyPaths map[string][]string
+	LocationStore      []string
+}
+
+// ModelPlugin is a set of methods that each model plugin should implement
+type ModelPlugin interface {
+	ModelData() (string, string, []*gnmi.ModelData, string)
+	UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoStruct, error)
+	Validate(*ygot.ValidatedGoStruct, ...ygot.ValidationOption) error
+	Schema() (map[string]*yang.Entry, error)
+}
+
+// RegisterModelPlugin adds an external model plugin to the model registry at startup
+// or through the 'admin' gRPC interface. Once plugins are loaded they cannot be unloaded
+func (registry *ModelRegistry) RegisterModelPlugin(moduleName string) (string, string, error) {
+	log.Info("Loading module ", moduleName)
+	modelPluginModule, err := plugin.Open(moduleName)
+	if err != nil {
+		log.Warning("Unable to load module ", moduleName)
+		return "", "", err
+	}
+	symbolMP, err := modelPluginModule.Lookup("ModelPlugin")
+	if err != nil {
+		log.Warning("Unable to find ModelPlugin in module ", moduleName)
+		return "", "", err
+	}
+	modelPlugin, ok := symbolMP.(ModelPlugin)
+	if !ok {
+		log.Warning("Unable to use ModelPlugin in ", moduleName)
+		return "", "", fmt.Errorf("symbol loaded from module %s is not a ModelPlugin",
+			moduleName)
+	}
+	//Saving the model plugin name in a distributed list for other instances to access it.
+	registry.LocationStore = append(registry.LocationStore, moduleName)
+
+	name, version, _, _ := modelPlugin.ModelData()
+	modelName := utils.ToModelName(name, version)
+	registry.ModelPlugins[modelName] = modelPlugin
+	modelschema, err := modelPlugin.Schema()
+	if err != nil {
+		log.Warning("Error loading schema from model plugin", modelName, err)
+		return "", "", err
+	}
+
+	registry.ModelReadOnlyPaths[modelName] = extractReadOnlyPaths(modelschema["Device"],
+		yang.TSUnset, "", "")
+	log.Infof("Model %s %s loaded. %d read only paths", name, version,
+		len(registry.ModelReadOnlyPaths[modelName]))
+	return name, version, nil
+}
+
+// Capabilities returns an aggregated set of modelData in gNMI capabilities format
+// with duplicates removed
+func (registry *ModelRegistry) Capabilities() []*gnmi.ModelData {
+	// Make a map - if we get duplicates overwrite them
+	modelMap := make(map[string]*gnmi.ModelData)
+	for _, model := range registry.ModelPlugins {
+		_, _, modelItem, _ := model.ModelData()
+		for _, mi := range modelItem {
+			modelName := utils.ToModelName(mi.Name, mi.Version)
+			modelMap[modelName] = mi
+		}
+	}
+
+	outputList := make([]*gnmi.ModelData, len(modelMap))
+	i := 0
+	for _, modelItem := range modelMap {
+		outputList[i] = modelItem
+		i++
+	}
+	return outputList
+}
+
+// extractReadOnlyPaths is a recursive function to extract a list of read only paths from a YGOT schema
+func extractReadOnlyPaths(deviceEntry *yang.Entry, parentState yang.TriState, parentPrefix string, parentPath string) []string {
+	readOnlyPaths := make([]string, 0)
+
+	for _, dirEntry := range deviceEntry.Dir {
+		prefix := ""
+		if dirEntry.Prefix != nil {
+			prefix = dirEntry.Prefix.Name
+		}
+		itemPath := formatName(dirEntry, false, parentPrefix, parentPath)
+		if dirEntry.IsLeaf() {
+			// No need to recurse
+			if dirEntry.Config == yang.TSFalse || parentState == yang.TSFalse {
+				readOnlyPaths = append(readOnlyPaths, itemPath)
+			}
+		} else if dirEntry.IsContainer() {
+			if dirEntry.Config == yang.TSFalse || parentState == yang.TSFalse {
+				readOnlyPaths = append(readOnlyPaths, itemPath)
+			}
+			newPaths := extractReadOnlyPaths(dirEntry, dirEntry.Config, prefix, itemPath)
+			for _, newPath := range newPaths {
+				readOnlyPaths = append(readOnlyPaths, newPath)
+			}
+		} else if dirEntry.IsList() {
+			itemPath = formatName(dirEntry, true, parentPrefix, parentPath)
+			if dirEntry.Config == yang.TSFalse || parentState == yang.TSFalse {
+				readOnlyPaths = append(readOnlyPaths, itemPath)
+			}
+			newPaths := extractReadOnlyPaths(dirEntry, dirEntry.Config, prefix, itemPath)
+			for _, newPath := range newPaths {
+				readOnlyPaths = append(readOnlyPaths, newPath)
+			}
+		}
+	}
+
+	return readOnlyPaths
+}
+
+// RemovePathIndices removes the index value from a path to allow it to be compared to a model path
+func RemovePathIndices(path string) string {
+	const indexPattern = `=.*?]`
+	rname := regexp.MustCompile(indexPattern)
+	indices := rname.FindAllStringSubmatch(path, -1)
+	for _, i := range indices {
+		path = strings.Replace(path, i[0], "=*]", 1)
+	}
+	return path
+}
+
+func formatName(dirEntry *yang.Entry, isList bool, parentPrefix string, parentPath string) string {
+	prefix := ""
+	if dirEntry.Prefix != nil {
+		prefix = dirEntry.Prefix.Name
+	}
+	var name string
+	if prefix == parentPrefix && isList {
+		name = fmt.Sprintf("%s/%s[%s=*]", parentPath, dirEntry.Name, dirEntry.Key)
+	} else if isList {
+		name = fmt.Sprintf("%s/%s:%s[%s=*]", parentPath, prefix, dirEntry.Name, dirEntry.Key)
+	} else if prefix == parentPrefix {
+		name = fmt.Sprintf("%s/%s", parentPath, dirEntry.Name)
+	} else {
+		name = fmt.Sprintf("%s/%s:%s", parentPath, prefix, dirEntry.Name)
+	}
+
+	return name
+}

--- a/pkg/modelregistry/modelregistry.go
+++ b/pkg/modelregistry/modelregistry.go
@@ -30,7 +30,7 @@ import (
 type ModelRegistry struct {
 	ModelPlugins       map[string]ModelPlugin
 	ModelReadOnlyPaths map[string][]string
-	LocationStore      []string
+	LocationStore      map[string]string
 }
 
 // ModelPlugin is a set of methods that each model plugin should implement
@@ -61,12 +61,11 @@ func (registry *ModelRegistry) RegisterModelPlugin(moduleName string) (string, s
 		return "", "", fmt.Errorf("symbol loaded from module %s is not a ModelPlugin",
 			moduleName)
 	}
-	//Saving the model plugin name in a distributed list for other instances to access it.
-	registry.LocationStore = append(registry.LocationStore, moduleName)
-
 	name, version, _, _ := modelPlugin.ModelData()
 	modelName := utils.ToModelName(name, version)
 	registry.ModelPlugins[modelName] = modelPlugin
+	//Saving the model plugin name and library name in a distributed list for other instances to access it.
+	registry.LocationStore[modelName] = moduleName
 	modelschema, err := modelPlugin.Schema()
 	if err != nil {
 		log.Warning("Error loading schema from model plugin", modelName, err)

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -1,0 +1,138 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package modelregistry
+
+import (
+	"fmt"
+	td1 "github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/goyang/pkg/yang"
+	"github.com/openconfig/ygot/ygot"
+	"gotest.tools/assert"
+	"testing"
+)
+
+type modelPluginTest string
+
+const modelTypeTest = "TestModel"
+const modelVersionTest = "0.0.1"
+const moduleNameTest = "testmodel.so.1.0.0"
+
+var modelData = []*gnmi.ModelData{
+	{Name: "testmodel", Organization: "Open Networking Lab", Version: "2019-07-10"},
+}
+
+func (m modelPluginTest) ModelData() (string, string, []*gnmi.ModelData, string) {
+	return modelTypeTest, modelVersionTest, modelData, moduleNameTest
+}
+
+// UnmarshalConfigValues uses the `generated.go` of the TestDevice1 plugin module
+func (m modelPluginTest) UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoStruct, error) {
+	device := &td1.Device{}
+	vgs := ygot.ValidatedGoStruct(device)
+
+	if err := td1.Unmarshal([]byte(jsonTree), device); err != nil {
+		return nil, err
+	}
+
+	return &vgs, nil
+}
+
+// Validate uses the `generated.go` of the TestDevice1 plugin module
+func (m modelPluginTest) Validate(ygotModel *ygot.ValidatedGoStruct, opts ...ygot.ValidationOption) error {
+	deviceDeref := *ygotModel
+	device, ok := deviceDeref.(*td1.Device)
+	if !ok {
+		return fmt.Errorf("unable to convert model in to testdevice_1_0_0")
+	}
+	return device.Validate()
+}
+
+// Schema uses the `generated.go` of the TestDevice1 plugin module
+func (m modelPluginTest) Schema() (map[string]*yang.Entry, error) {
+	return td1.UnzipSchema()
+}
+
+func Test_CastModelPlugin(t *testing.T) {
+	var modelPluginTest modelPluginTest
+	mpt := interface{}(modelPluginTest)
+
+	modelPlugin, ok := mpt.(ModelPlugin)
+	assert.Assert(t, ok, "Testing cast of model plugin")
+	name, version, _, _ := modelPlugin.ModelData()
+	assert.Equal(t, name, modelTypeTest)
+	assert.Equal(t, version, modelVersionTest)
+
+}
+
+func Test_Schema(t *testing.T) {
+	var modelPluginTest modelPluginTest
+
+	td1Schema, err := modelPluginTest.Schema()
+	assert.NilError(t, err)
+	assert.Equal(t, len(td1Schema), 6)
+
+	readOnlyPaths := extractReadOnlyPaths(td1Schema["Device"], yang.TSUnset, "", "")
+	assert.Equal(t, len(readOnlyPaths), 6)
+	// Can be in any order
+	for _, p := range readOnlyPaths {
+		switch p {
+		case "/test1:cont1a/cont2a/leaf2c",
+			"/test1:cont1b-state",
+			"/test1:cont1b-state/leaf2d",
+			"/test1:cont1b-state/list2b[index=*]",
+			"/test1:cont1b-state/list2b[index=*]/index",
+			"/test1:cont1b-state/list2b[index=*]/leaf3c":
+		default:
+			t.Fatal("Unexpected readOnlyPath", p)
+		}
+	}
+}
+
+func Test_RemovePathIndices(t *testing.T) {
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state"),
+		"/test1:cont1b-state")
+
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state/list2b[index=test1]/index"),
+		"/test1:cont1b-state/list2b[index=*]/index")
+
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state/list2b[index=test1,test2]/index"),
+		"/test1:cont1b-state/list2b[index=*]/index")
+
+	assert.Equal(t,
+		RemovePathIndices("/test1:cont1b-state/list2b[index=test1]/index/t3[name=5]"),
+		"/test1:cont1b-state/list2b[index=*]/index/t3[name=*]")
+
+}
+
+func Test_formatName1(t *testing.T) {
+	dirEntry1 := yang.Entry{
+		Name:   "testname",
+		Prefix: &yang.Value{Name: "pfx1"},
+	}
+	assert.Equal(t, formatName(&dirEntry1, false, "pfx1", "/pfx1:testpath/testpath2"), "/pfx1:testpath/testpath2/testname")
+}
+
+func Test_formatName2(t *testing.T) {
+	dirEntry1 := yang.Entry{
+		Name:   "testname",
+		Key:    "name",
+		Prefix: &yang.Value{Name: "pfx1"},
+	}
+	assert.Equal(t, formatName(&dirEntry1, true, "pfx1", "/pfx1:testpath/testpath2"), "/pfx1:testpath/testpath2/testname[name=*]")
+}


### PR DESCRIPTION
To avoid circular dependencies we are extracting the model registry as a first entity object.
The patch also adds a location list with the names of the loaded .so files for the model plugins.
This map will be replicated in `atomix` for other instances of `onos-config` to access it and keep state in check. 