### PR TITLE
Remove namespaces 

### DIFF
--- a/configs/changeStore-sample.json
+++ b/configs/changeStore-sample.json
@@ -2,105 +2,105 @@
   "Version": "1.0.0",
   "Storetype": "change",
   "Store": {
-    "TOA0Blur2YQTAdkzKkRrAPIU+9A=": {
-      "ID": "TOA0Blur2YQTAdkzKkRrAPIU+9A=",
+    "WCqhR1nJn3ZGFdaeN3DBLeYO6ks=": {
+      "ID": "WCqhR1nJn3ZGFdaeN3DBLeYO6ks=",
       "Description": "Remove txout 2",
       "Created": "2019-05-09T16:24:17.815274679Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/cont2a/leaf2d",
+          "Path": "/cont1a/cont2a/leaf2d",
           "Value": "AgAAAAAAAAA=",
           "Type": 5,
           "TypeOpts": [3]
         },
         {
-          "Path": "/test1:cont1a/cont2a/leaf2e",
+          "Path": "/cont1a/cont2a/leaf2e",
           "Value": "nf/////////8/////////wUAAAAAAAAAyAAAAAAAAAA=",
           "Type": 9
         },
         {
-          "Path": "/test1:cont1a/cont2a/leaf2g",
+          "Path": "/cont1a/cont2a/leaf2g",
           "Value": "AA==",
           "Type": 4
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout2]",
+          "Path": "/cont1a/list2a[name=txout2]",
           "Type": 0,
           "Remove": true
         }
       ]
     },
-    "50XCdm605t2/jZoPePGiUvboQzg=": {
-      "ID": "50XCdm605t2/jZoPePGiUvboQzg=",
+    "tAk3GZSh1qbdhdm5414r46RLvqw=": {
+      "ID": "tAk3GZSh1qbdhdm5414r46RLvqw=",
       "Description": "Trim power level",
       "Created": "2019-05-09T16:24:17.815259228Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/cont2a/leaf2b",
+          "Path": "/cont1a/cont2a/leaf2b",
           "Value": "AAAA4PND8j8=",
           "Type": 6
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout3]/tx-power",
+          "Path": "/cont1a/list2a[name=txout3]/tx-power",
           "Value": "EAAAAAAAAAA=",
           "Type": 3
         }
       ]
     },
-    "uOTzTiNotAGjjsl11EuVFY/lYsM=": {
-      "ID": "uOTzTiNotAGjjsl11EuVFY/lYsM=",
+    "Rc4/gKAMmgJfNPMC6+zLxvcMTwg=": {
+      "ID": "Rc4/gKAMmgJfNPMC6+zLxvcMTwg=",
       "Description": "Remove txout 1",
       "Created": "2019-05-09T16:24:17.815294258Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/list2a[name=txout1]",
+          "Path": "/cont1a/list2a[name=txout1]",
           "Type": 0,
           "Remove": true
         }
       ]
     },
-    "EQct6X4kZda3NqpW6N2TL4fFilA=": {
-      "ID": "EQct6X4kZda3NqpW6N2TL4fFilA=",
+    "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=": {
+      "ID": "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=",
       "Description": "Original Config for test switch",
       "Created": "2019-05-09T16:24:17.815187669Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/cont2a/leaf2a",
+          "Path": "/cont1a/cont2a/leaf2a",
           "Value": "DQAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/test1:cont1a/cont2a/leaf2b",
+          "Path": "/cont1a/cont2a/leaf2b",
           "Value": "AAAAgJVD+T8=",
           "Type": 6
         },
         {
-          "Path": "/test1:cont1a/leaf1a",
+          "Path": "/cont1a/leaf1a",
           "Value": "YWJjZGVm",
           "Type": 1
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout1]",
+          "Path": "/cont1a/list2a[name=txout1]",
           "Value": "",
           "Type": 0
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout1]/tx-power",
+          "Path": "/cont1a/list2a[name=txout1]/tx-power",
           "Value": "CAAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout2]",
+          "Path": "/cont1a/list2a[name=txout2]",
           "Value": "",
           "Type": 0
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout2]/tx-power",
+          "Path": "/cont1a/list2a[name=txout2]/tx-power",
           "Value": "CgAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/test1:leafAtTopLevel",
+          "Path": "/leafAtTopLevel",
           "Value": "V1hZLTEyMzQ=",
           "Type": 1
         }

--- a/configs/changeStore-sample.json
+++ b/configs/changeStore-sample.json
@@ -106,210 +106,210 @@
         }
       ]
     },
-    "yEeW6VaoPiXkRRuoCa0jfcW97vk=": {
-      "ID": "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
+    "OcRNRKUFjQCgntMb26WVe0iu23U=": {
+      "ID": "OcRNRKUFjQCgntMb26WVe0iu23U=",
       "Description": "Original configuration for devicesim",
       "Created": "2019-05-21T08:43:01Z",
       "Config": [
         {
-          "Path": "/openconfig-interfaces:interfaces/interface[name=admin]/config/name",
+          "Path": "/interfaces/interface[name=admin]/config/name",
           "Value": "YWRtaW4=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/aaa/authentication/admin-user/config/admin-password",
+          "Path": "/system/aaa/authentication/admin-user/config/admin-password",
           "Value": "cGFzc3dvcmQ=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/aaa/authentication/config/authentication-method",
+          "Path": "/system/aaa/authentication/config/authentication-method",
           "Value": "b3BlbmNvbmZpZy1hYWEtdHlwZXM6TE9DQUw=",
           "Type": 8
         },
         {
-          "Path": "/openconfig-system:system/clock/config/timezone-name",
+          "Path": "/system/clock/config/timezone-name",
           "Value": "RXVyb3BlL0R1Ymxpbg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "cmVwbGFjZS1kZXZpY2UtbmFtZQ==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/domain-name",
+          "Path": "/system/config/domain-name",
           "Value": "b3Blbm5ldHdvcmtpbmcub3Jn",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/login-banner",
+          "Path": "/system/config/login-banner",
           "Value": "VGhpcyBkZXZpY2UgaXMgZm9yIGF1dGhvcml6ZWQgdXNlIG9ubHk=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "cmVwbGFjZS1tb3RkLWJhbm5lcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/backoff-interval",
+          "Path": "/system/openflow/agent/config/backoff-interval",
           "Value": "BQAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/datapath-id",
+          "Path": "/system/openflow/agent/config/datapath-id",
           "Value": "MDA6MTY6M2U6MDA6MDA6MDA6MDA6MDA=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/failure-mode",
+          "Path": "/system/openflow/agent/config/failure-mode",
           "Value": "U0VDVVJF",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/inactivity-probe",
+          "Path": "/system/openflow/agent/config/inactivity-probe",
           "Value": "CgAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/max-backoff",
+          "Path": "/system/openflow/agent/config/max-backoff",
           "Value": "CgAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/config/name",
+          "Path": "/system/openflow/controllers/controller[name=main]/config/name",
           "Value": "bWFpbg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/address",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/address",
           "Value": "MTkyLjAuMi4xMA==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/aux-id",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/aux-id",
           "Value": "AAAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/port",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/port",
           "Value": "6RkAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/priority",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/priority",
           "Value": "AQAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/source-interface",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/source-interface",
           "Value": "YWRtaW4=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/transport",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/transport",
           "Value": "VExT",
           "Type": 1
         }
       ]
     },
-    "y/8sZEp9O7pLZvWDDKTmrISVk0U=": {
-      "ID": "y/8sZEp9O7pLZvWDDKTmrISVk0U=",
+    "6u5DggH8SyMQaikerhclgBmneO0=": {
+      "ID": "6u5DggH8SyMQaikerhclgBmneO0=",
       "Description": "Modification of device sim 1",
       "Created": "2019-05-21T08:43:02Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "bG9jYWxob3N0LTE=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gbG9jYWxob3N0OjEwMTYx",
           "Type": 1
         }
       ]
     },
-    "clnusGLfRRJx/+b8Q9uvTdAptk0=": {
-      "ID": "clnusGLfRRJx/+b8Q9uvTdAptk0=",
+    "wRmAtg1c8ATNeFK8Shiwc1N0gdw=": {
+      "ID": "wRmAtg1c8ATNeFK8Shiwc1N0gdw=",
       "Description": "Modification of device sim 2",
       "Created": "2019-05-21T08:43:03Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "bG9jYWxob3N0LTI=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gbG9jYWxob3N0OjEwMTYy",
           "Type": 1
         }
       ]
     },
-    "90srsoYe5BWlmh3wKToJvOC7iIU=": {
-      "ID": "90srsoYe5BWlmh3wKToJvOC7iIU=",
+    "z/uj5QRBaxP9ndgko8XUDkQR6kM=": {
+      "ID": "z/uj5QRBaxP9ndgko8XUDkQR6kM=",
       "Description": "Modification of device sim 3",
       "Created": "2019-05-21T08:43:04Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "bG9jYWxob3N0LTM=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gbG9jYWxob3N0OjEwMTYz",
           "Type": 1
         }
       ]
     },
-    "5H/7bq3MC16pF9cMQIOPcq/jhLg=": {
-      "ID": "5H/7bq3MC16pF9cMQIOPcq/jhLg=",
+    "HSG6Jf6bM1vfexEnSoMcNGJ68QE=": {
+      "ID": "HSG6Jf6bM1vfexEnSoMcNGJ68QE=",
       "Description": "Modification of device-1-device-simulator",
       "Created": "2019-05-30T18:03:17Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "ZGV2aWNlLTEtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gZGV2aWNlLTEtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         }
       ]
     },
-    "KiZ+OLazJHyL2ycFUc/NSRjsTiE=": {
-      "ID": "KiZ+OLazJHyL2ycFUc/NSRjsTiE=",
+    "aJIBGic9ci3G3KmJpuJxHEkteso=": {
+      "ID": "aJIBGic9ci3G3KmJpuJxHEkteso=",
       "Description": "Modification of device-2-device-simulator",
       "Created": "2019-05-30T18:03:17Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "ZGV2aWNlLTItZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gZGV2aWNlLTItZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         }
       ]
     },
-    "LJGPGbRk8dn/kqQkENTrweYkba4=": {
-      "ID": "LJGPGbRk8dn/kqQkENTrweYkba4=",
+    "EgnVE0n7/B6EF+GY/ismFIcbTbk=": {
+      "ID": "EgnVE0n7/B6EF+GY/ismFIcbTbk=",
       "Description": "Modification of device-3-device-simulator",
       "Created": "2019-05-30T18:03:17Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "ZGV2aWNlLTMtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gZGV2aWNlLTMtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         }

--- a/configs/configStore-sample.json
+++ b/configs/configStore-sample.json
@@ -10,9 +10,9 @@
       "Created": "2019-05-09T16:24:17Z",
       "Updated": "2019-05-09T16:24:17Z",
       "Changes": [
-        "EQct6X4kZda3NqpW6N2TL4fFilA=",
-        "50XCdm605t2/jZoPePGiUvboQzg=",
-        "TOA0Blur2YQTAdkzKkRrAPIU+9A="
+        "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=",
+        "tAk3GZSh1qbdhdm5414r46RLvqw=",
+        "WCqhR1nJn3ZGFdaeN3DBLeYO6ks="
       ]
     },
     "Device2-1.0.0": {
@@ -23,9 +23,9 @@
       "Created": "2019-05-09T16:24:17.815298386Z",
       "Updated": "2019-05-09T16:24:17.815300015Z",
       "Changes": [
-        "EQct6X4kZda3NqpW6N2TL4fFilA=",
-        "50XCdm605t2/jZoPePGiUvboQzg=",
-        "uOTzTiNotAGjjsl11EuVFY/lYsM="
+        "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=",
+        "tAk3GZSh1qbdhdm5414r46RLvqw=",
+        "Rc4/gKAMmgJfNPMC6+zLxvcMTwg="
       ]
     },
     "Device2-2.0.0": {
@@ -36,7 +36,7 @@
       "Created": "2019-05-09T17:00:00Z",
       "Updated": "2019-05-09T17:00:00Z",
       "Changes": [
-        "EQct6X4kZda3NqpW6N2TL4fFilA="
+        "e3tYWHBz7OYGt5e3SlfjfpxcwZ4="
       ]
     },
     "localhost-1-1.0.0": {

--- a/configs/configStore-sample.json
+++ b/configs/configStore-sample.json
@@ -47,8 +47,8 @@
       "Created": "2019-05-21T08:43:17Z",
       "Updated": "2019-05-21T08:43:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "y/8sZEp9O7pLZvWDDKTmrISVk0U="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "6u5DggH8SyMQaikerhclgBmneO0="
       ]
     },
     "localhost-2-1.0.0": {
@@ -59,8 +59,8 @@
       "Created": "2019-05-21T08:43:18Z",
       "Updated": "2019-05-21T08:43:18Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "clnusGLfRRJx/+b8Q9uvTdAptk0="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "wRmAtg1c8ATNeFK8Shiwc1N0gdw="
       ]
     },
     "localhost-3-1.0.0": {
@@ -71,8 +71,8 @@
       "Created": "2019-05-21T08:43:19Z",
       "Updated": "2019-05-21T08:43:19Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "90srsoYe5BWlmh3wKToJvOC7iIU="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "z/uj5QRBaxP9ndgko8XUDkQR6kM="
       ]
     },
     "device-1-device-simulator-1.0.0": {
@@ -83,8 +83,8 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "5H/7bq3MC16pF9cMQIOPcq/jhLg="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "HSG6Jf6bM1vfexEnSoMcNGJ68QE="
       ]
     },
     "device-2-device-simulator-1.0.0": {
@@ -95,8 +95,8 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "KiZ+OLazJHyL2ycFUc/NSRjsTiE="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "aJIBGic9ci3G3KmJpuJxHEkteso="
       ]
     },
     "device-3-device-simulator-1.0.0": {
@@ -107,8 +107,8 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "LJGPGbRk8dn/kqQkENTrweYkba4="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "EgnVE0n7/B6EF+GY/ismFIcbTbk="
       ]
     },
     "stratum-sim-1-1.0.0": {

--- a/deployments/helm/device-simulator/files/configs/ofsw_config.json
+++ b/deployments/helm/device-simulator/files/configs/ofsw_config.json
@@ -1,5 +1,5 @@
 {
-  "openconfig-interfaces:interfaces": {
+  "interfaces": {
     "interface": [
       {
         "name": "admin",
@@ -9,7 +9,7 @@
       }
     ]
   },
-  "openconfig-system:system": {
+  "system": {
     "aaa": {
       "authentication": {
         "admin-user": {
@@ -35,7 +35,7 @@
       "login-banner": "This device is for authorized use only",
       "motd-banner": "replace-motd-banner"
     },
-    "openconfig-openflow:openflow": {
+    "openflow": {
       "agent": {
         "config": {
           "backoff-interval": 5,

--- a/deployments/helm/onos-config/files/configs/changeStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/changeStore-sample.json
@@ -2,105 +2,105 @@
   "Version": "1.0.0",
   "Storetype": "change",
   "Store": {
-    "TOA0Blur2YQTAdkzKkRrAPIU+9A=": {
-      "ID": "TOA0Blur2YQTAdkzKkRrAPIU+9A=",
+    "WCqhR1nJn3ZGFdaeN3DBLeYO6ks=": {
+      "ID": "WCqhR1nJn3ZGFdaeN3DBLeYO6ks=",
       "Description": "Remove txout 2",
       "Created": "2019-05-09T16:24:17.815274679Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/cont2a/leaf2d",
+          "Path": "/cont1a/cont2a/leaf2d",
           "Value": "AgAAAAAAAAA=",
           "Type": 5,
           "TypeOpts": [3]
         },
         {
-          "Path": "/test1:cont1a/cont2a/leaf2e",
+          "Path": "/cont1a/cont2a/leaf2e",
           "Value": "nf/////////8/////////wUAAAAAAAAAyAAAAAAAAAA=",
           "Type": 9
         },
         {
-          "Path": "/test1:cont1a/cont2a/leaf2g",
+          "Path": "/cont1a/cont2a/leaf2g",
           "Value": "AA==",
           "Type": 4
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout2]",
+          "Path": "/cont1a/list2a[name=txout2]",
           "Type": 0,
           "Remove": true
         }
       ]
     },
-    "50XCdm605t2/jZoPePGiUvboQzg=": {
-      "ID": "50XCdm605t2/jZoPePGiUvboQzg=",
+    "tAk3GZSh1qbdhdm5414r46RLvqw=": {
+      "ID": "tAk3GZSh1qbdhdm5414r46RLvqw=",
       "Description": "Trim power level",
       "Created": "2019-05-09T16:24:17.815259228Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/cont2a/leaf2b",
+          "Path": "/cont1a/cont2a/leaf2b",
           "Value": "AAAA4PND8j8=",
           "Type": 6
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout3]/tx-power",
+          "Path": "/cont1a/list2a[name=txout3]/tx-power",
           "Value": "EAAAAAAAAAA=",
           "Type": 3
         }
       ]
     },
-    "uOTzTiNotAGjjsl11EuVFY/lYsM=": {
-      "ID": "uOTzTiNotAGjjsl11EuVFY/lYsM=",
+    "Rc4/gKAMmgJfNPMC6+zLxvcMTwg=": {
+      "ID": "Rc4/gKAMmgJfNPMC6+zLxvcMTwg=",
       "Description": "Remove txout 1",
       "Created": "2019-05-09T16:24:17.815294258Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/list2a[name=txout1]",
+          "Path": "/cont1a/list2a[name=txout1]",
           "Type": 0,
           "Remove": true
         }
       ]
     },
-    "EQct6X4kZda3NqpW6N2TL4fFilA=": {
-      "ID": "EQct6X4kZda3NqpW6N2TL4fFilA=",
+    "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=": {
+      "ID": "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=",
       "Description": "Original Config for test switch",
       "Created": "2019-05-09T16:24:17.815187669Z",
       "Config": [
         {
-          "Path": "/test1:cont1a/cont2a/leaf2a",
+          "Path": "/cont1a/cont2a/leaf2a",
           "Value": "DQAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/test1:cont1a/cont2a/leaf2b",
+          "Path": "/cont1a/cont2a/leaf2b",
           "Value": "AAAAgJVD+T8=",
           "Type": 6
         },
         {
-          "Path": "/test1:cont1a/leaf1a",
+          "Path": "/cont1a/leaf1a",
           "Value": "YWJjZGVm",
           "Type": 1
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout1]",
+          "Path": "/cont1a/list2a[name=txout1]",
           "Value": "",
           "Type": 0
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout1]/tx-power",
+          "Path": "/cont1a/list2a[name=txout1]/tx-power",
           "Value": "CAAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout2]",
+          "Path": "/cont1a/list2a[name=txout2]",
           "Value": "",
           "Type": 0
         },
         {
-          "Path": "/test1:cont1a/list2a[name=txout2]/tx-power",
+          "Path": "/cont1a/list2a[name=txout2]/tx-power",
           "Value": "CgAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/test1:leafAtTopLevel",
+          "Path": "/leafAtTopLevel",
           "Value": "V1hZLTEyMzQ=",
           "Type": 1
         }

--- a/deployments/helm/onos-config/files/configs/changeStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/changeStore-sample.json
@@ -106,210 +106,210 @@
         }
       ]
     },
-    "yEeW6VaoPiXkRRuoCa0jfcW97vk=": {
-      "ID": "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
+    "OcRNRKUFjQCgntMb26WVe0iu23U=": {
+      "ID": "OcRNRKUFjQCgntMb26WVe0iu23U=",
       "Description": "Original configuration for devicesim",
       "Created": "2019-05-21T08:43:01Z",
       "Config": [
         {
-          "Path": "/openconfig-interfaces:interfaces/interface[name=admin]/config/name",
+          "Path": "/interfaces/interface[name=admin]/config/name",
           "Value": "YWRtaW4=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/aaa/authentication/admin-user/config/admin-password",
+          "Path": "/system/aaa/authentication/admin-user/config/admin-password",
           "Value": "cGFzc3dvcmQ=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/aaa/authentication/config/authentication-method",
+          "Path": "/system/aaa/authentication/config/authentication-method",
           "Value": "b3BlbmNvbmZpZy1hYWEtdHlwZXM6TE9DQUw=",
           "Type": 8
         },
         {
-          "Path": "/openconfig-system:system/clock/config/timezone-name",
+          "Path": "/system/clock/config/timezone-name",
           "Value": "RXVyb3BlL0R1Ymxpbg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "cmVwbGFjZS1kZXZpY2UtbmFtZQ==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/domain-name",
+          "Path": "/system/config/domain-name",
           "Value": "b3Blbm5ldHdvcmtpbmcub3Jn",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/login-banner",
+          "Path": "/system/config/login-banner",
           "Value": "VGhpcyBkZXZpY2UgaXMgZm9yIGF1dGhvcml6ZWQgdXNlIG9ubHk=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "cmVwbGFjZS1tb3RkLWJhbm5lcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/backoff-interval",
+          "Path": "/system/openflow/agent/config/backoff-interval",
           "Value": "BQAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/datapath-id",
+          "Path": "/system/openflow/agent/config/datapath-id",
           "Value": "MDA6MTY6M2U6MDA6MDA6MDA6MDA6MDA=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/failure-mode",
+          "Path": "/system/openflow/agent/config/failure-mode",
           "Value": "U0VDVVJF",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/inactivity-probe",
+          "Path": "/system/openflow/agent/config/inactivity-probe",
           "Value": "CgAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/agent/config/max-backoff",
+          "Path": "/system/openflow/agent/config/max-backoff",
           "Value": "CgAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/config/name",
+          "Path": "/system/openflow/controllers/controller[name=main]/config/name",
           "Value": "bWFpbg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/address",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/address",
           "Value": "MTkyLjAuMi4xMA==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/aux-id",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/aux-id",
           "Value": "AAAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/port",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/port",
           "Value": "6RkAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/priority",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/priority",
           "Value": "AQAAAAAAAAA=",
           "Type": 3
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/source-interface",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/source-interface",
           "Value": "YWRtaW4=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/transport",
+          "Path": "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/config/transport",
           "Value": "VExT",
           "Type": 1
         }
       ]
     },
-    "y/8sZEp9O7pLZvWDDKTmrISVk0U=": {
-      "ID": "y/8sZEp9O7pLZvWDDKTmrISVk0U=",
+    "6u5DggH8SyMQaikerhclgBmneO0=": {
+      "ID": "6u5DggH8SyMQaikerhclgBmneO0=",
       "Description": "Modification of device sim 1",
       "Created": "2019-05-21T08:43:02Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "bG9jYWxob3N0LTE=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gbG9jYWxob3N0OjEwMTYx",
           "Type": 1
         }
       ]
     },
-    "clnusGLfRRJx/+b8Q9uvTdAptk0=": {
-      "ID": "clnusGLfRRJx/+b8Q9uvTdAptk0=",
+    "wRmAtg1c8ATNeFK8Shiwc1N0gdw=": {
+      "ID": "wRmAtg1c8ATNeFK8Shiwc1N0gdw=",
       "Description": "Modification of device sim 2",
       "Created": "2019-05-21T08:43:03Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "bG9jYWxob3N0LTI=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gbG9jYWxob3N0OjEwMTYy",
           "Type": 1
         }
       ]
     },
-    "90srsoYe5BWlmh3wKToJvOC7iIU=": {
-      "ID": "90srsoYe5BWlmh3wKToJvOC7iIU=",
+    "z/uj5QRBaxP9ndgko8XUDkQR6kM=": {
+      "ID": "z/uj5QRBaxP9ndgko8XUDkQR6kM=",
       "Description": "Modification of device sim 3",
       "Created": "2019-05-21T08:43:04Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "bG9jYWxob3N0LTM=",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gbG9jYWxob3N0OjEwMTYz",
           "Type": 1
         }
       ]
     },
-    "5H/7bq3MC16pF9cMQIOPcq/jhLg=": {
-      "ID": "5H/7bq3MC16pF9cMQIOPcq/jhLg=",
+    "HSG6Jf6bM1vfexEnSoMcNGJ68QE=": {
+      "ID": "HSG6Jf6bM1vfexEnSoMcNGJ68QE=",
       "Description": "Modification of device-1-device-simulator",
       "Created": "2019-05-30T18:03:17Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "ZGV2aWNlLTEtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gZGV2aWNlLTEtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         }
       ]
     },
-    "KiZ+OLazJHyL2ycFUc/NSRjsTiE=": {
-      "ID": "KiZ+OLazJHyL2ycFUc/NSRjsTiE=",
+    "aJIBGic9ci3G3KmJpuJxHEkteso=": {
+      "ID": "aJIBGic9ci3G3KmJpuJxHEkteso=",
       "Description": "Modification of device-2-device-simulator",
       "Created": "2019-05-30T18:03:17Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "ZGV2aWNlLTItZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gZGV2aWNlLTItZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         }
       ]
     },
-    "LJGPGbRk8dn/kqQkENTrweYkba4=": {
-      "ID": "LJGPGbRk8dn/kqQkENTrweYkba4=",
+    "EgnVE0n7/B6EF+GY/ismFIcbTbk=": {
+      "ID": "EgnVE0n7/B6EF+GY/ismFIcbTbk=",
       "Description": "Modification of device-3-device-simulator",
       "Created": "2019-05-30T18:03:17Z",
       "Config": [
         {
-          "Path": "/openconfig-system:system/config/hostname",
+          "Path": "/system/config/hostname",
           "Value": "ZGV2aWNlLTMtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         },
         {
-          "Path": "/openconfig-system:system/config/motd-banner",
+          "Path": "/system/config/motd-banner",
           "Value": "V2VsY29tZSB0byBnTk1JIHNlcnZpY2Ugb24gZGV2aWNlLTMtZGV2aWNlLXNpbXVsYXRvcg==",
           "Type": 1
         }

--- a/deployments/helm/onos-config/files/configs/configStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/configStore-sample.json
@@ -10,9 +10,9 @@
       "Created": "2019-05-09T16:24:17Z",
       "Updated": "2019-05-09T16:24:17Z",
       "Changes": [
-        "EQct6X4kZda3NqpW6N2TL4fFilA=",
-        "50XCdm605t2/jZoPePGiUvboQzg=",
-        "TOA0Blur2YQTAdkzKkRrAPIU+9A="
+        "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=",
+        "tAk3GZSh1qbdhdm5414r46RLvqw=",
+        "WCqhR1nJn3ZGFdaeN3DBLeYO6ks="
       ]
     },
     "Device2-1.0.0": {
@@ -23,9 +23,9 @@
       "Created": "2019-05-09T16:24:17.815298386Z",
       "Updated": "2019-05-09T16:24:17.815300015Z",
       "Changes": [
-        "EQct6X4kZda3NqpW6N2TL4fFilA=",
-        "50XCdm605t2/jZoPePGiUvboQzg=",
-        "uOTzTiNotAGjjsl11EuVFY/lYsM="
+        "e3tYWHBz7OYGt5e3SlfjfpxcwZ4=",
+        "tAk3GZSh1qbdhdm5414r46RLvqw=",
+        "Rc4/gKAMmgJfNPMC6+zLxvcMTwg="
       ]
     },
     "Device2-2.0.0": {
@@ -36,7 +36,7 @@
       "Created": "2019-05-09T17:00:00Z",
       "Updated": "2019-05-09T17:00:00Z",
       "Changes": [
-        "EQct6X4kZda3NqpW6N2TL4fFilA="
+        "e3tYWHBz7OYGt5e3SlfjfpxcwZ4="
       ]
     },
     "localhost-1-1.0.0": {

--- a/deployments/helm/onos-config/files/configs/configStore-sample.json
+++ b/deployments/helm/onos-config/files/configs/configStore-sample.json
@@ -47,8 +47,8 @@
       "Created": "2019-05-21T08:43:17Z",
       "Updated": "2019-05-21T08:43:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "y/8sZEp9O7pLZvWDDKTmrISVk0U="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "6u5DggH8SyMQaikerhclgBmneO0="
       ]
     },
     "localhost-2-1.0.0": {
@@ -59,8 +59,8 @@
       "Created": "2019-05-21T08:43:18Z",
       "Updated": "2019-05-21T08:43:18Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "clnusGLfRRJx/+b8Q9uvTdAptk0="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "wRmAtg1c8ATNeFK8Shiwc1N0gdw="
       ]
     },
     "localhost-3-1.0.0": {
@@ -71,8 +71,8 @@
       "Created": "2019-05-21T08:43:19Z",
       "Updated": "2019-05-21T08:43:19Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "90srsoYe5BWlmh3wKToJvOC7iIU="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "z/uj5QRBaxP9ndgko8XUDkQR6kM="
       ]
     },
     "device-1-device-simulator-1.0.0": {
@@ -83,8 +83,8 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "5H/7bq3MC16pF9cMQIOPcq/jhLg="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "HSG6Jf6bM1vfexEnSoMcNGJ68QE="
       ]
     },
     "device-2-device-simulator-1.0.0": {
@@ -95,8 +95,8 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "KiZ+OLazJHyL2ycFUc/NSRjsTiE="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "aJIBGic9ci3G3KmJpuJxHEkteso="
       ]
     },
     "device-3-device-simulator-1.0.0": {
@@ -107,8 +107,8 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "yEeW6VaoPiXkRRuoCa0jfcW97vk=",
-        "LJGPGbRk8dn/kqQkENTrweYkba4="
+        "OcRNRKUFjQCgntMb26WVe0iu23U=",
+        "EgnVE0n7/B6EF+GY/ismFIcbTbk="
       ]
     },
     "stratum-sim-1-1.0.0": {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -189,10 +189,10 @@ To get the aggregate configuration of a device in a hierarchical JSON structure 
 DEVICE			CONFIGURATION		TYPE		VERSION
 Device1                 Device1-1.0.0           TestDevice      1.0.0
 CHANGE:	2uUbeEV4i3ADedjeORmgQt6CVDM=
-CHANGE:	50XCdm605t2/jZoPePGiUvboQzg=
+CHANGE:	tAk3GZSh1qbdhdm5414r46RLvqw=
 CHANGE:	MY8s8Opw+xjbcARIMzIpUIzeXv0=
 TREE:
-{"test1:cont1a":{"cont2a":{"leaf2a":13,"leaf2b":1.14159,"leaf2c":"def","leaf2d":0.002,"leaf2e":[-99,-4,5,200],"leaf2g":false},"leaf1a":"abcdef","list2a":[{"name":"txout1","tx-power":8},{"name":"txout3","tx-power":16}]},"test1:leafAtTopLevel":"WXY-1234"}
+{"cont1a":{"cont2a":{"leaf2a":13,"leaf2b":1.14159,"leaf2c":"def","leaf2d":0.002,"leaf2e":[-99,-4,5,200],"leaf2g":false},"leaf1a":"abcdef","list2a":[{"name":"txout1","tx-power":8},{"name":"txout3","tx-power":16}]},"test1:leafAtTopLevel":"WXY-1234"}
 ```
 
 > This displays the list of changes IDs and the aggregate effect of layering each

--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -25,7 +25,7 @@ Use `gnmi_cli -get` to get configuration for a particular device (target) from t
 > If config from several devices are required, several paths can be added
 ```bash
 gnmi_cli -get -address localhost:5150 \
-    -proto "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
+    -proto "path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
     -timeout 5s -alsologtostderr\
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -53,8 +53,8 @@ gnmi_cli -get -address localhost:5150 \
 ### Get a keyed index in a list
 Use a proto value like:
 >    -proto "path: <target: 'localhost-1',
->         elem: <name: 'openconfig-system:system'>
->         elem: <name: 'openconfig-openflow:openflow'> elem: <name: 'controllers'>
+>         elem: <name: 'system'>
+>         elem: <name: 'openflow'> elem: <name: 'controllers'>
 >         elem: <name: 'controller' key: <key: 'name' value: 'main'>>
 >         elem: <name: 'connections'> elem: <name: 'connection' key: <key: 'aux-id' value: '0'>>
 >         elem: <name: 'config'> elem: <name: 'address'>>"
@@ -64,7 +64,7 @@ Similarly, to make a gNMI Set request, use the `gnmi_cli -set` command as in the
 
 ```bash
 gnmi_cli -address localhost:5150 -set \
-    -proto "update: <path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
+    -proto "update: <path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -75,7 +75,7 @@ giving a response like
 response: <
   path: <
     elem: <
-      name: "openconfig-system:system"
+      name: "system"
     >
     elem: <
       name: "clock"
@@ -109,7 +109,7 @@ SetRequest() with the 100 extension at the end of the -proto section like:
 > See [gnmi_extensions.md](./gnmi_extensions.md) for more on gNMI extensions supported.
 
 > The corresponding -get for this require using the -proto
-> "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>"
+> "path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>"
 
 > Currently (Jul '19) checking of the contents done only when a Model Plugin is
 > loaded for the device type. 2 checks are done 1) that a attempt is not being
@@ -129,7 +129,7 @@ To make a gNMI Set request do delete a path, use the `gnmi_cli -set` command as 
 
 ```bash
 gnmi_cli -address localhost:5150 -set \
-    -proto "delete: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
+    -proto "delete: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -142,7 +142,7 @@ please note the `0` as subscription mode to indicate streaming:
 
 ```bash
 gnmi_cli -address localhost:5150 \
-    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -158,7 +158,7 @@ please note the `1` as subscription mode to indicate to send the response once:
 
 ```bash
 gnmi_cli -address localhost:5150 \
-    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -173,7 +173,7 @@ please note the `2` as subscription mode to indicate to send the response in a p
 
 ```bash
 gnmi_cli -address localhost:5150 \
-     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
      -timeout 5s \
      -polling_interval 5s \
      -client_crt pkg/southbound/testdata/client1.crt \

--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -10,6 +10,10 @@ the [OpenConfig](https://github.com/openconfig/gnmi) project. If it's not on you
 go get -u github.com/openconfig/gnmi/cmd/gnmi_cli
 ```
 > For troubleshooting information see [gnmi_user_manual.md](https://github.com/onosproject/simulators/blob/master/docs/gnmi/gnmi_user_manual.md)
+## Namespaces
+**onos-config** follows the YGOT project in simplification by not using namespaces in paths. This can be achieved 
+because the YANG models used do not have clashing device names that need to be qualified by namespaces. 
+This helps developers, avoiding un-needed complication and redundancy. 
 
 ## Northbound gNMI Get Request 
 __onos-config__ extends standard gNMI as a method of accessing a complete

--- a/docs/gnmi_extensions.md
+++ b/docs/gnmi_extensions.md
@@ -29,7 +29,7 @@ Therefore when using a gNMI client like gnmi_cli (see [gnmi.md](./gnmi.md)) the
 target can be specified like
 ```bash
 gnmi_cli -get -address localhost:5150 \
-    -proto "path: <target: 'stratum-sim-1', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
+    -proto "path: <target: 'stratum-sim-1', elem: <name: 'system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
 ...
 ```
 

--- a/docs/modelplugin.md
+++ b/docs/modelplugin.md
@@ -236,7 +236,7 @@ should give an appropriate error
 
 ```bash
 gnmi_cli -address localhost:5150 -set \
-    -proto "update: <path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem: <name: 'openconfig-openflow:openflow'> elem: <name: 'controllers'> elem: <name: 'controller' key: <key: 'name' value: 'main'>> elem: <name: 'connections'> elem: <name: 'connection' key: <key: 'aux-id' value: '0'>> elem: <name: 'state'> elem: <name: 'address'>> val: <string_val: '192.0.2.11'>>" \
+    -proto "update: <path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'openflow'> elem: <name: 'controllers'> elem: <name: 'controller' key: <key: 'name' value: 'main'>> elem: <name: 'connections'> elem: <name: 'connection' key: <key: 'aux-id' value: '0'>> elem: <name: 'state'> elem: <name: 'address'>> val: <string_val: '192.0.2.11'>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \
@@ -245,7 +245,7 @@ gnmi_cli -address localhost:5150 -set \
 gives the error:
 ```
 rpc error: code = InvalidArgument desc = update contains a change to a read only
-  path /openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/address. Rejected
+  path /system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/address. Rejected
 ```
 
 

--- a/docs/modelplugin.md
+++ b/docs/modelplugin.md
@@ -83,6 +83,11 @@ Follow the steps in **Loading the Model Plugin** below for how to load it.
 The YANG files to be used with generator.go should be collected together in a
 folder and named in the style: **\<modulename>@\<latestrevision>.yang**
 
+> **Note** The Yang files provided are required not to contain overlapping or clashing namespaces at the same path level.
+> This requirement is necessary during the model compilation in YGOT because this tool offers no support for namespaces 
+> in the form of `/namespace:path/path2`, e.g. `/openconfig-system:system/clock`. YGOT compilation of a model containing 
+> `/openconfig-system:system/clock` will result in the path being `/system/clock`
+
 Running the generator command in the form:
 ```bash
 go run $GOPATH/src/github.com/openconfig/ygot/generator/generator.go \

--- a/docs/run.md
+++ b/docs/run.md
@@ -48,7 +48,7 @@ The system provides a full implementation of the gNMI spec as a northbound servi
 Here is an example on how to use `gnmi_cli -get` to get configuration for a particular device (target) from the system.
 ```bash
 gnmi_cli -get -address localhost:5150 \
-    -proto "path: <target: 'localhost-1', elem: <name: 'openconfig-system:system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
+    -proto "path: <target: 'localhost-1', elem: <name: 'system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
     -timeout 5s -alsologtostderr \
     -client_crt pkg/southbound/testdata/client1.crt \
     -client_key pkg/southbound/testdata/client1.key \

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -28,12 +28,12 @@ import (
 )
 
 const (
-	Test1Cont1A             = "/test1:cont1a"
-	Test1Cont1ACont2A       = "/test1:cont1a/cont2a"
-	Test1Cont1ACont2ALeaf2A = "/test1:cont1a/cont2a/leaf2a"
-	Test1Cont1ACont2ALeaf2B = "/test1:cont1a/cont2a/leaf2b"
-	Test1Cont1ACont2ALeaf2C = "/test1:cont1a/cont2a/leaf2c"
-	Test1Cont1ACont2ALeaf2D = "/test1:cont1a/cont2a/leaf2d"
+	Test1Cont1A             = "/cont1a"
+	Test1Cont1ACont2A       = "/cont1a/cont2a"
+	Test1Cont1ACont2ALeaf2A = "/cont1a/cont2a/leaf2a"
+	Test1Cont1ACont2ALeaf2B = "/cont1a/cont2a/leaf2b"
+	Test1Cont1ACont2ALeaf2C = "/cont1a/cont2a/leaf2c"
+	Test1Cont1ACont2ALeaf2D = "/cont1a/cont2a/leaf2d"
 )
 
 const (
@@ -191,7 +191,7 @@ func Test_GetNetworkConfig(t *testing.T) {
 
 func Test_SetNetworkConfig(t *testing.T) {
 	// First verify the value beforehand
-	const origChangeHash = "B0jBLCNC+OAgqy/6PVL+/AcTn90="
+	const origChangeHash = "65MwjiKdV5lnh19sKeapnlAUxGw="
 	mgrTest, changeStoreTest, configurationStoreTest := setUp()
 	assert.Equal(t, len(changeStoreTest), 1)
 	i := 0
@@ -344,24 +344,24 @@ func TestManager_GetAllConfig(t *testing.T) {
 	result, err := mgrTest.GetTargetConfig("Device1", "Running", "/*", 0)
 	assert.Assert(t, len(result) == 3, "Get of device all paths does not return proper array")
 	assert.NilError(t, err, "Configuration not found")
-	assert.Assert(t, networkConfigContainsPath(result, "/test1:cont1a"), "/test1:cont1a not found")
-	assert.Assert(t, networkConfigContainsPath(result, "/test1:cont1a/cont2a"), "/test1:cont1a/cont2a not found")
-	assert.Assert(t, networkConfigContainsPath(result, "/test1:cont1a/cont2a/leaf2a"), "/test1:cont1a/cont2a/leaf2a not found")
+	assert.Assert(t, networkConfigContainsPath(result, "/cont1a"), "/cont1a not found")
+	assert.Assert(t, networkConfigContainsPath(result, "/cont1a/cont2a"), "/cont1a/cont2a not found")
+	assert.Assert(t, networkConfigContainsPath(result, "/cont1a/cont2a/leaf2a"), "/cont1a/cont2a/leaf2a not found")
 }
 
 func TestManager_GetOneConfig(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetTargetConfig("Device1", "Running", "/test1:cont1a/cont2a/leaf2a", 0)
+	result, err := mgrTest.GetTargetConfig("Device1", "Running", "/cont1a/cont2a/leaf2a", 0)
 	assert.Assert(t, len(result) == 1, "Get of device one path does not return proper array")
 	assert.NilError(t, err, "Configuration not found")
-	assert.Assert(t, networkConfigContainsPath(result, "/test1:cont1a/cont2a/leaf2a"), "/test1:cont1a/cont2a/leaf2a not found")
+	assert.Assert(t, networkConfigContainsPath(result, "/cont1a/cont2a/leaf2a"), "/cont1a/cont2a/leaf2a not found")
 }
 
 func TestManager_GetConfigNoTarget(t *testing.T) {
 	mgrTest, _, _ := setUp()
 
-	result, err := mgrTest.GetTargetConfig("", "Running", "/test1:cont1a/cont2a/leaf2a", 0)
+	result, err := mgrTest.GetTargetConfig("", "Running", "/cont1a/cont2a/leaf2a", 0)
 	assert.Assert(t, len(result) == 0, "Get of device one path does not return proper array")
 	assert.ErrorContains(t, err, "No Configuration found for Running")
 }

--- a/pkg/modelregistry/jsonvalues/convertJson_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJson_test.go
@@ -75,83 +75,83 @@ func Test_correctJsonPathValues(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, len(ds1Schema), 137)
 
-	readOnlyPaths := modelregistry.ExtractReadOnlyPaths(ds1Schema["Device"], yang.TSUnset, "", "", "")
+	readOnlyPaths := modelregistry.ExtractReadOnlyPaths(ds1Schema["Device"], yang.TSUnset, "", "")
 	assert.Equal(t, len(readOnlyPaths), 37)
 
 	// All values are taken from testdata/sample-openconfig.json and defined
 	// here in the intermediate jsonToValues format
-	const systemNtpAuthMismatch = "/openconfig-system:system/ntp/state/auth-mismatch"
+	const systemNtpAuthMismatch = "/system/ntp/state/auth-mismatch"
 	const systemNtpAuthMismatchValue = 123456.00000
 	val01 := change.ConfigValue{Path: systemNtpAuthMismatch,
 		TypedValue: *change.CreateTypedValueFloat(systemNtpAuthMismatchValue)}
 
-	const systemNtpEnableAuth = "/openconfig-system:system/ntp/state/enable-ntp-auth"
+	const systemNtpEnableAuth = "/system/ntp/state/enable-ntp-auth"
 	const systemNtpEnableAuthValue = true
 	val02 := change.ConfigValue{Path: systemNtpEnableAuth,
 		TypedValue: *change.CreateTypedValueBool(systemNtpEnableAuthValue)}
 
-	const systemNtpSourceAddr = "/openconfig-system:system/ntp/state/ntp-source-address"
+	const systemNtpSourceAddr = "/system/ntp/state/ntp-source-address"
 	const systemNtpSourceAddrValue = "192.168.0.17"
 	val03 := change.ConfigValue{Path: systemNtpSourceAddr,
 		TypedValue: *change.CreateTypedValueString(systemNtpSourceAddrValue)}
 
-	const iface1Mtu = "/openconfig-interfaces:interfaces/interface[1]/state/mtu"
+	const iface1Mtu = "/interfaces/interface[1]/state/mtu"
 	const iface1MtuValue = 960.0
 	val04 := change.ConfigValue{Path: iface1Mtu,
 		TypedValue: *change.CreateTypedValueFloat(iface1MtuValue)}
-	const iface1Name = "/openconfig-interfaces:interfaces/interface[1]/name"
+	const iface1Name = "/interfaces/interface[1]/name"
 	const iface1NameValue = "eth1"
 	val05 := change.ConfigValue{Path: iface1Name,
 		TypedValue: *change.CreateTypedValueString(iface1NameValue)}
-	const iface1Desc = "/openconfig-interfaces:interfaces/interface[1]/state/description"
+	const iface1Desc = "/interfaces/interface[1]/state/description"
 	const iface1DescValue = "new if desc"
 	val06 := change.ConfigValue{Path: iface1Desc,
 		TypedValue: *change.CreateTypedValueString(iface1DescValue)}
 
-	const iface1Sub15IfaceIdx = "/openconfig-interfaces:interfaces/interface[1]/subinterfaces/subinterface[15]/state/ifindex"
+	const iface1Sub15IfaceIdx = "/interfaces/interface[1]/subinterfaces/subinterface[15]/state/ifindex"
 	const iface1Sub15IfaceIdxValue = 10.0
 	val07 := change.ConfigValue{Path: iface1Sub15IfaceIdx,
 		TypedValue: *change.CreateTypedValueFloat(iface1Sub15IfaceIdxValue)}
-	const iface1Sub15Idx = "/openconfig-interfaces:interfaces/interface[1]/subinterfaces/subinterface[15]/index"
+	const iface1Sub15Idx = "/interfaces/interface[1]/subinterfaces/subinterface[15]/index"
 	const iface1Sub15IdxValue = "120"
 	val08 := change.ConfigValue{Path: iface1Sub15Idx,
 		TypedValue: *change.CreateTypedValueString(iface1Sub15IdxValue)}
-	const iface1Sub15AdSt = "/openconfig-interfaces:interfaces/interface[1]/subinterfaces/subinterface[15]/state/admin-status"
+	const iface1Sub15AdSt = "/interfaces/interface[1]/subinterfaces/subinterface[15]/state/admin-status"
 	const iface1Sub15AdStValue = "UP"
 	val09 := change.ConfigValue{Path: iface1Sub15AdSt,
 		TypedValue: *change.CreateTypedValueString(iface1Sub15AdStValue)}
 
-	const sysAaaGr10Svr199Ca = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[10]/servers/server[199]/state/connection-aborts"
+	const sysAaaGr10Svr199Ca = "/system/aaa/server-groups/server-group[10]/servers/server[199]/state/connection-aborts"
 	const sysAaaGr10Svr199CaValue = 12.00
 	val10 := change.ConfigValue{Path: sysAaaGr10Svr199Ca,
 		TypedValue: *change.CreateTypedValueFloat(sysAaaGr10Svr199CaValue)}
-	const sysAaaGr10Name = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[10]/name"
+	const sysAaaGr10Name = "/system/aaa/server-groups/server-group[10]/name"
 	const sysAaaGr10NameValue = "g1"
 	val11 := change.ConfigValue{Path: sysAaaGr10Name,
 		TypedValue: *change.CreateTypedValueString(sysAaaGr10NameValue)}
-	const sysAaaGr10Svr199Addr = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[10]/servers/server[199]/address"
+	const sysAaaGr10Svr199Addr = "/system/aaa/server-groups/server-group[10]/servers/server[199]/address"
 	const sysAaaGr10Svr199AddrValue = "192.168.0.7"
 	val12 := change.ConfigValue{Path: sysAaaGr10Svr199Addr,
 		TypedValue: *change.CreateTypedValueString(sysAaaGr10Svr199AddrValue)}
 
-	const sysAaaGr12Svr199Ca = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[12]/servers/server[199]/state/connection-aborts"
+	const sysAaaGr12Svr199Ca = "/system/aaa/server-groups/server-group[12]/servers/server[199]/state/connection-aborts"
 	const sysAaaGr12Svr199CaValue = 4.0
 	val13 := change.ConfigValue{Path: sysAaaGr12Svr199Ca,
 		TypedValue: *change.CreateTypedValueFloat(sysAaaGr12Svr199CaValue)}
-	const sysAaaGr12Name = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[12]/name"
+	const sysAaaGr12Name = "/system/aaa/server-groups/server-group[12]/name"
 	const sysAaaGr12NameValue = "g2"
 	val14 := change.ConfigValue{Path: sysAaaGr12Name,
 		TypedValue: *change.CreateTypedValueString(sysAaaGr12NameValue)}
-	const sysAaaGr12Svr199Addr = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[12]/servers/server[199]/address"
+	const sysAaaGr12Svr199Addr = "/system/aaa/server-groups/server-group[12]/servers/server[199]/address"
 	const sysAaaGr12Svr199AddrValue = "192.168.0.4"
 	val15 := change.ConfigValue{Path: sysAaaGr12Svr199Addr,
 		TypedValue: *change.CreateTypedValueString(sysAaaGr12Svr199AddrValue)}
 
-	const sysAaaGr12Svr200Ca = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[12]/servers/server[200]/state/connection-aborts"
+	const sysAaaGr12Svr200Ca = "/system/aaa/server-groups/server-group[12]/servers/server[200]/state/connection-aborts"
 	const sysAaaGr12Svr200CaValue = 5.0
 	val16 := change.ConfigValue{Path: sysAaaGr12Svr200Ca,
 		TypedValue: *change.CreateTypedValueFloat(sysAaaGr12Svr200CaValue)}
-	const sysAaaGr12Svr200Addr = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[12]/servers/server[200]/address"
+	const sysAaaGr12Svr200Addr = "/system/aaa/server-groups/server-group[12]/servers/server[200]/address"
 	const sysAaaGr12Svr200AddrValue = "192.168.0.5"
 	val17 := change.ConfigValue{Path: sysAaaGr12Svr200Addr,
 		TypedValue: *change.CreateTypedValueString(sysAaaGr12Svr200AddrValue)}
@@ -168,13 +168,13 @@ func Test_correctJsonPathValues(t *testing.T) {
 	assert.Equal(t, len(correctedPathValues), 10)
 
 	for _, correctedPathValue := range correctedPathValues {
-		const ifEth1Mtu = "/openconfig-interfaces:interfaces/interface[name=eth1]/state/mtu"
-		const ifEth1Desc = "/openconfig-interfaces:interfaces/interface[name=eth1]/state/description"
-		const ifEth1Sub120IfIdx = "/openconfig-interfaces:interfaces/interface[name=eth1]/subinterfaces/subinterface[index=120]/state/ifindex"
-		const ifEth1Sub120AdSt = "/openconfig-interfaces:interfaces/interface[name=eth1]/subinterfaces/subinterface[index=120]/state/admin-status"
-		const sysAaaGrG1Srv7Ca = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=g1]/servers/server[address=192.168.0.7]/state/connection-aborts"
-		const sysAaaGrG2Srv4Ca = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=g2]/servers/server[address=192.168.0.4]/state/connection-aborts"
-		const sysAaaGrG2Srv5Ca = "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=g2]/servers/server[address=192.168.0.5]/state/connection-aborts"
+		const ifEth1Mtu = "/interfaces/interface[name=eth1]/state/mtu"
+		const ifEth1Desc = "/interfaces/interface[name=eth1]/state/description"
+		const ifEth1Sub120IfIdx = "/interfaces/interface[name=eth1]/subinterfaces/subinterface[index=120]/state/ifindex"
+		const ifEth1Sub120AdSt = "/interfaces/interface[name=eth1]/subinterfaces/subinterface[index=120]/state/admin-status"
+		const sysAaaGrG1Srv7Ca = "/system/aaa/server-groups/server-group[name=g1]/servers/server[address=192.168.0.7]/state/connection-aborts"
+		const sysAaaGrG2Srv4Ca = "/system/aaa/server-groups/server-group[name=g2]/servers/server[address=192.168.0.4]/state/connection-aborts"
+		const sysAaaGrG2Srv5Ca = "/system/aaa/server-groups/server-group[name=g2]/servers/server[address=192.168.0.5]/state/connection-aborts"
 		switch correctedPathValue.Path {
 		case systemNtpAuthMismatch:
 			assert.Equal(t, correctedPathValue.Type, change.ValueTypeUINT)
@@ -224,11 +224,11 @@ func Test_correctJsonPathValues(t *testing.T) {
 
 func Test_hasPrefixMultipleIdx(t *testing.T) {
 
-	const a = "/openconfig-interfaces:interfaces/interface[*]/subinterfaces/subinterface[*]/state/mtu"
-	const b = "/openconfig-interfaces:interfaces/interface[*]/subinterfaces/subinterface[*]/state"
+	const a = "/interfaces/interface[*]/subinterfaces/subinterface[*]/state/mtu"
+	const b = "/interfaces/interface[*]/subinterfaces/subinterface[*]/state"
 
 	assert.Assert(t, hasPrefixMultipleIdx(a, b), "a should match b", a, b)
 
-	const c = "/openconfig-interfaces:interfaces/interface[*]/state"
+	const c = "/interfaces/interface[*]/state"
 	assert.Assert(t, !hasPrefixMultipleIdx(a, c), "a should NOT match b", a, c)
 }

--- a/pkg/modelregistry/jsonvalues/testdata/sample-openconfig.json
+++ b/pkg/modelregistry/jsonvalues/testdata/sample-openconfig.json
@@ -1,5 +1,5 @@
 {
-  "openconfig-interfaces:interfaces": {
+  "interfaces": {
     "interface": [
       {
         "name": "eth1",
@@ -19,7 +19,7 @@
       }
     ]
   },
-  "openconfig-system:system": {
+  "system": {
     "ntp": {
       "state": {
         "auth-mismatch": 123456,
@@ -27,7 +27,7 @@
         "ntp-source-address": "192.168.0.17"
       }
     },
-    "openconfig-aaa:aaa": {
+    "aaa": {
       "server-groups": {
         "server-group": [
           {

--- a/pkg/modelregistry/modelregistryTestDevice1_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice1_test.go
@@ -32,34 +32,34 @@ func Test_SchemaTestDevice1(t *testing.T) {
 	for _, p := range readOnlyPathsKeys {
 		switch p {
 		case
-			"/test1:cont1b-state",
-			"/test1:cont1a/cont2a/leaf2c":
+			"/cont1b-state",
+			"/cont1a/cont2a/leaf2c":
 
 		default:
 			t.Fatal("Unexpected readOnlyPath", p)
 		}
 	}
 
-	leaf2c, leaf2cOk := readOnlyPathsTestDevice1["/test1:cont1a/cont2a/leaf2c"]
-	assert.Assert(t, leaf2cOk, "expected to get /test1:cont1a/cont2a/leaf2c")
-	assert.Equal(t, len(leaf2c), 1, "expected /test1:cont1a/cont2a/leaf2c to have only 1 subpath")
+	leaf2c, leaf2cOk := readOnlyPathsTestDevice1["/cont1a/cont2a/leaf2c"]
+	assert.Assert(t, leaf2cOk, "expected to get /cont1a/cont2a/leaf2c")
+	assert.Equal(t, len(leaf2c), 1, "expected /cont1a/cont2a/leaf2c to have only 1 subpath")
 	leaf2cVt, leaf2cVtOk := leaf2c["/"]
-	assert.Assert(t, leaf2cVtOk, "expected /test1:cont1a/cont2a/leaf2c to have subpath /")
+	assert.Assert(t, leaf2cVtOk, "expected /cont1a/cont2a/leaf2c to have subpath /")
 	assert.Equal(t, leaf2cVt, change.ValueTypeSTRING)
 
-	cont1b, cont1bOk := readOnlyPathsTestDevice1["/test1:cont1b-state"]
-	assert.Assert(t, cont1bOk, "expected to get /test1:cont1b-state")
-	assert.Equal(t, len(cont1b), 3, "expected /test1:cont1b-state to have 3 subpaths")
+	cont1b, cont1bOk := readOnlyPathsTestDevice1["/cont1b-state"]
+	assert.Assert(t, cont1bOk, "expected to get /cont1b-state")
+	assert.Equal(t, len(cont1b), 3, "expected /cont1b-state to have 3 subpaths")
 
 	cont1bVt, cont1bVtOk := cont1b["/leaf2d"]
-	assert.Assert(t, cont1bVtOk, "expected /test1:cont1b-state to have subpath /leaf2d")
+	assert.Assert(t, cont1bVtOk, "expected /cont1b-state to have subpath /leaf2d")
 	assert.Equal(t, cont1bVt, change.ValueTypeUINT)
 
 	l2bIdxVt, l2bIdxVtOk := cont1b["/list2b[index=*]/index"]
-	assert.Assert(t, l2bIdxVtOk, "expected /test1:cont1b-state to have subpath /list2b[index[*]/index")
+	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
 	assert.Equal(t, l2bIdxVt, change.ValueTypeUINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1b["/list2b[index=*]/leaf3c"]
-	assert.Assert(t, l2bLeaf3cVtOk, "expected /test1:cont1b-state to have subpath /list2b[index[*]/leaf3c")
+	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
 	assert.Equal(t, l2bLeaf3cVt, change.ValueTypeSTRING)
 }

--- a/pkg/modelregistry/modelregistryTestDevice1_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice1_test.go
@@ -24,7 +24,7 @@ import (
 
 func Test_SchemaTestDevice1(t *testing.T) {
 	td1Schema, _ := td1.UnzipSchema()
-	readOnlyPathsTestDevice1 := ExtractReadOnlyPaths(td1Schema["Device"], yang.TSUnset, "", "", "")
+	readOnlyPathsTestDevice1 := ExtractReadOnlyPaths(td1Schema["Device"], yang.TSUnset, "", "")
 
 	readOnlyPathsKeys := Paths(readOnlyPathsTestDevice1)
 	assert.Equal(t, len(readOnlyPathsKeys), 2)

--- a/pkg/modelregistry/modelregistryTestDevice2_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice2_test.go
@@ -24,7 +24,7 @@ import (
 
 func Test_SchemaTestDevice2(t *testing.T) {
 	td2Schema, _ := td2.UnzipSchema()
-	readOnlyPathsTestDevice1 := ExtractReadOnlyPaths(td2Schema["Device"], yang.TSUnset, "", "", "")
+	readOnlyPathsTestDevice1 := ExtractReadOnlyPaths(td2Schema["Device"], yang.TSUnset, "", "")
 
 	readOnlyPathsKeys := Paths(readOnlyPathsTestDevice1)
 	assert.Equal(t, len(readOnlyPathsKeys), 2)

--- a/pkg/modelregistry/modelregistryTestDevice2_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice2_test.go
@@ -32,34 +32,34 @@ func Test_SchemaTestDevice2(t *testing.T) {
 	for _, p := range readOnlyPathsKeys {
 		switch p {
 		case
-			"/test1:cont1b-state",
-			"/test1:cont1a/cont2a/leaf2c":
+			"/cont1b-state",
+			"/cont1a/cont2a/leaf2c":
 
 		default:
 			t.Fatal("Unexpected readOnlyPath", p)
 		}
 	}
 
-	leaf2c, leaf2cOk := readOnlyPathsTestDevice1["/test1:cont1a/cont2a/leaf2c"]
-	assert.Assert(t, leaf2cOk, "expected to get /test1:cont1a/cont2a/leaf2c")
-	assert.Equal(t, len(leaf2c), 1, "expected /test1:cont1a/cont2a/leaf2c to have only 1 subpath")
+	leaf2c, leaf2cOk := readOnlyPathsTestDevice1["/cont1a/cont2a/leaf2c"]
+	assert.Assert(t, leaf2cOk, "expected to get /cont1a/cont2a/leaf2c")
+	assert.Equal(t, len(leaf2c), 1, "expected /cont1a/cont2a/leaf2c to have only 1 subpath")
 	leaf2cVt, leaf2cVtOk := leaf2c["/"]
-	assert.Assert(t, leaf2cVtOk, "expected /test1:cont1a/cont2a/leaf2c to have subpath /")
+	assert.Assert(t, leaf2cVtOk, "expected /cont1a/cont2a/leaf2c to have subpath /")
 	assert.Equal(t, leaf2cVt, change.ValueTypeSTRING)
 
-	cont1b, cont1bOk := readOnlyPathsTestDevice1["/test1:cont1b-state"]
-	assert.Assert(t, cont1bOk, "expected to get /test1:cont1b-state")
-	assert.Equal(t, len(cont1b), 5, "expected /test1:cont1b-state to have 5 subpaths")
+	cont1b, cont1bOk := readOnlyPathsTestDevice1["/cont1b-state"]
+	assert.Assert(t, cont1bOk, "expected to get /cont1b-state")
+	assert.Equal(t, len(cont1b), 5, "expected /cont1b-state to have 5 subpaths")
 
 	cont1bVt, cont1bVtOk := cont1b["/leaf2d"]
-	assert.Assert(t, cont1bVtOk, "expected /test1:cont1b-state to have subpath /leaf2d")
+	assert.Assert(t, cont1bVtOk, "expected /cont1b-state to have subpath /leaf2d")
 	assert.Equal(t, cont1bVt, change.ValueTypeUINT)
 
 	l2bIdxVt, l2bIdxVtOk := cont1b["/list2b[index=*]/index"]
-	assert.Assert(t, l2bIdxVtOk, "expected /test1:cont1b-state to have subpath /list2b[index[*]/index")
+	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
 	assert.Equal(t, l2bIdxVt, change.ValueTypeUINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1b["/list2b[index=*]/leaf3c"]
-	assert.Assert(t, l2bLeaf3cVtOk, "expected /test1:cont1b-state to have subpath /list2b[index[*]/leaf3c")
+	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
 	assert.Equal(t, l2bLeaf3cVt, change.ValueTypeSTRING)
 }

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -42,7 +42,7 @@ func TestMain(m *testing.M) {
 	var modelPluginTest modelPluginTest
 
 	ds1Schema, _ = modelPluginTest.Schema()
-	readOnlyPaths = ExtractReadOnlyPaths(ds1Schema["Device"], yang.TSUnset, "", "", "")
+	readOnlyPaths = ExtractReadOnlyPaths(ds1Schema["Device"], yang.TSUnset, "", "")
 }
 
 func (m modelPluginTest) ModelData() (string, string, []*gnmi.ModelData, string) {
@@ -98,43 +98,43 @@ func Test_Schema(t *testing.T) {
 	for _, p := range readOnlyPathsKeys {
 		switch p {
 		case
-			"/openconfig-platform:components/component[name=*]/properties/property[name=*]/state",
-			"/openconfig-platform:components/component[name=*]/state",
-			"/openconfig-platform:components/component[name=*]/subcomponents/subcomponent[name=*]/state",
-			"/openconfig-interfaces:interfaces/interface[name=*]/subinterfaces/subinterface[index=*]/state",
-			"/openconfig-interfaces:interfaces/interface[name=*]/hold-time/state",
-			"/openconfig-interfaces:interfaces/interface[name=*]/state",
-			"/openconfig-system:system/dns/host-entries/host-entry[hostname=*]/state",
-			"/openconfig-system:system/dns/servers/server[address=*]/state",
-			"/openconfig-system:system/dns/state",
-			"/openconfig-system:system/openconfig-system-logging:logging/console/state",
-			"/openconfig-system:system/openconfig-system-logging:logging/console/selectors/selector[facility severity=*]/state",
-			"/openconfig-system:system/openconfig-system-logging:logging/remote-servers/remote-server[host=*]/state",
-			"/openconfig-system:system/openconfig-system-logging:logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/state",
-			"/openconfig-system:system/state",
-			"/openconfig-system:system/openconfig-system-terminal:telnet-server/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/accounting/events/event[event-type=*]/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/accounting/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/authentication/admin-user/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/authentication/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/authentication/users/user[username=*]/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/authorization/events/event[event-type=*]/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/authorization/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/servers/server[address=*]/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/servers/server[address=*]/tacacs/state",
-			"/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/state",
-			"/openconfig-system:system/clock/state",
-			"/openconfig-system:system/openconfig-openflow:openflow/agent/state",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=*]/connections/connection[aux-id=*]/state",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=*]/state",
-			"/openconfig-system:system/openconfig-procmon:processes/process[pid=*]",
-			"/openconfig-system:system/openconfig-system-terminal:ssh-server/state",
-			"/openconfig-system:system/memory/state",
-			"/openconfig-system:system/ntp/ntp-keys/ntp-key[key-id=*]/state",
-			"/openconfig-system:system/ntp/servers/server[address=*]/state",
-			"/openconfig-system:system/ntp/state":
+			"/components/component[name=*]/properties/property[name=*]/state",
+			"/components/component[name=*]/state",
+			"/components/component[name=*]/subcomponents/subcomponent[name=*]/state",
+			"/interfaces/interface[name=*]/subinterfaces/subinterface[index=*]/state",
+			"/interfaces/interface[name=*]/hold-time/state",
+			"/interfaces/interface[name=*]/state",
+			"/system/dns/host-entries/host-entry[hostname=*]/state",
+			"/system/dns/servers/server[address=*]/state",
+			"/system/dns/state",
+			"/system/logging/console/state",
+			"/system/logging/console/selectors/selector[facility severity=*]/state",
+			"/system/logging/remote-servers/remote-server[host=*]/state",
+			"/system/logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/state",
+			"/system/state",
+			"/system/telnet-server/state",
+			"/system/aaa/state",
+			"/system/aaa/accounting/events/event[event-type=*]/state",
+			"/system/aaa/accounting/state",
+			"/system/aaa/authentication/admin-user/state",
+			"/system/aaa/authentication/state",
+			"/system/aaa/authentication/users/user[username=*]/state",
+			"/system/aaa/authorization/events/event[event-type=*]/state",
+			"/system/aaa/authorization/state",
+			"/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state",
+			"/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/state",
+			"/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/tacacs/state",
+			"/system/aaa/server-groups/server-group[name=*]/state",
+			"/system/clock/state",
+			"/system/openflow/agent/state",
+			"/system/openflow/controllers/controller[name=*]/connections/connection[aux-id=*]/state",
+			"/system/openflow/controllers/controller[name=*]/state",
+			"/system/processes/process[pid=*]",
+			"/system/ssh-server/state",
+			"/system/memory/state",
+			"/system/ntp/ntp-keys/ntp-key[key-id=*]/state",
+			"/system/ntp/servers/server[address=*]/state",
+			"/system/ntp/state":
 
 		default:
 			t.Fatal("Unexpected readOnlyPath", p)
@@ -144,7 +144,7 @@ func Test_Schema(t *testing.T) {
 
 func Test_State(t *testing.T) {
 
-	k := "/openconfig-platform:components/component[name=*]/properties/property[name=*]/state"
+	k := "/components/component[name=*]/properties/property[name=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/configurable", "/name", "/value":
@@ -156,7 +156,7 @@ func Test_State(t *testing.T) {
 
 func Test_Component(t *testing.T) {
 
-	k := "/openconfig-platform:components/component[name=*]/state"
+	k := "/components/component[name=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/description", "/id", "/mfg-name", "/name", "/part-no", "/serial-no", "/type", "/version":
@@ -168,7 +168,7 @@ func Test_Component(t *testing.T) {
 
 func Test_SubComponent(t *testing.T) {
 
-	k := "/openconfig-platform:components/component[name=*]/subcomponents/subcomponent[name=*]/state"
+	k := "/components/component[name=*]/subcomponents/subcomponent[name=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/name":
@@ -180,7 +180,7 @@ func Test_SubComponent(t *testing.T) {
 
 func Test_hold_time(t *testing.T) {
 
-	k := "/openconfig-interfaces:interfaces/interface[name=*]/hold-time/state"
+	k := "/interfaces/interface[name=*]/hold-time/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/down", "/up":
@@ -192,7 +192,7 @@ func Test_hold_time(t *testing.T) {
 
 func Test_SubInterfaces(t *testing.T) {
 
-	k := "/openconfig-interfaces:interfaces/interface[name=*]/subinterfaces/subinterface[index=*]/state"
+	k := "/interfaces/interface[name=*]/subinterfaces/subinterface[index=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/admin-status", "/description", "/enabled", "/ifindex", "/index", "/last-change", "/name", "/oper-status":
@@ -204,7 +204,7 @@ func Test_SubInterfaces(t *testing.T) {
 
 func Test_InterfaceName(t *testing.T) {
 
-	k := "/openconfig-interfaces:interfaces/interface[name=*]/state"
+	k := "/interfaces/interface[name=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/admin-status", "/description", "/enabled", "/hardware-port", "/ifindex", "/last-change", "/mtu", "/name", "/oper-status", "/type":
@@ -216,7 +216,7 @@ func Test_InterfaceName(t *testing.T) {
 
 func Test_DnsHost(t *testing.T) {
 
-	k := "/openconfig-system:system/dns/host-entries/host-entry[hostname=*]/state"
+	k := "/system/dns/host-entries/host-entry[hostname=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/hostname":
@@ -228,7 +228,7 @@ func Test_DnsHost(t *testing.T) {
 
 func Test_DnsServer(t *testing.T) {
 
-	k := "/openconfig-system:system/dns/servers/server[address=*]/state"
+	k := "/system/dns/servers/server[address=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/address", "/port":
@@ -240,7 +240,7 @@ func Test_DnsServer(t *testing.T) {
 
 func Test_Dns(t *testing.T) {
 
-	k := "/openconfig-system:system/dns/state"
+	k := "/system/dns/state"
 	if len(readOnlyPaths[k]) != 0 {
 		t.Fatalf("Unexpected readOnlyPath sub path %v for %s", readOnlyPaths, k)
 	}
@@ -248,7 +248,7 @@ func Test_Dns(t *testing.T) {
 
 func Test_LoggingConsole(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-system-logging:logging/console/state"
+	k := "/system/logging/console/state"
 	if len(readOnlyPaths[k]) != 0 {
 		t.Fatalf("Unexpected readOnlyPath sub path %v for %s", readOnlyPaths, k)
 	}
@@ -256,7 +256,7 @@ func Test_LoggingConsole(t *testing.T) {
 
 func Test_LoggingSelector(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-system-logging:logging/console/selectors/selector[facility severity=*]/state"
+	k := "/system/logging/console/selectors/selector[facility severity=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/facility", "/severity":
@@ -268,7 +268,7 @@ func Test_LoggingSelector(t *testing.T) {
 
 func Test_LoggingServer(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-system-logging:logging/remote-servers/remote-server[host=*]/state"
+	k := "/system/logging/remote-servers/remote-server[host=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/host", "/remote-port", "/source-address":
@@ -280,7 +280,7 @@ func Test_LoggingServer(t *testing.T) {
 
 func Test_Logging(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-system-logging:logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/state"
+	k := "/system/logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/facility", "/severity":
@@ -292,7 +292,7 @@ func Test_Logging(t *testing.T) {
 
 func Test_SysState(t *testing.T) {
 
-	k := "/openconfig-system:system/state"
+	k := "/system/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/boot-time", "/current-datetime", "/domain-name", "/hostname", "/login-banner", "/motd-banner":
@@ -304,7 +304,7 @@ func Test_SysState(t *testing.T) {
 
 func Test_Telnet(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-system-terminal:telnet-server/state"
+	k := "/system/telnet-server/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/enable", "/rate-limit", "/session-limit", "/timeout":
@@ -316,7 +316,7 @@ func Test_Telnet(t *testing.T) {
 
 func Test_AAA(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/state"
+	k := "/system/aaa/state"
 	if len(readOnlyPaths[k]) != 0 {
 		t.Fatalf("Unexpected readOnlyPath sub path %v for %s", readOnlyPaths, k)
 	}
@@ -324,7 +324,7 @@ func Test_AAA(t *testing.T) {
 
 func Test_AccountingEvents(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/accounting/events/event[event-type=*]/state"
+	k := "/system/aaa/accounting/events/event[event-type=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/event-type", "/record":
@@ -336,7 +336,7 @@ func Test_AccountingEvents(t *testing.T) {
 
 func Test_Accounting(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/accounting/state"
+	k := "/system/aaa/accounting/state"
 	if len(readOnlyPaths[k]) != 0 {
 		t.Fatalf("Unexpected readOnlyPath sub path %v for %s", readOnlyPaths, k)
 	}
@@ -344,7 +344,7 @@ func Test_Accounting(t *testing.T) {
 
 func Test_AuthAdmin(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/authentication/admin-user/state"
+	k := "/system/aaa/authentication/admin-user/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/admin-password", "/admin-password-hashed", "/admin-username":
@@ -356,7 +356,7 @@ func Test_AuthAdmin(t *testing.T) {
 
 func Test_AuthState(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/authentication/state"
+	k := "/system/aaa/authentication/state"
 	if len(readOnlyPaths[k]) != 0 {
 		t.Fatalf("Unexpected readOnlyPath sub path %v for %s", readOnlyPaths, k)
 	}
@@ -364,7 +364,7 @@ func Test_AuthState(t *testing.T) {
 
 func Test_AuthUser(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/authentication/users/user[username=*]/state"
+	k := "/system/aaa/authentication/users/user[username=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/password", "/password-hashed", "/role", "/ssh-key", "/username":
@@ -376,7 +376,7 @@ func Test_AuthUser(t *testing.T) {
 
 func Test_AuthEvent(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/authorization/events/event[event-type=*]/state"
+	k := "/system/aaa/authorization/events/event[event-type=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/event-type":
@@ -388,7 +388,7 @@ func Test_AuthEvent(t *testing.T) {
 
 func Test_Auth(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/authorization/state"
+	k := "/system/aaa/authorization/state"
 	if len(readOnlyPaths[k]) != 0 {
 		t.Fatalf("Unexpected readOnlyPath sub path %v for %s", readOnlyPaths, k)
 	}
@@ -396,7 +396,7 @@ func Test_Auth(t *testing.T) {
 
 func Test_Radius(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state"
+	k := "/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/radius/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/acct-port", "/auth-port", "/retransmit-attempts", "/secret-key", "/source-address":
@@ -408,7 +408,7 @@ func Test_Radius(t *testing.T) {
 
 func Test_AAAServerGroup(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/servers/server[address=*]/state"
+	k := "/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/address", "/connection-aborts", "/connection-closes", "/connection-failures", "/connection-opens",
@@ -421,7 +421,7 @@ func Test_AAAServerGroup(t *testing.T) {
 
 func Test_AAAtacacs(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/servers/server[address=*]/tacacs/state"
+	k := "/system/aaa/server-groups/server-group[name=*]/servers/server[address=*]/tacacs/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/port", "/secret-key", "/source-address":
@@ -433,7 +433,7 @@ func Test_AAAtacacs(t *testing.T) {
 
 func Test_AAAServer(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-aaa:aaa/server-groups/server-group[name=*]/state"
+	k := "/system/aaa/server-groups/server-group[name=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/name", "/type":
@@ -445,7 +445,7 @@ func Test_AAAServer(t *testing.T) {
 
 func Test_Clock(t *testing.T) {
 
-	k := "/openconfig-system:system/clock/state"
+	k := "/system/clock/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/timezone-name":
@@ -457,7 +457,7 @@ func Test_Clock(t *testing.T) {
 
 func Test_OfAgent(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-openflow:openflow/agent/state"
+	k := "/system/openflow/agent/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/backoff-interval", "/datapath-id", "/failure-mode", "/inactivity-probe", "/max-backoff":
@@ -469,7 +469,7 @@ func Test_OfAgent(t *testing.T) {
 
 func Test_OFControllerConnection(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=*]/connections/connection[aux-id=*]/state"
+	k := "/system/openflow/controllers/controller[name=*]/connections/connection[aux-id=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/address", "/aux-id", "/connected", "/port", "/priority", "/source-interface", "/transport":
@@ -481,7 +481,7 @@ func Test_OFControllerConnection(t *testing.T) {
 
 func Test_OfControllers(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[name=*]/state"
+	k := "/system/openflow/controllers/controller[name=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/name":
@@ -493,7 +493,7 @@ func Test_OfControllers(t *testing.T) {
 
 func Test_ProcMonProcess(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-procmon:processes/process[pid=*]"
+	k := "/system/processes/process[pid=*]"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/cpu-usage-system", "/cpu-usage-user", "/cpu-utilization", "/memory-usage", "/memory-utilization",
@@ -506,7 +506,7 @@ func Test_ProcMonProcess(t *testing.T) {
 
 func Test_SshServer(t *testing.T) {
 
-	k := "/openconfig-system:system/openconfig-system-terminal:ssh-server/state"
+	k := "/system/ssh-server/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/enable", "/protocol-version", "/rate-limit", "/session-limit", "/timeout":
@@ -518,7 +518,7 @@ func Test_SshServer(t *testing.T) {
 
 func Test_SystemMemory(t *testing.T) {
 
-	k := "/openconfig-system:system/memory/state"
+	k := "/system/memory/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/physical", "/reserved":
@@ -530,7 +530,7 @@ func Test_SystemMemory(t *testing.T) {
 
 func Test_NtpKeys(t *testing.T) {
 
-	k := "/openconfig-system:system/ntp/ntp-keys/ntp-key[key-id=*]/state"
+	k := "/system/ntp/ntp-keys/ntp-key[key-id=*]/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/key-id", "/key-type", "/key-value":
@@ -542,7 +542,7 @@ func Test_NtpKeys(t *testing.T) {
 
 func Test_NtpServer(t *testing.T) {
 
-	k := "/openconfig-system:system/ntp/servers/server[address=*]/state"
+	k := "/system/ntp/servers/server[address=*]/state"
 	for p, v := range readOnlyPaths[k] {
 		switch p {
 		case "/address", "/association-type", "/port":
@@ -559,7 +559,7 @@ func Test_NtpServer(t *testing.T) {
 
 func Test_Ntp(t *testing.T) {
 
-	k := "/openconfig-system:system/ntp/state"
+	k := "/system/ntp/state"
 	for p := range readOnlyPaths[k] {
 		switch p {
 		case "/auth-mismatch", "/enable-ntp-auth", "/enabled", "/ntp-source-address":
@@ -571,20 +571,20 @@ func Test_Ntp(t *testing.T) {
 
 func Test_RemovePathIndices(t *testing.T) {
 	assert.Equal(t,
-		RemovePathIndices("/test1:cont1b-state"),
-		"/test1:cont1b-state")
+		RemovePathIndices("/cont1b-state"),
+		"/cont1b-state")
 
 	assert.Equal(t,
-		RemovePathIndices("/test1:cont1b-state/list2b[index=test1]/index"),
-		"/test1:cont1b-state/list2b[index=*]/index")
+		RemovePathIndices("/cont1b-state/list2b[index=test1]/index"),
+		"/cont1b-state/list2b[index=*]/index")
 
 	assert.Equal(t,
-		RemovePathIndices("/test1:cont1b-state/list2b[index=test1,test2]/index"),
-		"/test1:cont1b-state/list2b[index=*]/index")
+		RemovePathIndices("/cont1b-state/list2b[index=test1,test2]/index"),
+		"/cont1b-state/list2b[index=*]/index")
 
 	assert.Equal(t,
-		RemovePathIndices("/test1:cont1b-state/list2b[index=test1]/index/t3[name=5]"),
-		"/test1:cont1b-state/list2b[index=*]/index/t3[name=*]")
+		RemovePathIndices("/cont1b-state/list2b[index=test1]/index/t3[name=5]"),
+		"/cont1b-state/list2b[index=*]/index/t3[name=*]")
 
 }
 
@@ -593,7 +593,7 @@ func Test_formatName1(t *testing.T) {
 		Name:   "testname",
 		Prefix: &yang.Value{Name: "pfx1"},
 	}
-	assert.Equal(t, formatName(&dirEntry1, false, "pfx1", "/pfx1:testpath/testpath2", ""), "/pfx1:testpath/testpath2/testname")
+	assert.Equal(t, formatName(&dirEntry1, false, "/testpath/testpath2", ""), "/testpath/testpath2/testname")
 }
 
 func Test_formatName2(t *testing.T) {
@@ -602,5 +602,5 @@ func Test_formatName2(t *testing.T) {
 		Key:    "name",
 		Prefix: &yang.Value{Name: "pfx1"},
 	}
-	assert.Equal(t, formatName(&dirEntry1, true, "pfx1", "/pfx1:testpath/testpath2", ""), "/pfx1:testpath/testpath2/testname[name=*]")
+	assert.Equal(t, formatName(&dirEntry1, true, "/testpath/testpath2", ""), "/testpath/testpath2/testname[name=*]")
 }

--- a/pkg/northbound/diags/diags_test.go
+++ b/pkg/northbound/diags/diags_test.go
@@ -45,7 +45,7 @@ func Test_GetChanges_All(t *testing.T) {
 }
 
 func Test_GetChanges_Change(t *testing.T) {
-	testGetChanges(t, "50XCdm605t2/jZoPePGiUvboQzg=")
+	testGetChanges(t, "tAk3GZSh1qbdhdm5414r46RLvqw=")
 }
 
 func testGetChanges(t *testing.T, changeID string) {

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -42,7 +42,7 @@ func Test_getNoTarget(t *testing.T) {
 func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 	server, _ := setUp()
 
-	prefixPath, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a"})
+	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
 
 	request := gnmi.GetRequest{
@@ -125,7 +125,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 func Test_get2PathsWithPrefix(t *testing.T) {
 	server, _ := setUp()
 
-	prefixPath, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a"})
+	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
 
 	leafAPath, err := utils.ParseGNMIElements([]string{"leaf2a"})
@@ -149,7 +149,7 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 	assert.Equal(t, len(result.Notification[0].Update), 1)
 
 	assert.Equal(t, utils.StrPath(result.Notification[0].Prefix),
-		"/test1:cont1a/cont2a")
+		"/cont1a/cont2a")
 	assert.Equal(t, utils.StrPath(result.Notification[0].Update[0].Path),
 		"/leaf2a")
 	assert.Equal(t, result.Notification[0].Update[0].GetVal().GetUintVal(), uint64(13))
@@ -162,7 +162,7 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 	server, _ := setUp()
 
-	prefixPath, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a"})
+	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
 	prefixPath.Target = "Device1"
 
@@ -178,7 +178,7 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 	assert.Equal(t, len(result.Notification[0].Update), 1)
 
 	assert.Equal(t, utils.StrPath(result.Notification[0].Prefix),
-		"/test1:cont1a/cont2a")
+		"/cont1a/cont2a")
 
 	assert.Equal(t, utils.StrPath(result.Notification[0].Update[0].Path),
 		"/")
@@ -189,7 +189,7 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 func Test_targetDoesNotExist(t *testing.T) {
 	server, _ := setUp()
 
-	prefixPath, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a"})
+	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
 	prefixPath.Target = "Device3"
 
@@ -206,7 +206,7 @@ func Test_targetDoesNotExist(t *testing.T) {
 func Test_pathDoesNotExist(t *testing.T) {
 	server, _ := setUp()
 
-	prefixPath, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a"})
+	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
 	prefixPath.Target = "Device1"
 	path, err := utils.ParseGNMIElements([]string{"leaf2w"})
@@ -225,7 +225,7 @@ func Test_pathDoesNotExist(t *testing.T) {
 	assert.Equal(t, len(result.Notification[0].Update), 1)
 
 	assert.Equal(t, utils.StrPath(result.Notification[0].Prefix),
-		"/test1:cont1a/cont2a")
+		"/cont1a/cont2a")
 
 	assert.Equal(t, utils.StrPath(result.Notification[0].Update[0].Path),
 		"/leaf2w")

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -35,7 +35,7 @@ func Test_doSingleSet(t *testing.T) {
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
 
-	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a", "leaf2a"})
+	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	typedValue := gnmi.TypedValue_UintVal{UintVal: 16}
 	value := gnmi.TypedValue{Value: &typedValue}
 	updatePath := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "Device1"}
@@ -76,7 +76,7 @@ func Test_doSingleSet(t *testing.T) {
 
 	assert.Equal(t, len(path.Elem), 3, "Expected 3 path elements")
 
-	assert.Equal(t, path.Elem[0].Name, "test1:cont1a")
+	assert.Equal(t, path.Elem[0].Name, "cont1a")
 	assert.Equal(t, path.Elem[1].Name, "cont2a")
 	assert.Equal(t, path.Elem[2].Name, "leaf2a")
 
@@ -100,13 +100,13 @@ func Test_doSingleSet(t *testing.T) {
 
 	changeID, ok := nwChange.ConfigurationChanges["Device1-1.0.0"]
 	assert.Assert(t, ok)
-	assert.Equal(t, store.B64(changeID), "WfJRlDpr8wXmvVzlqNe3SzDAdWw=")
+	assert.Equal(t, store.B64(changeID), "few5qsScVH0YFFapIqfq+dyvuks=")
 
 	assert.Equal(t, len(manager.GetManager().ChangeStore.Store), 13)
 	newChange, ok := manager.GetManager().ChangeStore.Store[store.B64(changeID)]
 	assert.Assert(t, ok)
 	assert.Equal(t, len(newChange.Config), 1)
-	assert.Equal(t, newChange.Config[0].Path, "/test1:cont1a/cont2a/leaf2a")
+	assert.Equal(t, newChange.Config[0].Path, "/cont1a/cont2a/leaf2a")
 	assert.Equal(t, (*change.TypedUint64)(&newChange.Config[0].TypedValue).Uint(), uint(16))
 }
 

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -75,7 +75,7 @@ func (x gNMISubscribeServerPollFake) Recv() (*gnmi.SubscribeRequest, error) {
 func Test_SubscribeLeafOnce(t *testing.T) {
 	server, _ := setUp()
 
-	path, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a", "leaf2a"})
+	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
 	assert.NilError(t, err, "Unexpected error doing parsing")
 
@@ -97,7 +97,7 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 	assert.NilError(t, err, "Unexpected error doing Subscribe")
 
 	device1 := "Device1"
-	path1Once := "test1:cont1a"
+	path1Once := "cont1a"
 	path2Once := "cont2a"
 	path3Once := "leaf2a"
 	value := uint(13)
@@ -111,7 +111,7 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 func Test_SubscribeLeafStream(t *testing.T) {
 	server, _ := setUp()
 
-	path, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a", "leaf4a"})
+	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
 	assert.NilError(t, err, "Unexpected error doing parsing")
 
@@ -200,10 +200,10 @@ func Test_WrongDevice(t *testing.T) {
 	}
 
 	targets["Device1"] = struct{}{}
-	subs["/test1:cont1a/cont2a/leaf3c"] = struct{}{}
+	subs["/cont1a/cont2a/leaf3c"] = struct{}{}
 	go listenForUpdates(changeChan, serverFake, mgr, targets, subs, resChan)
-	config1Value05, _ := change.CreateChangeValue("/test1:cont1a/cont2a/leaf2c", change.CreateTypedValueString("def"), false)
-	config1Value09, _ := change.CreateChangeValue("/test1:cont1a/list2a[name=txout2]", change.CreateTypedValueEmpty(), true)
+	config1Value05, _ := change.CreateChangeValue("/cont1a/cont2a/leaf2c", change.CreateTypedValueString("def"), false)
+	config1Value09, _ := change.CreateChangeValue("/cont1a/list2a[name=txout2]", change.CreateTypedValueEmpty(), true)
 	change1, _ := change.CreateChange(change.ValueCollections{config1Value05, config1Value09}, "Remove txout 2")
 	changeChan <- events.CreateConfigEvent("Device1", change1.ID, true)
 	select {
@@ -247,7 +247,7 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 func Test_Poll(t *testing.T) {
 	server, _ := setUp()
 
-	path, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a", "leaf2a"})
+	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
 	assert.NilError(t, err, "Unexpected error doing parsing")
 
@@ -281,7 +281,7 @@ func Test_Poll(t *testing.T) {
 	serverFake.Signal <- struct{}{}
 
 	device1 := "Device1"
-	path1Poll := "test1:cont1a"
+	path1Poll := "cont1a"
 	path2Poll := "cont2a"
 	path3Poll := "leaf2a"
 	value := uint(13)
@@ -304,7 +304,7 @@ func Test_Poll(t *testing.T) {
 func Test_SubscribeLeafStreamDelete(t *testing.T) {
 	server, _ := setUp()
 
-	path, err := utils.ParseGNMIElements([]string{"test1:cont1a", "cont2a", "leaf2a"})
+	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 
 	assert.NilError(t, err, "Unexpected error doing parsing")
 

--- a/pkg/store/change/change_test.go
+++ b/pkg/store/change/change_test.go
@@ -33,20 +33,20 @@ var (
 )
 
 const (
-	Test1Cont1A                  = "/test1:cont1a"
-	Test1Cont1ACont2A            = "/test1:cont1a/cont2a"
-	Test1Cont1ACont2ALeaf2A      = "/test1:cont1a/cont2a/leaf2a"
-	Test1Cont1ACont2ALeaf2B      = "/test1:cont1a/cont2a/leaf2b"
-	Test1Cont1ACont2ALeaf2C      = "/test1:cont1a/cont2a/leaf2c"
-	Test1Cont1ACont2ALeaf2D      = "/test1:cont1a/cont2a/leaf2d"
-	Test1Cont1ACont2ALeaf2E      = "/test1:cont1a/cont2a/leaf2e"
-	Test1Cont1ACont2ALeaf2F      = "/test1:cont1a/cont2a/leaf2f"
-	Test1Cont1ALeaf1A            = "/test1:cont1a/leaf1a"
-	Test1Cont1AList2ATxout1      = "/test1:cont1a/list2a[name=txout1]"
-	Test1Cont1AList2ATxout1Txpwr = "/test1:cont1a/list2a[name=txout1]/tx-power"
-	Test1Cont1AList2ATxout2      = "/test1:cont1a/list2a[name=txout2]"
-	Test1Cont1AList2ATxout2Txpwr = "/test1:cont1a/list2a[name=txout2]/tx-power"
-	Test1Leaftoplevel            = "/test1:leafAtTopLevel"
+	Test1Cont1A                  = "/cont1a"
+	Test1Cont1ACont2A            = "/cont1a/cont2a"
+	Test1Cont1ACont2ALeaf2A      = "/cont1a/cont2a/leaf2a"
+	Test1Cont1ACont2ALeaf2B      = "/cont1a/cont2a/leaf2b"
+	Test1Cont1ACont2ALeaf2C      = "/cont1a/cont2a/leaf2c"
+	Test1Cont1ACont2ALeaf2D      = "/cont1a/cont2a/leaf2d"
+	Test1Cont1ACont2ALeaf2E      = "/cont1a/cont2a/leaf2e"
+	Test1Cont1ACont2ALeaf2F      = "/cont1a/cont2a/leaf2f"
+	Test1Cont1ALeaf1A            = "/cont1a/leaf1a"
+	Test1Cont1AList2ATxout1      = "/cont1a/list2a[name=txout1]"
+	Test1Cont1AList2ATxout1Txpwr = "/cont1a/list2a[name=txout1]/tx-power"
+	Test1Cont1AList2ATxout2      = "/cont1a/list2a[name=txout2]"
+	Test1Cont1AList2ATxout2Txpwr = "/cont1a/list2a[name=txout2]/tx-power"
+	Test1Leaftoplevel            = "/leafAtTopLevel"
 )
 
 const (
@@ -101,14 +101,14 @@ func TestMain(m *testing.M) {
 
 func Test_ConfigValue(t *testing.T) {
 	// Create ConfigValue from strings
-	path := "/test1:cont1a/cont2a/leaf2a"
+	path := "/cont1a/cont2a/leaf2a"
 	value := 13
 
 	configValue2a, _ := CreateChangeValue(path, CreateTypedValueUint64(uint(value)), false)
 
 	assert.Equal(t, configValue2a.Path, path)
 
-	assert.Equal(t, configValue2a.String(), "/test1:cont1a/cont2a/leaf2a [13 0 0 0 0 0 0 0] false")
+	assert.Equal(t, configValue2a.String(), "/cont1a/cont2a/leaf2a [13 0 0 0 0 0 0 0] false")
 }
 
 func Test_changecreation(t *testing.T) {
@@ -183,10 +183,10 @@ func Test_changeString(t *testing.T) {
 	changeObj, _ := CreateChange(ValueCollections{cv1, cv2, cv3, cv4}, "Test Change")
 
 	var expected = `"Config":[` +
-		`{"Path":"/test1:cont1a/cont2a/leaf2a","Value":"ewAAAAAAAAA=","Type":3,"TypeOpts":null,"Remove":false},` +
-		`{"Path":"/test1:cont1a/cont2a/leaf2b","Value":"QUJD","Type":1,"TypeOpts":null,"Remove":false},` +
-		`{"Path":"/test1:cont1a/cont2a/leaf2c","Value":"SGVsbG8=","Type":1,"TypeOpts":null,"Remove":false},` +
-		`{"Path":"/test1:cont1a/cont2a/leaf2d","Value":"AQ==","Type":4,"TypeOpts":null,"Remove":false}]}`
+		`{"Path":"/cont1a/cont2a/leaf2a","Value":"ewAAAAAAAAA=","Type":3,"TypeOpts":null,"Remove":false},` +
+		`{"Path":"/cont1a/cont2a/leaf2b","Value":"QUJD","Type":1,"TypeOpts":null,"Remove":false},` +
+		`{"Path":"/cont1a/cont2a/leaf2c","Value":"SGVsbG8=","Type":1,"TypeOpts":null,"Remove":false},` +
+		`{"Path":"/cont1a/cont2a/leaf2d","Value":"AQ==","Type":4,"TypeOpts":null,"Remove":false}]}`
 
 	assert.Assert(t, strings.Contains(changeObj.String(), expected),
 		"Expected change to produce string. Got", changeObj.String())

--- a/pkg/store/jsonToValues_test.go
+++ b/pkg/store/jsonToValues_test.go
@@ -62,21 +62,21 @@ func Test_DecomposeTree(t *testing.T) {
 
 		switch newPath {
 		case
-			"/openconfig-interfaces:interfaces/default-type",
-			"/openconfig-interfaces:interfaces/interface[*]/type",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/name",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/type",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/example-ll[*]",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/conn-type",
-			"/openconfig-interfaces:interfaces/interface[*]/name":
+			"/interfaces/default-type",
+			"/interfaces/interface[*]/type",
+			"/system/openflow/controllers/controller[*]/name",
+			"/system/openflow/controllers/controller[*]/type",
+			"/system/openflow/controllers/controller[*]/connections/example-ll[*]",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/conn-type",
+			"/interfaces/interface[*]/name":
 			assert.Equal(t, v.Type, change.ValueTypeSTRING, newPath)
 		case
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/discombobulator":
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/discombobulator":
 			assert.Equal(t, v.Type, change.ValueTypeBOOL, newPath)
 		case
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connections-type",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/aux-id",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connections-freq":
+			"/system/openflow/controllers/controller[*]/connections/connections-type",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/aux-id",
+			"/system/openflow/controllers/controller[*]/connections/connections-freq":
 			assert.Equal(t, v.Type, change.ValueTypeFLOAT, newPath)
 		default:
 			t.Fatal("Unexpected jsonPath", newPath)
@@ -113,17 +113,17 @@ func Test_DecomposeTree2(t *testing.T) {
 		}
 
 		switch newPath {
-		case "/openconfig-interfaces:interfaces/interface[*]/name",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/name",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/state/address",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/state/source-interface",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/state/transport":
+		case "/interfaces/interface[*]/name",
+			"/system/openflow/controllers/controller[*]/name",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/address",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/source-interface",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/transport":
 			assert.Equal(t, v.Type, change.ValueTypeSTRING, newPath)
 		case
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/aux-id",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/state/aux-id",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/state/priority",
-			"/openconfig-system:system/openconfig-openflow:openflow/controllers/controller[*]/connections/connection[*]/state/port":
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/aux-id",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/aux-id",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/priority",
+			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/port":
 			assert.Equal(t, v.Type, change.ValueTypeFLOAT, newPath)
 		default:
 			t.Fatal("Unexpected jsonPath", newPath)

--- a/pkg/store/store-api_test.go
+++ b/pkg/store/store-api_test.go
@@ -27,23 +27,23 @@ import (
 )
 
 const (
-	Test1Cont1A                  = "/test1:cont1a"
-	Test1Cont1ACont2A            = "/test1:cont1a/cont2a"
-	Test1Cont1ACont2ALeaf2A      = "/test1:cont1a/cont2a/leaf2a"
-	Test1Cont1ACont2ALeaf2B      = "/test1:cont1a/cont2a/leaf2b"
-	Test1Cont1ACont2ALeaf2C      = "/test1:cont1a/cont2a/leaf2c"
-	Test1Cont1ACont2ALeaf2D      = "/test1:cont1a/cont2a/leaf2d"
-	Test1Cont1ACont2ALeaf2E      = "/test1:cont1a/cont2a/leaf2e"
-	Test1Cont1ACont2ALeaf2F      = "/test1:cont1a/cont2a/leaf2f"
-	Test1Cont1ACont2ALeaf2G      = "/test1:cont1a/cont2a/leaf2g"
-	Test1Cont1ALeaf1A            = "/test1:cont1a/leaf1a"
-	Test1Cont1AList2ATxout1      = "/test1:cont1a/list2a[name=txout1]"
-	Test1Cont1AList2ATxout1Txpwr = "/test1:cont1a/list2a[name=txout1]/tx-power"
-	Test1Cont1AList2ATxout2      = "/test1:cont1a/list2a[name=txout2]"
-	Test1Cont1AList2ATxout2Txpwr = "/test1:cont1a/list2a[name=txout2]/tx-power"
-	Test1Cont1AList2ATxout3      = "/test1:cont1a/list2a[name=txout3]"
-	Test1Cont1AList2ATxout3Txpwr = "/test1:cont1a/list2a[name=txout3]/tx-power"
-	Test1Leaftoplevel            = "/test1:leafAtTopLevel"
+	Test1Cont1A                  = "/cont1a"
+	Test1Cont1ACont2A            = "/cont1a/cont2a"
+	Test1Cont1ACont2ALeaf2A      = "/cont1a/cont2a/leaf2a"
+	Test1Cont1ACont2ALeaf2B      = "/cont1a/cont2a/leaf2b"
+	Test1Cont1ACont2ALeaf2C      = "/cont1a/cont2a/leaf2c"
+	Test1Cont1ACont2ALeaf2D      = "/cont1a/cont2a/leaf2d"
+	Test1Cont1ACont2ALeaf2E      = "/cont1a/cont2a/leaf2e"
+	Test1Cont1ACont2ALeaf2F      = "/cont1a/cont2a/leaf2f"
+	Test1Cont1ACont2ALeaf2G      = "/cont1a/cont2a/leaf2g"
+	Test1Cont1ALeaf1A            = "/cont1a/leaf1a"
+	Test1Cont1AList2ATxout1      = "/cont1a/list2a[name=txout1]"
+	Test1Cont1AList2ATxout1Txpwr = "/cont1a/list2a[name=txout1]/tx-power"
+	Test1Cont1AList2ATxout2      = "/cont1a/list2a[name=txout2]"
+	Test1Cont1AList2ATxout2Txpwr = "/cont1a/list2a[name=txout2]/tx-power"
+	Test1Cont1AList2ATxout3      = "/cont1a/list2a[name=txout3]"
+	Test1Cont1AList2ATxout3Txpwr = "/cont1a/list2a[name=txout3]/tx-power"
+	Test1Leaftoplevel            = "/leafAtTopLevel"
 )
 
 const (
@@ -234,6 +234,8 @@ var Config2Types = [11]change.ValueType{
 	change.ValueTypeSTRING, // 10
 }
 
+var c1ID, c2ID, c3ID change.ID
+
 func TestMain(m *testing.M) {
 	log.SetOutput(os.Stdout)
 	os.Exit(m.Run())
@@ -293,6 +295,10 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 	changeStore[B64(change2.ID)] = change2
 	changeStore[B64(change3.ID)] = change3
 
+	c1ID = change1.ID
+	c2ID = change2.ID
+	c3ID = change2.ID
+
 	device1V, err = CreateConfiguration("Device1", "1.0.0", "TestDevice",
 		[]change.ID{change1.ID, change2.ID, change3.ID})
 	if err != nil {
@@ -332,7 +338,7 @@ func Test_device1_version(t *testing.T) {
 	assert.Equal(t, device1V.Name, ConfigName("Device1-1.0.0"))
 
 	//Check the value of leaf2c before
-	change1, ok := changeStore["y65WFkPuZXZgRkQ+kUL/wpjXHj8="]
+	change1, ok := changeStore[B64(c1ID)]
 	assert.Assert(t, ok)
 	assert.Equal(t, len(change1.Config), 11)
 	leaf2c := change1.Config[4]
@@ -345,7 +351,7 @@ func Test_device1_version(t *testing.T) {
 
 	// Check the value of leaf2c after - the value from the early change should be the same
 	// This is here because ExtractFullConfig had been inadvertently changing the value
-	change1, ok = changeStore["y65WFkPuZXZgRkQ+kUL/wpjXHj8="]
+	change1, ok = changeStore[B64(c1ID)]
 	assert.Assert(t, ok)
 	assert.Equal(t, len(change1.Config), 11)
 	leaf2c = change1.Config[4]

--- a/pkg/store/testdata/sample-tree-from-devicesim.json
+++ b/pkg/store/testdata/sample-tree-from-devicesim.json
@@ -1,13 +1,13 @@
 {
-  "openconfig-interfaces:interfaces": {
+  "interfaces": {
     "interface": [
       {
         "name": "admin"
       }
     ]
   },
-  "openconfig-system:system": {
-    "openconfig-openflow:openflow": {
+  "system": {
+    "openflow": {
       "controllers": {
         "controller": [
           {

--- a/pkg/store/testdata/sample-tree.json
+++ b/pkg/store/testdata/sample-tree.json
@@ -1,5 +1,5 @@
 {
-  "openconfig-interfaces:interfaces": {
+  "interfaces": {
     "default-type": "ethernet",
     "interface": [
       {
@@ -12,8 +12,8 @@
       }
     ]
   },
-  "openconfig-system:system": {
-    "openconfig-openflow:openflow": {
+  "system": {
+    "openflow": {
       "controllers": {
         "controller": [
           {

--- a/pkg/store/tree_test.go
+++ b/pkg/store/tree_test.go
@@ -20,14 +20,14 @@ import (
 	"testing"
 )
 
-const testJSON1 = `{"test1:cont1a":{"cont2a":{"leaf2a":12,"leaf2b":1.14159,"leaf2c":"myvalue1a2c","leaf2d":1.14159,"leaf2e":12,"leaf2f":"YXMgYnl0ZSBhcnJheQ==","leaf2g":true},"leaf1a":"myvalue1a1a","list2a":[{"name":"First","rx-power":6,"tx-power":5},{"name":"Second","rx-power":8,"tx-power":7}]},"test1:leafAtTopLevel":"WXY-1234"}`
+const testJSON1 = `{"cont1a":{"cont2a":{"leaf2a":12,"leaf2b":1.14159,"leaf2c":"myvalue1a2c","leaf2d":1.14159,"leaf2e":12,"leaf2f":"YXMgYnl0ZSBhcnJheQ==","leaf2g":true},"leaf1a":"myvalue1a1a","list2a":[{"name":"First","rx-power":6,"tx-power":5},{"name":"Second","rx-power":8,"tx-power":7}]},"leafAtTopLevel":"WXY-1234"}`
 
 const (
-	Test1Cont1ALeaf1a   = "/test1:cont1a/leaf1a"
-	Test1Cont1AList2a1t = "/test1:cont1a/list2a[name=First]/tx-power"
-	Test1Cont1AList2a1r = "/test1:cont1a/list2a[name=First]/rx-power"
-	Test1Cont1AList2a2t = "/test1:cont1a/list2a[name=Second]/tx-power"
-	Test1Cont1AList2a2r = "/test1:cont1a/list2a[name=Second]/rx-power"
+	Test1Cont1ALeaf1a   = "/cont1a/leaf1a"
+	Test1Cont1AList2a1t = "/cont1a/list2a[name=First]/tx-power"
+	Test1Cont1AList2a1r = "/cont1a/list2a[name=First]/rx-power"
+	Test1Cont1AList2a2t = "/cont1a/list2a[name=Second]/tx-power"
+	Test1Cont1AList2a2r = "/cont1a/list2a[name=Second]/rx-power"
 )
 
 const (

--- a/test/configs/device/default.json
+++ b/test/configs/device/default.json
@@ -1,5 +1,5 @@
 {
-  "openconfig-interfaces:interfaces": {
+  "interfaces": {
     "interface": [
       {
         "name": "admin",
@@ -9,7 +9,7 @@
       }
     ]
   },
-  "openconfig-system:system": {
+  "system": {
     "aaa": {
       "authentication": {
         "admin-user": {
@@ -35,7 +35,7 @@
       "login-banner": "This device is for authorized use only",
       "motd-banner": "replace-motd-banner"
     },
-    "openconfig-openflow:openflow": {
+    "openflow": {
       "agent": {
         "config": {
           "backoff-interval": 5,

--- a/test/integration/modelstest.go
+++ b/test/integration/modelstest.go
@@ -28,10 +28,10 @@ func init() {
 // TestModels tests GNMI operation involving unknown or illegal paths
 func TestModels(t *testing.T) {
 	const (
-		unknownPath       = "/openconfig-system:system/config/no-such-path"
-		ntpPath           = "/openconfig-system:system/ntp/state/enable-ntp-auth"
-		hostNamePath      = "/openconfig-system:system/config/hostname"
-		clockTimeZonePath = "/openconfig-system:system/clock/config/timezone-name"
+		unknownPath       = "/system/config/no-such-path"
+		ntpPath           = "/system/ntp/state/enable-ntp-auth"
+		hostNamePath      = "/system/config/hostname"
+		clockTimeZonePath = "/system/clock/config/timezone-name"
 	)
 
 	// Get the configured device from the environment.

--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	tzValue = "Europe/Dublin"
-	tzPath  = "/openconfig-system:system/clock/config/timezone-name"
+	tzPath  = "/system/clock/config/timezone-name"
 )
 
 func makeDevicePath(device string, path string) []DevicePath {

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	subValue = "Europe/Madrid"
-	subPath  = "/openconfig-system:system/clock/config/timezone-name"
+	subPath  = "/system/clock/config/timezone-name"
 )
 
 func init() {

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -26,9 +26,9 @@ import (
 
 const (
 	value1 = "test-motd-banner"
-	path1  = "/openconfig-system:system/config/motd-banner"
+	path1  = "/system/config/motd-banner"
 	value2 = "test-login-banner"
-	path2  = "/openconfig-system:system/config/login-banner"
+	path2  = "/system/config/login-banner"
 )
 
 var (


### PR DESCRIPTION
This patch removes namespace and connected methods from onos-config.
This is due to ygot not supporting namespaces and for simplification of operations.
Please see more info https://github.com/openconfig/ygot/issues/300 and in #573 

Fixes #573 