### PR TITLE
Add onos-topo deployment to onit

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -64,7 +64,7 @@ To enable this for **zsh**, run the following from the shell:
 > source <(onit completion zsh)
 ```
 
-**Note**: We also recomment to add the output of the above commands to *.bashrc* or *.zshrc*.
+**Note**: We also recommend to add the output of the above commands to *.bashrc* or *.zshrc*.
 
 ### Docker
 
@@ -157,11 +157,19 @@ The first step to running tests is to setup a test cluster with `onit create clu
 
 ```bash
 > onit create cluster
- ✓ Creating cluster namespace
- ✓ Setting up Atomix controller
- ✓ Starting Raft partitions
- ✓ Bootstrapping onos-config cluster
+✓ Creating cluster namespace
+✓ Setting up Atomix controller
+✓ Starting Raft partitions
+✓ Creating secret for onos nodes
+✓ Bootstrapping onos-config cluster
+✓ Bootstrapping onos-topo cluster
 cluster-b8c45834-a81c-11e9-82f4-3c15c2cff232
+```
+
+You can also specify the number of nodes for each onos subsystem, for example, to create a cluster which runs 
+two onos-config and two onos-topo pods, run the following command:
+```bash
+onit create cluster onit-1 --config-nodes 2 --topo-nodes 2
 ```
 
 To setup the cluster, onit creates a unique namespace within which to create test resources,
@@ -380,13 +388,18 @@ can be used to `get logs` for every resource deployed in the test cluster. Simpl
 resource ID (e.g. test `ID`, node `ID`, partition `ID`, etc) to the `onit get logs` command
 to get the logs for a resource.
 
-To list the onos-config nodes running in the cluster, use `onit get nodes`:
+To list all types of nodes (e.g. onos-topo, onos-config, etc) running in the cluster, use `onit get nodes`, the output will be like the following:
 
 ```bash
 > onit get nodes
-ID                             STATUS
-onos-config-569c7d8546-jscg8   RUNNING
+onit get nodes
+ID                             TYPE     STATUS
+onos-topo-7cd788fb7f-2zvsp     topo     RUNNING
+onos-topo-7cd788fb7f-rc6m5     topo     RUNNING
+onos-config-6f8fcf5954-55zn2   config   RUNNING
+onos-config-6f8fcf5954-pglkz   config   RUNNING
 ```
+
 
 To get logs for the above node, run the following command:
 ```bash

--- a/test/runner/cluster.go
+++ b/test/runner/cluster.go
@@ -58,10 +58,20 @@ func (c *ClusterController) Setup() console.ErrorStatus {
 		return c.status.Fail(err)
 	}
 	c.status.Succeed()
+	c.status.Start("Creating secret for onos nodes")
+	if err := c.createOnosSecret(); err != nil {
+		return c.status.Fail(err)
+	}
+	c.status.Succeed()
 	c.status.Start("Bootstrapping onos-config cluster")
 	if err := c.setupOnosConfig(); err != nil {
 		return c.status.Fail(err)
 	}
+	c.status.Start("Bootstrapping onos-topo cluster")
+	if err := c.setupOnosTopo(); err != nil {
+		return c.status.Fail(err)
+	}
+	c.status.Succeed()
 	return c.status.Succeed()
 }
 

--- a/test/runner/common.go
+++ b/test/runner/common.go
@@ -1,0 +1,141 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// NodeStatus node status
+type NodeStatus string
+
+const (
+	// NodeRunning node is running
+	NodeRunning NodeStatus = "RUNNING"
+
+	// NodeFailed node has failed
+	NodeFailed NodeStatus = "FAILED"
+)
+
+// NodeType node type
+type NodeType string
+
+const (
+	// OnosConfig  type of node is config
+	OnosConfig NodeType = "config"
+
+	// OnosTopo type of node is topo
+	OnosTopo NodeType = "topo"
+
+	// OnosAll type of node is all
+	OnosAll NodeType = "all"
+)
+
+// NodeInfo contains information about a node
+type NodeInfo struct {
+	ID     string
+	Status NodeStatus
+	Type   NodeType
+}
+
+// GetNodes returns a list of all onos nodes  running in the cluster
+func (c *ClusterController) GetNodes() ([]NodeInfo, error) {
+
+	onosTopoNodes, _ := c.GetOnosTopoNodes()
+	onosConfigNodes, _ := c.GetOnosConfigNodes()
+	nodes := append(onosTopoNodes, onosConfigNodes...)
+
+	return nodes, nil
+}
+
+// execute executes a command in the given pod
+func (c *ClusterController) execute(pod corev1.Pod, command []string) error {
+	container := pod.Spec.Containers[0]
+	req := c.kubeclient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		Param("container", container.Name)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container.Name,
+		Command:   command,
+		Stdout:    true,
+		Stderr:    true,
+		Stdin:     false,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(c.restconfig, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		print(stdout.String())
+		print(stderr.String())
+	}
+	return err
+
+}
+
+// createOnosSecret creates a secret for configuring TLS in onos nodes and clients
+func (c *ClusterController) createOnosSecret() error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.clusterID,
+			Namespace: c.clusterID,
+		},
+		StringData: map[string]string{},
+	}
+
+	err := filepath.Walk(certsPath, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		fileBytes, err := ioutil.ReadAll(file)
+		if err != nil {
+			return err
+		}
+
+		secret.StringData[info.Name()] = string(fileBytes)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = c.kubeclient.CoreV1().Secrets(c.clusterID).Create(secret)
+	return err
+}

--- a/test/runner/config.go
+++ b/test/runner/config.go
@@ -32,7 +32,8 @@ var (
 // ClusterConfig provides the configuration for the Kubernetes test cluster
 type ClusterConfig struct {
 	Preset        string `yaml:"preset" mapstructure:"preset"`
-	Nodes         int    `yaml:"nodes" mapstructure:"nodes"`
+	ConfigNodes   int    `yaml:"configNodes" mapstructure:"topoNodes"`
+	TopoNodes     int    `yaml:"topoNodes" mapstructure:"topoNodes"`
 	Partitions    int    `yaml:"partitions" mapstructure:"partitions"`
 	PartitionSize int    `yaml:"partitionSize" mapstructure:"partitionSize"`
 }

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -18,68 +18,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strconv"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
 
 	"gopkg.in/yaml.v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/remotecommand"
 )
-
-// NodeStatus node status
-type NodeStatus string
-
-const (
-	// NodeRunning node is running
-	NodeRunning NodeStatus = "RUNNING"
-
-	// NodeFailed node has failed
-	NodeFailed NodeStatus = "FAILED"
-)
-
-// NodeInfo contains information about an onos-config node
-type NodeInfo struct {
-	ID     string
-	Status NodeStatus
-}
-
-// GetNodes returns a list of onos-config nodes running in the cluster
-func (c *ClusterController) GetNodes() ([]NodeInfo, error) {
-	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: "app=onos-config",
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	nodes := make([]NodeInfo, len(pods.Items))
-	for i, pod := range pods.Items {
-		var status NodeStatus
-		if pod.Status.Phase == corev1.PodRunning {
-			status = NodeRunning
-		} else if pod.Status.Phase == corev1.PodFailed {
-			status = NodeFailed
-		}
-		nodes[i] = NodeInfo{
-			ID:     pod.Name,
-			Status: status,
-		}
-	}
-	return nodes, nil
-}
 
 // setupOnosConfig sets up the onos-config Deployment
 func (c *ClusterController) setupOnosConfig() error {
-	if err := c.createOnosConfigSecret(); err != nil {
-		return err
-	}
 	if err := c.createOnosConfigConfigMap(); err != nil {
 		return err
 	}
@@ -93,42 +45,6 @@ func (c *ClusterController) setupOnosConfig() error {
 		return err
 	}
 	return nil
-}
-
-// createOnosConfigSecret creates a secret for configuring TLS in onos-config and clients
-func (c *ClusterController) createOnosConfigSecret() error {
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.clusterID,
-			Namespace: c.clusterID,
-		},
-		StringData: map[string]string{},
-	}
-
-	err := filepath.Walk(certsPath, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
-			return nil
-		}
-
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-
-		fileBytes, err := ioutil.ReadAll(file)
-		if err != nil {
-			return err
-		}
-
-		secret.StringData[info.Name()] = string(fileBytes)
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-
-	_, err = c.kubeclient.CoreV1().Secrets(c.clusterID).Create(secret)
-	return err
 }
 
 // createOnosConfigConfigMap creates a ConfigMap for the onos-config Deployment
@@ -180,8 +96,9 @@ func (c *ClusterController) createOnosConfigConfigMap() error {
 
 // addSimulatorToConfig adds a simulator to the onos-config configuration
 func (c *ClusterController) addSimulatorToConfig(name string) error {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
 	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: "app=onos-config",
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 	})
 	if err != nil {
 		return err
@@ -197,8 +114,9 @@ func (c *ClusterController) addSimulatorToConfig(name string) error {
 
 // addNetworkToConfig adds a network to the onos-config configuration
 func (c *ClusterController) addNetworkToConfig(name string, config *NetworkConfig) error {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
 	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: "app=onos-config",
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 	})
 	if err != nil {
 		return err
@@ -235,8 +153,9 @@ func (c *ClusterController) addNetworkToPod(name string, port int, pod corev1.Po
 
 // removeSimulatorFromConfig removes a simulator from the onos-config configuration
 func (c *ClusterController) removeSimulatorFromConfig(name string) error {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
 	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: "app=onos-config",
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 	})
 	if err != nil {
 		return err
@@ -252,8 +171,9 @@ func (c *ClusterController) removeSimulatorFromConfig(name string) error {
 
 // removeNetworkFromConfig removes a network from the onos-config configuration
 func (c *ClusterController) removeNetworkFromConfig(name string, configMap *corev1.ConfigMapList) error {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
 	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: "app=onos-config",
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 	})
 	if err != nil {
 		return err
@@ -292,7 +212,7 @@ func (c *ClusterController) removeNetworkFromPod(name string, pod corev1.Pod) er
 
 // createOnosConfigDeployment creates an onos-config Deployment
 func (c *ClusterController) createOnosConfigDeployment() error {
-	nodes := int32(c.config.Nodes)
+	nodes := int32(c.config.ConfigNodes)
 	zero := int64(0)
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -303,13 +223,15 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 			Replicas: &nodes,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"app": "onos-config",
+					"app":  "onos",
+					"type": "config",
 				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"app":      "onos-config",
+						"app":      "onos",
+						"type":     "config",
 						"resource": "onos-config",
 					},
 					Annotations: map[string]string{
@@ -438,7 +360,8 @@ func (c *ClusterController) createOnosConfigService() error {
 		},
 		Spec: corev1.ServiceSpec{
 			Selector: map[string]string{
-				"app": "onos-config",
+				"app":  "onos",
+				"type": "config",
 			},
 			Ports: []corev1.ServicePort{
 				{
@@ -454,11 +377,12 @@ func (c *ClusterController) createOnosConfigService() error {
 
 // awaitOnosConfigDeploymentReady waits for the onos-config pods to complete startup
 func (c *ClusterController) awaitOnosConfigDeploymentReady() error {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
 	unblocked := make(map[string]bool)
 	for {
 		// Get a list of the pods that match the deployment
 		pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-			LabelSelector: "app=onos-config",
+			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
 		})
 		if err != nil {
 			return err
@@ -482,44 +406,38 @@ func (c *ClusterController) awaitOnosConfigDeploymentReady() error {
 		}
 
 		// Return once the all replicas in the deployment are ready
-		if int(dep.Status.ReadyReplicas) == c.config.Nodes {
+		if int(dep.Status.ReadyReplicas) == c.config.ConfigNodes {
 			return nil
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 }
 
-// execute executes a command in the given pod
-func (c *ClusterController) execute(pod corev1.Pod, command []string) error {
-	container := pod.Spec.Containers[0]
-	req := c.kubeclient.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(pod.Name).
-		Namespace(pod.Namespace).
-		SubResource("exec").
-		Param("container", container.Name)
-	req.VersionedParams(&corev1.PodExecOptions{
-		Container: container.Name,
-		Command:   command,
-		Stdout:    true,
-		Stderr:    true,
-		Stdin:     false,
-	}, scheme.ParameterCodec)
+// GetOnosConfigNodes returns a list of all onos-config nodes running in the cluster
+func (c *ClusterController) GetOnosConfigNodes() ([]NodeInfo, error) {
+	configLabelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
 
-	exec, err := remotecommand.NewSPDYExecutor(c.restconfig, "POST", req.URL())
-	if err != nil {
-		return err
-	}
-
-	var stdout, stderr bytes.Buffer
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: labels.Set(configLabelSelector.MatchLabels).String(),
 	})
 	if err != nil {
-		print(stdout.String())
-		print(stderr.String())
+		return nil, err
 	}
-	return err
+
+	onosConfigNodes := make([]NodeInfo, len(pods.Items))
+	for i, pod := range pods.Items {
+		var status NodeStatus
+		if pod.Status.Phase == corev1.PodRunning {
+			status = NodeRunning
+		} else if pod.Status.Phase == corev1.PodFailed {
+			status = NodeFailed
+		}
+		onosConfigNodes[i] = NodeInfo{
+			ID:     pod.Name,
+			Status: status,
+			Type:   OnosConfig,
+		}
+	}
+
+	return onosConfigNodes, nil
 }

--- a/test/runner/onos-topo.go
+++ b/test/runner/onos-topo.go
@@ -1,0 +1,287 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// setupOnosTopo sets up the onos-topo Deployment
+func (c *ClusterController) setupOnosTopo() error {
+	if err := c.createOnosTopoConfigMap(); err != nil {
+		return err
+	}
+
+	if err := c.createOnosTopoService(); err != nil {
+		return err
+	}
+
+	if err := c.createOnosTopoDeployment(); err != nil {
+		return err
+	}
+	if err := c.awaitOnosTopoDeploymentReady(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createOnosTopoConfigMap creates a ConfigMap for the onos-topo Deployment
+func (c *ClusterController) createOnosTopoConfigMap() error {
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "onos-topo",
+			Namespace: c.clusterID,
+		},
+		Data: map[string]string{},
+	}
+	_, err := c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
+	return err
+}
+
+// createOnosTopoService creates a Service to expose the onos-topo Deployment to other pods
+func (c *ClusterController) createOnosTopoService() error {
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "onos-topo",
+			Namespace: c.clusterID,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app":  "onos",
+				"type": "topo",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name: "grpc",
+					Port: 5150,
+				},
+			},
+		},
+	}
+	_, err := c.kubeclient.CoreV1().Services(c.clusterID).Create(service)
+	return err
+}
+
+// createOnosTopoDeployment creates an onos-topo Deployment
+func (c *ClusterController) createOnosTopoDeployment() error {
+	nodes := int32(c.config.TopoNodes)
+	zero := int64(0)
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "onos-topo",
+			Namespace: c.clusterID,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &nodes,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":  "onos",
+					"type": "topo",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":      "onos",
+						"type":     "topo",
+						"resource": "onos-topo",
+					},
+					Annotations: map[string]string{
+						"seccomp.security.alpha.kubernetes.io/pod": "unconfined",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            "onos-topo",
+							Image:           "onosproject/onos-topo:debug",
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ATOMIX_CONTROLLER",
+									Value: fmt.Sprintf("atomix-controller.%s.svc.cluster.local:5679", c.clusterID),
+								},
+								{
+									Name:  "ATOMIX_APP",
+									Value: "test",
+								},
+								{
+									Name:  "ATOMIX_NAMESPACE",
+									Value: c.clusterID,
+								},
+							},
+							Args: []string{
+								"-caPath=/etc/onos-topo/certs/onf.cacrt",
+								"-keyPath=/etc/onos-topo/certs/onos-config.key",
+								"-certPath=/etc/onos-topo/certs/onos-config.crt",
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "grpc",
+									ContainerPort: 5150,
+								},
+								{
+									Name:          "debug",
+									ContainerPort: 40000,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(5150),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+							},
+							LivenessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(5150),
+									},
+								},
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       20,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "topo",
+									MountPath: "/etc/onos-topo/configs",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret",
+									MountPath: "/etc/onos-topo/certs",
+									ReadOnly:  true,
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{
+										"SYS_PTRACE",
+									},
+								},
+							},
+						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: &zero,
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "topo",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: "onos-topo",
+									},
+								},
+							},
+						},
+						{
+							Name: "secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: c.clusterID,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err := c.kubeclient.AppsV1().Deployments(c.clusterID).Create(dep)
+	return err
+}
+
+// awaitOnosTopoDeploymentReady waits for the onos-topo pods to complete startup
+func (c *ClusterController) awaitOnosTopoDeploymentReady() error {
+	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "topo"}}
+	unblocked := make(map[string]bool)
+	for {
+		// Get a list of the pods that match the deployment
+		pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+			LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+		})
+		if err != nil {
+			return err
+		}
+
+		// Iterate through the pods in the deployment and unblock the debugger
+		for _, pod := range pods.Items {
+			if _, ok := unblocked[pod.Name]; !ok && len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].State.Running != nil {
+				err := c.execute(pod, []string{"/bin/bash", "-c", "dlv --init <(echo \"exit -c\") connect 127.0.0.1:40000"})
+				if err != nil {
+					return err
+				}
+				unblocked[pod.Name] = true
+			}
+		}
+
+		// Get the onos-topo deployment
+		dep, err := c.kubeclient.AppsV1().Deployments(c.clusterID).Get("onos-topo", metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		// Return once the all replicas in the deployment are ready
+		if int(dep.Status.ReadyReplicas) == c.config.TopoNodes {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// GetOnosTopoNodes returns a list of all onos-topo nodes running in the cluster
+func (c *ClusterController) GetOnosTopoNodes() ([]NodeInfo, error) {
+	topoLabelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "topo"}}
+
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: labels.Set(topoLabelSelector.MatchLabels).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	onosTopoNodes := make([]NodeInfo, len(pods.Items))
+	for i, pod := range pods.Items {
+		var status NodeStatus
+		if pod.Status.Phase == corev1.PodRunning {
+			status = NodeRunning
+		} else if pod.Status.Phase == corev1.PodFailed {
+			status = NodeFailed
+		}
+		onosTopoNodes[i] = NodeInfo{
+			ID:     pod.Name,
+			Status: status,
+			Type:   OnosTopo,
+		}
+	}
+
+	return onosTopoNodes, nil
+}


### PR DESCRIPTION
This PR is to address issue #532 

Example: 

Suppose you want to create an onit cluster which runs two onos-config and two onos-topo nodes. To do that run the following command:
`onit create cluster onit-2 --config-nodes 2 --topo-nodes 2`

To get list of all nodes in the cluster, run the following command:
`onit get nodes `

To get list of all onos-config nodes, run the following command:
`onit get nodes --type config`

To get list of all onos-topo nodes, run the following command: 
`onit get nodes --type topo`

**Note 1:** Until we move `onit` to its repo, the default number of onos-topo pod is set to zero.
**Note 2:**  A phase is added to create secret for the cluster (look at `createOnosSecret `function in `common.go`)