### PR TITLE
Race test fix

### DIFF
--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -38,8 +38,8 @@ type Dispatcher struct {
 }
 
 // NewDispatcher creates and initializes a new event dispatcher
-func NewDispatcher() Dispatcher {
-	return Dispatcher{
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{
 		deviceListeners:        make(map[topocache.ID]chan events.ConfigEvent),
 		nbiListeners:           make(map[string]chan events.ConfigEvent),
 		nbiOpStateListeners:    make(map[string]chan events.OperationalStateEvent),
@@ -133,6 +133,7 @@ func (d *Dispatcher) UnregisterDevice(id topocache.ID) error {
 	if !ok {
 		return fmt.Errorf("Subscriber %s had not been registered", id)
 	}
+	//Accessing device listener in concurrency with Listen()
 	delete(d.deviceListeners, id)
 	close(channel)
 	respChan, ok := d.deviceResponseListener[id]

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -53,7 +53,7 @@ func setUp() *Dispatcher {
 	device2Channel, respChannel2, err = d.RegisterDevice(device2.ID)
 	device3Channel, respChannel3, err = d.RegisterDevice(device3.ID)
 	optStateChannel, err = d.RegisterOpState(opStateTest)
-	return &d
+	return d
 }
 
 func tearDown(d *Dispatcher) {
@@ -146,6 +146,7 @@ func Test_unregister(t *testing.T) {
 
 func Test_listen_device(t *testing.T) {
 	d := setUp()
+	defer tearDown(d)
 	changes := make(map[string]bool)
 	// Start the main listener system
 	go testSync(device1Channel, changes)
@@ -161,7 +162,7 @@ func Test_listen_device(t *testing.T) {
 
 	// Wait for the changes to get distributed
 	time.Sleep(time.Second)
-	tearDown(d)
+
 }
 
 func Test_listen_nbi(t *testing.T) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -42,7 +42,7 @@ type Manager struct {
 	ChangesChannel          chan events.ConfigEvent
 	OperationalStateChannel chan events.OperationalStateEvent
 	SouthboundErrorChan     chan events.DeviceResponse
-	Dispatcher              dispatcher.Dispatcher
+	Dispatcher              *dispatcher.Dispatcher
 	OperationalStateCache   map[topocache.ID]change.TypedValueMap
 }
 
@@ -223,7 +223,7 @@ func (m *Manager) Run() {
 	go listenOnResponseChannel(m.SouthboundErrorChan)
 	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
 	go synchronizer.Factory(m.ChangeStore, m.ConfigStore, m.DeviceStore, m.TopoChannel,
-		m.OperationalStateChannel, m.SouthboundErrorChan, &m.Dispatcher, m.ModelRegistry.ModelReadOnlyPaths, m.OperationalStateCache)
+		m.OperationalStateChannel, m.SouthboundErrorChan, m.Dispatcher, m.ModelRegistry.ModelReadOnlyPaths,  m.OperationalStateCache)
 }
 
 //Close kills the channels and manager related objects

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -223,7 +223,7 @@ func (m *Manager) Run() {
 	go listenOnResponseChannel(m.SouthboundErrorChan)
 	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
 	go synchronizer.Factory(m.ChangeStore, m.ConfigStore, m.DeviceStore, m.TopoChannel,
-		m.OperationalStateChannel, m.SouthboundErrorChan, m.Dispatcher, m.ModelRegistry.ModelReadOnlyPaths,  m.OperationalStateCache)
+		m.OperationalStateChannel, m.SouthboundErrorChan, m.Dispatcher, m.ModelRegistry.ModelReadOnlyPaths, m.OperationalStateCache)
 }
 
 //Close kills the channels and manager related objects

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -48,17 +48,8 @@ func setUp() (*Server, *manager.Manager) {
 		os.Exit(-1)
 	}
 
-	//mgr = manager.GetManager()
-	//mgr.Dispatcher = dispatcher.Dispatcher{
-	//	DeviceListeners:        make(map[topocache.ID]chan events.ConfigEvent),
-	//	NbiListeners:           make(map[string]chan events.ConfigEvent),
-	//	NbiOpStateListeners:    make(map[string]chan events.OperationalStateEvent),
-	//	DeviceResponseListener: make(map[topocache.ID]chan events.DeviceResponse),
-	//}
 	log.Infof("Dispatcher pointer %p", &mgr.Dispatcher)
-	//mgr.TopoChannel = make(chan events.TopoEvent)
 	go listenToTopoLoading(mgr.TopoChannel)
-	//mgr.ChangesChannel = make(chan events.ConfigEvent)
 	go mgr.Dispatcher.Listen(mgr.ChangesChannel)
 
 	log.Info("Finished setUp()")

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/manager"
 	log "k8s.io/klog"
 	"os"
+	"sync"
 	"testing"
 )
 
@@ -47,15 +48,33 @@ func setUp() (*Server, *manager.Manager) {
 		os.Exit(-1)
 	}
 
-	mgr = manager.GetManager()
-	mgr.Dispatcher = dispatcher.NewDispatcher()
-	mgr.TopoChannel = make(chan events.TopoEvent)
+	//mgr = manager.GetManager()
+	//mgr.Dispatcher = dispatcher.Dispatcher{
+	//	DeviceListeners:        make(map[topocache.ID]chan events.ConfigEvent),
+	//	NbiListeners:           make(map[string]chan events.ConfigEvent),
+	//	NbiOpStateListeners:    make(map[string]chan events.OperationalStateEvent),
+	//	DeviceResponseListener: make(map[topocache.ID]chan events.DeviceResponse),
+	//}
+	log.Infof("Dispatcher pointer %p", &mgr.Dispatcher)
+	//mgr.TopoChannel = make(chan events.TopoEvent)
 	go listenToTopoLoading(mgr.TopoChannel)
-	mgr.ChangesChannel = make(chan events.ConfigEvent)
+	//mgr.ChangesChannel = make(chan events.ConfigEvent)
 	go mgr.Dispatcher.Listen(mgr.ChangesChannel)
 
 	log.Info("Finished setUp()")
 	return server, mgr
+}
+
+func tearDown(mgr *manager.Manager, wg sync.WaitGroup) {
+	// `wg.Wait` blocks until `wg.Done` is called the same number of times
+	// as the amount of tasks we have (in this case, 1 time)
+	wg.Wait()
+
+	mgr.Dispatcher = &dispatcher.Dispatcher{}
+	log.Infof("Dispatcher Teardown %p", mgr.Dispatcher)
+
+
+
 }
 
 func listenToTopoLoading(deviceChan <-chan events.TopoEvent) {

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -65,15 +65,13 @@ func setUp() (*Server, *manager.Manager) {
 	return server, mgr
 }
 
-func tearDown(mgr *manager.Manager, wg sync.WaitGroup) {
+func tearDown(mgr *manager.Manager, wg *sync.WaitGroup) {
 	// `wg.Wait` blocks until `wg.Done` is called the same number of times
 	// as the amount of tasks we have (in this case, 1 time)
 	wg.Wait()
 
 	mgr.Dispatcher = &dispatcher.Dispatcher{}
 	log.Infof("Dispatcher Teardown %p", mgr.Dispatcher)
-
-
 
 }
 

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -78,7 +78,7 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 	server, mgr := setUp()
 
 	var wg sync.WaitGroup
-	defer tearDown(mgr, wg)
+	defer tearDown(mgr, &wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
@@ -117,7 +117,7 @@ func Test_SubscribeLeafStream(t *testing.T) {
 	server, mgr := setUp()
 
 	var wg sync.WaitGroup
-	defer tearDown(mgr, wg)
+	defer tearDown(mgr, &wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -265,7 +265,7 @@ func Test_WrongPath(t *testing.T) {
 func Test_ErrorDoubleSubscription(t *testing.T) {
 	server, mgr := setUp()
 	var wg sync.WaitGroup
-	defer tearDown(mgr, wg)
+	defer tearDown(mgr, &wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -305,7 +305,7 @@ func Test_Poll(t *testing.T) {
 	server, mgr := setUp()
 
 	var wg sync.WaitGroup
-	defer tearDown(mgr, wg)
+	defer tearDown(mgr, &wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
@@ -365,7 +365,7 @@ func Test_SubscribeLeafStreamDelete(t *testing.T) {
 	server, mgr := setUp()
 
 	var wg sync.WaitGroup
-	defer tearDown(mgr, wg)
+	defer tearDown(mgr, &wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -291,7 +291,6 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 			log.Error("Should not be receiving response ", response)
 			t.FailNow()
 		case <-time.After(50 * time.Millisecond):
-			log.Info("$$$ Returning from function")
 		}
 	}()
 	//FIXME Waiting for subscribe to finish properly --> when event is issued assuring state consistency we can remove

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -17,6 +17,7 @@ package gnmi
 import (
 	"context"
 	"regexp"
+	"sync"
 	"testing"
 	"time"
 
@@ -74,7 +75,10 @@ func (x gNMISubscribeServerPollFake) Recv() (*gnmi.SubscribeRequest, error) {
 
 // Test_SubscribeLeafOnce tests subscribing with mode ONCE and then immediately receiving the subscription for a specific leaf.
 func Test_SubscribeLeafOnce(t *testing.T) {
-	server, _ := setUp()
+	server, mgr := setUp()
+
+	var wg sync.WaitGroup
+	defer tearDown(mgr, wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
@@ -110,7 +114,10 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with updates for that path
 func Test_SubscribeLeafStream(t *testing.T) {
-	server, _ := setUp()
+	server, mgr := setUp()
+
+	var wg sync.WaitGroup
+	defer tearDown(mgr, wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -199,7 +206,6 @@ func Test_WrongDevice(t *testing.T) {
 		t.FailNow()
 	case <-time.After(50 * time.Millisecond):
 	}
-
 	targets["Device1"] = struct{}{}
 	subs = append(subs, utils.MatchWildcardRegexp("/cont1a/*/leaf3c"))
 	go listenForUpdates(changeChan, serverFake, mgr, targets, subs, resChan)
@@ -216,8 +222,50 @@ func Test_WrongDevice(t *testing.T) {
 
 }
 
+func Test_WrongPath(t *testing.T) {
+	_, mgr := setUp()
+
+	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
+
+	assert.NilError(t, err, "Unexpected error doing parsing")
+
+	path.Target = "Device1"
+
+	request := buildRequest(path, gnmi.SubscriptionList_STREAM)
+
+	changeChan := make(chan events.ConfigEvent)
+	responsesChan := make(chan *gnmi.SubscribeResponse, 1)
+	serverFake := gNMISubscribeServerFake{
+		Request:   request,
+		Responses: responsesChan,
+		Signal:    make(chan struct{}),
+	}
+
+	targets := make(map[string]struct{})
+	resChan := make(chan result)
+	var response *gnmi.SubscribeResponse
+	targets["Device1"] = struct{}{}
+	subscriptionPathStr := "/test1:cont1a/cont2a/leaf3c"
+	subsStr := make([]*regexp.Regexp, 0)
+	subsStr = append(subsStr, utils.MatchWildcardRegexp(subscriptionPathStr))
+	go listenForUpdates(changeChan, serverFake, mgr, targets, subsStr, resChan)
+	config1Value05, _ := change.CreateChangeValue("/test1:cont1a/cont2a/leaf2c", change.CreateTypedValueString("def"), false)
+	config1Value09, _ := change.CreateChangeValue("/test1:cont1a/list2a[name=txout2]", change.CreateTypedValueEmpty(), true)
+	change1, _ := change.CreateChange(change.ValueCollections{config1Value05, config1Value09}, "Remove txout 2")
+	changeChan <- events.CreateConfigEvent("Device1", change1.ID, true)
+	select {
+	case response = <-responsesChan:
+		log.Error("Should not be receiving response ", response)
+		t.FailNow()
+	case <-time.After(50 * time.Millisecond):
+	}
+
+}
+
 func Test_ErrorDoubleSubscription(t *testing.T) {
-	server, _ := setUp()
+	server, mgr := setUp()
+	var wg sync.WaitGroup
+	defer tearDown(mgr, wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -237,6 +285,14 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 	go func() {
 		err = server.Subscribe(serverFake)
 		assert.NilError(t, err, "Unexpected error doing Subscribe")
+		var response *gnmi.SubscribeResponse
+		select {
+		case response = <-responsesChan:
+			log.Error("Should not be receiving response ", response)
+			t.FailNow()
+		case <-time.After(50 * time.Millisecond):
+			log.Info("$$$ Returning from function")
+		}
 	}()
 	//FIXME Waiting for subscribe to finish properly --> when event is issued assuring state consistency we can remove
 	time.Sleep(100000)
@@ -246,7 +302,10 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 }
 
 func Test_Poll(t *testing.T) {
-	server, _ := setUp()
+	server, mgr := setUp()
+
+	var wg sync.WaitGroup
+	defer tearDown(mgr, wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
@@ -303,7 +362,10 @@ func Test_Poll(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with delete paths
 func Test_SubscribeLeafStreamDelete(t *testing.T) {
-	server, _ := setUp()
+	server, mgr := setUp()
+
+	var wg sync.WaitGroup
+	defer tearDown(mgr, wg)
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 


### PR DESCRIPTION
This patch fixes partially the RACE conditions in the tests. 
I'm seeing race conditions in the dispatcher, please see below, I want some opinion if this is a valid use case that can happen on the norma operation of ONOS config. If so we need a way to lock the map of listeners in such a way that r/w is in sync. 

If you want our un just the dispatcher tests after getting this patch please run:
 `GO111MODULE=on CGO_ENABLED=1 go test -race github.com/onosproject/onos-config/pkg/dispatcher`

running normal test you will not see the race condition behaviour because this is not placed on top of #555 

```
WARNING: DATA RACE
Write at 0x00c00015ce50 by goroutine 19:
  runtime.closechan()
      /usr/local/go/src/runtime/chan.go:334 +0x0
  github.com/onosproject/onos-config/pkg/dispatcher.(*Dispatcher).UnregisterOperationalState()
      /Users/andrea/go/src/github.com/onosproject/onos-config/pkg/dispatcher/dispatcher.go:166 +0x109
  github.com/onosproject/onos-config/pkg/dispatcher.Test_listen_operational()
      /Users/andrea/go/src/github.com/onosproject/onos-config/pkg/dispatcher/dispatcher_test.go:217 +0x5ca
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163

Previous read at 0x00c00015ce50 by goroutine 21:
  runtime.chansend()
      /usr/local/go/src/runtime/chan.go:142 +0x0
  github.com/onosproject/onos-config/pkg/dispatcher.(*Dispatcher).ListenOperationalState()
      /Users/andrea/go/src/github.com/onosproject/onos-config/pkg/dispatcher/dispatcher.go:88 +0x154

Goroutine 19 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:916 +0x65a
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1157 +0xa8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1155 +0x523
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1072 +0x2eb
  github.com/onosproject/onos-config/pkg/dispatcher.TestMain()
      /Users/andrea/go/src/github.com/onosproject/onos-config/pkg/dispatcher/dispatcher_test.go:87 +0x639
  main.main()
      _testmain.go:54 +0x222

Goroutine 21 (finished) created at:
  github.com/onosproject/onos-config/pkg/dispatcher.Test_listen_operational()
      /Users/andrea/go/src/github.com/onosproject/onos-config/pkg/dispatcher/dispatcher_test.go:204 +0x34c
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163
```