### PR TITLE
Add the golangci-lint meta linter 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,17 @@
+linters:
+  enable:
+    - gofmt
+    - gocyclo
+    - golint
+    - misspell
+    - typecheck
+    - errcheck
+run:
+  skip-dirs:
+    - modelplugin
+
+issues:
+  exclude-rules:
+    - path: pkg/northbound/gnmi/set.go
+      linters:
+        - typecheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_script:
   - go get -u github.com/fzipp/gocyclo
   - go get -u github.com/client9/misspell/cmd/misspell
   - go get -u github.com/gordonklaus/ineffassign
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
 
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,13 @@ build/_output/devicesim.so.1.0.0: modelplugin/Devicesim-1.0.0/modelmain.go model
 	-CGO_ENABLED=1 go build -o build/_output/devicesim-debug.so.1.0.0 -gcflags "all=-N -l" -buildmode=plugin -tags=modelplugin ./modelplugin/Devicesim-1.0.0
 
 test: # @HELP run the unit tests and source code validation
-test: build deps lint vet license_check gofmt cyclo misspell ineffassign
+test: build deps linters
 	go test github.com/onosproject/onos-config/pkg/...
 	go test github.com/onosproject/onos-config/cmd/...
 	go test github.com/onosproject/onos-config/modelplugin/...
 
 coverage: # @HELP generate unit test coverage data
-coverage: build deps lint vet license_check gofmt cyclo misspell ineffassign
+coverage: build deps linters
 	./build/bin/coveralls-coverage
 
 deps: # @HELP ensure that the required dependencies are in place
@@ -44,34 +44,8 @@ deps: # @HELP ensure that the required dependencies are in place
 	bash -c "diff -u <(echo -n) <(git diff go.mod)"
 	bash -c "diff -u <(echo -n) <(git diff go.sum)"
 
-lint: # @HELP run the linters for Go source code
-	golint -set_exit_status github.com/onosproject/onos-config/pkg/...
-	golint -set_exit_status github.com/onosproject/onos-config/cmd/...
-	golint -set_exit_status github.com/onosproject/onos-config/test/...
-
-vet: # @HELP examines Go source code and reports suspicious constructs
-	go vet github.com/onosproject/onos-config/pkg/...
-	go vet github.com/onosproject/onos-config/cmd/...
-	go vet github.com/onosproject/onos-config/test/...
-	go vet github.com/onosproject/onos-config/modelplugin/...
-
-cyclo: # @HELP examines Go source code and reports complex cycles in code
-	gocyclo -over 25 pkg/
-	gocyclo -over 25 cmd/
-	gocyclo -over 25 test/
-	gocyclo -over 25 modelplugin/
-
-misspell: # @HELP examines Go source code and reports misspelled words
-	misspell -error -source=text pkg/
-	misspell -error -source=text cmd/
-	misspell -error -source=text test/
-	misspell -error docs/
-
-ineffassign: # @HELP examines Go source code and reports inefficient assignments
-	ineffassign pkg/
-	ineffassign cmd/
-	ineffassign test/
-	ineffassign modelplugin/
+linters: # @HELP examines Go source code and reports coding problems
+	golangci-lint run
 
 license_check: # @HELP examine and ensure license headers exist
 	./build/licensing/boilerplate.py -v

--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -87,14 +87,13 @@ func main() {
 	caPath := flag.String("caPath", "", "path to CA certificate")
 	keyPath := flag.String("keyPath", "", "path to client private key")
 	certPath := flag.String("certPath", "", "path to client certificate")
-	var err error
 
 	//lines 93-109 are implemented according to
 	// https://github.com/kubernetes/klog/blob/master/examples/coexist_glog/coexist_glog.go
 	// because of libraries importing glog. With glog import we can't call log.InitFlags(nil) as per klog readme
 	// thus the alsologtostderr is not set properly and we issue multiple logs.
 	// Calling log.InitFlags(nil) throws panic with error `flag redefined: log_dir`
-	err = flag.Set("alsologtostderr", "true")
+	err := flag.Set("alsologtostderr", "true")
 	if err != nil {
 		log.Error("Cant' avoid double Error logging ", err)
 	}
@@ -108,7 +107,7 @@ func main() {
 		f2 := klogFlags.Lookup(f1.Name)
 		if f2 != nil {
 			value := f1.Value.String()
-			f2.Value.Set(value)
+			_ = f2.Value.Set(value)
 		}
 	})
 	log.Info("Starting onos-config")

--- a/cmd/profiling/profile-config.go
+++ b/cmd/profiling/profile-config.go
@@ -41,7 +41,7 @@ func main() {
 		fmt.Println(err)
 		return
 	}
-	pprof.StartCPUProfile(cpuFile)
+	_ = pprof.StartCPUProfile(cpuFile)
 	defer pprof.StopCPUProfile()
 
 	changeValues := change.ValueCollections{}
@@ -53,14 +53,14 @@ func main() {
 		changeValues = append(changeValues, cv)
 	}
 
-	change, err := change.CreateChange(changeValues, "Benchmarked Change")
+	newChange, err := change.CreateChange(changeValues, "Benchmarked Change")
 	if err != nil {
-		log.Error("Cannot create a change object from ChangeValues ", err)
+		log.Error("Cannot create a newChange object from ChangeValues ", err)
 	}
 
-	err = change.IsValid()
+	err = newChange.IsValid()
 	if err != nil {
-		log.Error("Invalid change ", err)
+		log.Error("Invalid newChange ", err)
 	}
 
 	log.Info("Finished after ", iterations, " iterations")

--- a/pkg/cli/command/changes.go
+++ b/pkg/cli/command/changes.go
@@ -72,7 +72,7 @@ func runChangesCommand(cmd *cobra.Command, args []string) {
 			if err != nil {
 				ExitWithErrorMessage("Failed to receive response : %v", err)
 			}
-			tmplChanges.Execute(os.Stdout, in)
+			_ = tmplChanges.Execute(os.Stdout, in)
 		}
 	}()
 	err = stream.CloseSend()

--- a/pkg/cli/command/completion.go
+++ b/pkg/cli/command/completion.go
@@ -53,7 +53,7 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	zshHead := "#compdef onos\n"
 
-	out.Write([]byte(zshHead))
+	_, _ = out.Write([]byte(zshHead))
 
 	zshInitialization := `
 __onos_bash_source() {
@@ -180,11 +180,11 @@ __onos_convert_bash_to_zsh() {
 	-e "s/\\\$(type${RWORD}/\$(__onos_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `
-	out.Write([]byte(zshInitialization))
+	_, _ = out.Write([]byte(zshInitialization))
 
 	buf := new(bytes.Buffer)
-	cmd.GenBashCompletion(buf)
-	out.Write(buf.Bytes())
+	_ = cmd.GenBashCompletion(buf)
+	_, _ = out.Write(buf.Bytes())
 
 	zshTail := `
 BASH_COMPLETION_EOF
@@ -192,6 +192,6 @@ BASH_COMPLETION_EOF
 __onos_bash_source <(__onos_convert_bash_to_zsh)
 _complete onos 2>/dev/null
 `
-	out.Write([]byte(zshTail))
+	_, _ = out.Write([]byte(zshTail))
 	return nil
 }

--- a/pkg/cli/command/config.go
+++ b/pkg/cli/command/config.go
@@ -126,7 +126,7 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				ExitWithError(ExitError, err)
 			} else {
-				f.Close()
+				_ = f.Close()
 			}
 
 			err = viper.WriteConfig()
@@ -137,11 +137,6 @@ func newInitCommand() *cobra.Command {
 			}
 		},
 	}
-}
-
-func setConfig(key string, value string) error {
-	viper.Set(key, value)
-	return viper.WriteConfig()
 }
 
 func getConfig(key string) string {
@@ -163,5 +158,5 @@ func initConfig() {
 		viper.AddConfigPath(".")
 	}
 
-	viper.ReadInConfig()
+	_ = viper.ReadInConfig()
 }

--- a/pkg/cli/command/devices.go
+++ b/pkg/cli/command/devices.go
@@ -74,9 +74,9 @@ func runDevicesListCommand(cmd *cobra.Command, args []string) {
 			if err != nil {
 				ExitWithErrorMessage("Failed to receive device: %v\n", err)
 			}
-			tmplDevicesList.Execute(os.Stdout, in)
+			_ = tmplDevicesList.Execute(os.Stdout, in)
 			if verbose {
-				tmplDevicesListVerbose.Execute(os.Stdout, in)
+				_ = tmplDevicesListVerbose.Execute(os.Stdout, in)
 			}
 		}
 	}()

--- a/pkg/cli/command/devicetree.go
+++ b/pkg/cli/command/devicetree.go
@@ -171,7 +171,7 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) {
 
 	tmplDevicetreeList, _ := template.New("devices").Funcs(funcMapDeviceTree).Parse(devicetreeTemplate)
 	for _, configuration := range configurations {
-		tmplDevicetreeList.Execute(os.Stdout, configuration)
+		_ = tmplDevicetreeList.Execute(os.Stdout, configuration)
 		fullDeviceConfigValues := configuration.ExtractFullConfig(changes, 0) // Passing 0 as change set has already been reduced by n='layer'
 		jsonTree, _ := store.BuildTree(fullDeviceConfigValues, false)
 		Output("TREE:\n%s\n\n", string(jsonTree))

--- a/pkg/cli/command/models.go
+++ b/pkg/cli/command/models.go
@@ -83,7 +83,7 @@ func runListPluginsCommand(cmd *cobra.Command, args []string) {
 			if err != nil {
 				ExitWithErrorMessage("Failed to receive response : %v", err)
 			}
-			tmplModelList.Execute(os.Stdout, in)
+			_ = tmplModelList.Execute(os.Stdout, in)
 			Output("\n")
 		}
 	}()

--- a/pkg/cli/command/root.go
+++ b/pkg/cli/command/root.go
@@ -39,9 +39,9 @@ func GetRootCommand() *cobra.Command {
 	cmd.PersistentFlags().StringP("certPath", "c", viper.GetString("certPath"), "path to client certificate")
 	cmd.PersistentFlags().String("config", "", "config file (default: $HOME/.onos/config.yaml)")
 
-	viper.BindPFlag("address", cmd.PersistentFlags().Lookup("address"))
-	viper.BindPFlag("keyPath", cmd.PersistentFlags().Lookup("keyPath"))
-	viper.BindPFlag("certPath", cmd.PersistentFlags().Lookup("certPath"))
+	_ = viper.BindPFlag("address", cmd.PersistentFlags().Lookup("address"))
+	_ = viper.BindPFlag("keyPath", cmd.PersistentFlags().Lookup("keyPath"))
+	_ = viper.BindPFlag("certPath", cmd.PersistentFlags().Lookup("certPath"))
 
 	cmd.AddCommand(newInitCommand())
 	cmd.AddCommand(newConfigCommand())

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -37,8 +37,6 @@ const (
 )
 
 const (
-	ValueEmpty     = ""
-	ValueLeaf2A13  = 13
 	ValueLeaf2B159 = 1.579
 	ValueLeaf2B314 = 3.14
 	ValueLeaf2D314 = 3.14

--- a/pkg/modelregistry/jsonvalues/convertJson_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJson_test.go
@@ -82,7 +82,6 @@ func Test_correctJsonPathValues(t *testing.T) {
 
 	// All values are taken from testdata/sample-openconfig.json and defined
 	// here in the intermediate jsonToValues format
-	const systemNtpAuthMismatch = "/openconfig-system:system/ntp/state/auth-mismatch"
 	const systemNtpAuthMismatchNoNs = "/system/ntp/state/auth-mismatch"
 	const systemNtpAuthMismatchValue = 123456.00000
 	val01 := change.ConfigValue{Path: systemNtpAuthMismatchNoNs,

--- a/pkg/modelregistry/jsonvalues/convertjson.go
+++ b/pkg/modelregistry/jsonvalues/convertjson.go
@@ -130,7 +130,8 @@ func CorrectJSONPaths(jsonPathValues []*change.ConfigValue,
 	return correctedPathValues, nil
 }
 
-func subPathType(jsonPathValue *change.ConfigValue, spType change.ValueType, newTypeValue *change.TypedValue) *change.TypedValue {
+func subPathType(jsonPathValue *change.ConfigValue, spType change.ValueType, typeValue *change.TypedValue) *change.TypedValue {
+	var newTypeValue *change.TypedValue
 	switch jsonPathValue.Type {
 	case change.ValueTypeFLOAT:
 		// Could be int, uint, or float from json - convert to numeric

--- a/pkg/northbound/admin/admin.go
+++ b/pkg/northbound/admin/admin.go
@@ -165,7 +165,7 @@ func (s Server) RollbackNetworkChange(
 		}
 	}
 
-	configNames := make(map[string][]string, 0)
+	configNames := make(map[string][]string)
 	// Check all are valid before we delete anything
 	for configName, changeID := range networkConfig.ConfigurationChanges {
 		configChangeIds := manager.GetManager().ConfigStore.Store[configName].Changes
@@ -181,7 +181,7 @@ func (s Server) RollbackNetworkChange(
 			return nil, err
 		}
 	}
-	manager.GetManager().NetworkStore.RemoveEntry(networkConfig.Name)
+	_ = manager.GetManager().NetworkStore.RemoveEntry(networkConfig.Name)
 
 	return &proto.RollbackResponse{
 		Message: fmt.Sprintf("Rolled back change '%s' Updated configs %s",

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -117,9 +117,7 @@ func getUpdate(prefix *gnmi.Path, path *gnmi.Path) (*gnmi.Update, error) {
 	}
 	stateValues := manager.GetManager().GetTargetState(target, pathAsString)
 	//Merging the two results
-	for _, value := range stateValues {
-		configValues = append(configValues, value)
-	}
+	configValues = append(configValues, stateValues...)
 
 	return buildUpdate(prefix, path, configValues)
 }
@@ -139,7 +137,7 @@ func buildUpdate(prefix *gnmi.Path, path *gnmi.Path, configValues []*change.Conf
 	} else {
 		json, err := store.BuildTree(configValues, false)
 		if err != nil {
-
+			return nil, err
 		}
 		typedValue := &gnmi.TypedValue_JsonVal{
 			JsonVal: json,

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -15,6 +15,7 @@
 package gnmi
 
 import (
+	"context"
 	"testing"
 
 	"github.com/onosproject/onos-config/pkg/utils"
@@ -35,7 +36,7 @@ func Test_getNoTarget(t *testing.T) {
 		Path: []*gnmi.Path{&noTargetPath1, &noTargetPath2},
 	}
 
-	_, err := server.Get(nil, &request)
+	_, err := server.Get(context.TODO(), &request)
 	assert.ErrorContains(t, err, "has no target")
 }
 
@@ -49,7 +50,7 @@ func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 		Prefix: prefixPath,
 	}
 
-	_, err = server.Get(nil, &request)
+	_, err = server.Get(context.TODO(), &request)
 	assert.ErrorContains(t, err, "has no target")
 
 }
@@ -65,7 +66,7 @@ func Test_getNoPathElems(t *testing.T) {
 		Path: []*gnmi.Path{&noPath1, &noPath2},
 	}
 
-	result, err := server.Get(nil, &request)
+	result, err := server.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(result.Notification), 2)
@@ -86,7 +87,7 @@ func Test_getAllDevices(t *testing.T) {
 		Path: []*gnmi.Path{&allDevicesPath},
 	}
 
-	result, err := server.Get(nil, &request)
+	result, err := server.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(result.Notification), 1)
@@ -109,7 +110,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 		Prefix: &gnmi.Path{Target: "*"},
 	}
 
-	result, err := server.Get(nil, &request)
+	result, err := server.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(result.Notification), 1)
@@ -141,7 +142,7 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 		Path:   []*gnmi.Path{leafAPath, leafBPath},
 	}
 
-	result, err := server.Get(nil, &request)
+	result, err := server.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(result.Notification), 2)
@@ -170,7 +171,7 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 		Prefix: prefixPath,
 	}
 
-	result, err := server.Get(nil, &request)
+	result, err := server.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(result.Notification), 1)
@@ -197,7 +198,7 @@ func Test_targetDoesNotExist(t *testing.T) {
 		Prefix: prefixPath,
 	}
 
-	_, err = server.Get(nil, &request)
+	_, err = server.Get(context.TODO(), &request)
 	assert.ErrorContains(t, err, "No Configuration found for")
 }
 
@@ -217,7 +218,7 @@ func Test_pathDoesNotExist(t *testing.T) {
 		Path:   []*gnmi.Path{path},
 	}
 
-	result, err := server.Get(nil, &request)
+	result, err := server.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 
 	assert.Equal(t, len(result.Notification), 1)

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -65,11 +65,10 @@ func (s *Server) Subscribe(stream gnmi.GNMI_SubscribeServer) error {
 	//Handles each subscribe request coming into the server, blocks until a new request or an error comes in
 	go listenOnChannel(stream, mgr, hash, resChan, subscribe, changesChan, opStateChan)
 
-	for result := range resChan {
-		if !result.success {
-			return status.Error(codes.Internal, result.err.Error())
-		}
-		return nil
+	res := <-resChan
+
+	if !res.success {
+		return status.Error(codes.Internal, res.err.Error())
 	}
 	return nil
 }

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -289,7 +289,7 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 		select {
 		case response = <-responsesChan:
 			log.Error("Should not be receiving response ", response)
-			t.FailNow()
+			t.Fail()
 		case <-time.After(50 * time.Millisecond):
 		}
 	}()

--- a/pkg/northbound/server.go
+++ b/pkg/northbound/server.go
@@ -20,13 +20,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/certs"
 	"google.golang.org/grpc/credentials"
 	"io/ioutil"
 	log "k8s.io/klog"
 	"net"
-	"sync"
-
-	"github.com/onosproject/onos-config/pkg/certs"
 
 	"google.golang.org/grpc"
 )
@@ -40,7 +38,6 @@ type Service interface {
 type Server struct {
 	cfg      *ServerConfig
 	services []Service
-	mu       sync.Mutex
 }
 
 // ServerConfig comprises a set of server configuration options.

--- a/pkg/southbound/clientManager_test.go
+++ b/pkg/southbound/clientManager_test.go
@@ -251,7 +251,7 @@ func Test_Get(t *testing.T) {
 		Path: []*gnmi.Path{&allDevicesPath},
 	}
 
-	response, err := target.Get(nil, &request)
+	response, err := target.Get(context.TODO(), &request)
 	assert.NilError(t, err)
 	assert.Assert(t, response != nil)
 	assert.Equal(t, response.Notification[0].Update[0].Path.Target, "*", "Expected target")
@@ -371,12 +371,12 @@ func Test_NewSubscribeRequest(t *testing.T) {
 	assert.Equal(t, request.GetSubscribe().GetSubscription()[0].Mode, gnmi.SubscriptionMode_SAMPLE)
 
 	options.Mode = "Test_Error"
-	request, requestError = NewSubscribeRequest(options)
+	_, requestError = NewSubscribeRequest(options)
 	assert.ErrorContains(t, requestError, "invalid")
 
 	options.Mode = "Poll"
 	options.StreamMode = "test_error"
-	request, requestError = NewSubscribeRequest(options)
+	_, requestError = NewSubscribeRequest(options)
 	assert.ErrorContains(t, requestError, "invalid")
 
 }

--- a/pkg/southbound/gnmiBaseClient_test.go
+++ b/pkg/southbound/gnmiBaseClient_test.go
@@ -15,6 +15,7 @@
 package southbound
 
 import (
+	"context"
 	"github.com/openconfig/gnmi/client"
 	"gotest.tools/assert"
 	"testing"
@@ -24,6 +25,6 @@ func Test_GnmiBaseClient(t *testing.T) {
 	baseClient := GnmiBaseClientFactory()
 	assert.Assert(t, baseClient != nil)
 	query := client.Query{Type: client.Unknown}
-	err := baseClient.Subscribe(nil, query, "XXX")
+	err := baseClient.Subscribe(context.TODO(), query, "XXX")
 	assert.ErrorContains(t, err, "Addrs is empty")
 }

--- a/pkg/southbound/topocache/topocache.go
+++ b/pkg/southbound/topocache/topocache.go
@@ -64,7 +64,7 @@ func LoadDeviceStore(file string, topoChannel chan<- events.TopoEvent) (*DeviceS
 
 	jsonDecoder := json.NewDecoder(storeFile)
 	var deviceStore = DeviceStore{}
-	jsonDecoder.Decode(&deviceStore)
+	_ = jsonDecoder.Decode(&deviceStore)
 	if deviceStore.Storetype != storeTypeDevice {
 		return nil,
 			fmt.Errorf("Store type invalid: " + deviceStore.Storetype)

--- a/pkg/southbound/topocache/topocache_test.go
+++ b/pkg/southbound/topocache/topocache_test.go
@@ -83,7 +83,7 @@ func Test_DeviceStoreDuplicates(t *testing.T) {
 
 func Test_AddDevice(t *testing.T) {
 	deviceStore := loadDeviceStore(t)
-	deviceStore.AddOrUpdateDevice("foobar", Device{ID: "foobar", Addr: "foobar:123", SoftwareVersion: "1.0"})
+	assert.NilError(t, deviceStore.AddOrUpdateDevice("foobar", Device{ID: "foobar", Addr: "foobar:123", SoftwareVersion: "1.0"}))
 	d, ok := deviceStore.Store["foobar"]
 	assert.Assert(t, ok, "device not added")
 	assert.Assert(t, d.Addr == "foobar:123", "wrong device added")

--- a/pkg/store/change/change_test.go
+++ b/pkg/store/change/change_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	change1, change2, change3, change4 *Change
+	change1 *Change
 )
 
 const (
@@ -53,9 +53,7 @@ const (
 	ValueLeaf2A13       = 13
 	ValueLeaf2B159D     = 1579
 	ValueLeaf2B159P     = 3
-	ValueLeaf2B314      = float64(3.14159)
 	ValueLeaf2CAbc      = "abc"
-	ValueLeaf2D         = true
 	ValueLeaf2E1        = -32
 	ValueLeaf2E2        = 99
 	ValueLeaf2E3        = 123
@@ -63,7 +61,6 @@ const (
 	ValueLeaf1AAbcdef   = "abcdef"
 	ValueTxout1Txpwr8   = 8
 	ValueTxout2Txpwr10  = 10
-	ValueTxout3Txpwr16  = 16
 	ValueLeaftopWxy1234 = "WXY-1234"
 )
 

--- a/pkg/store/change/typedvalue.go
+++ b/pkg/store/change/typedvalue.go
@@ -450,10 +450,7 @@ func (tv *TypedBool) String() string {
 
 // Bool extracts the unsigned bool value
 func (tv *TypedBool) Bool() bool {
-	if tv.Value[0] == 1 {
-		return true
-	}
-	return false
+	return tv.Value[0] == 1
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -603,9 +600,7 @@ func NewLeafListString(values []string) *TypedLeafListString {
 		} else {
 			bytes = append(bytes, 0x1D) // Group separator
 		}
-		for _, s := range []byte(v) {
-			bytes = append(bytes, s)
-		}
+		bytes = append(bytes, []byte(v)...)
 	}
 	typedLeafListString := TypedLeafListString{
 		Value: bytes,
@@ -657,9 +652,7 @@ func NewLeafListInt64(values []int) *TypedLeafListInt64 {
 	for _, v := range values {
 		buf := make([]byte, 8)
 		binary.LittleEndian.PutUint64(buf, uint64(v))
-		for _, b := range buf {
-			bytes = append(bytes, b)
-		}
+		bytes = append(bytes, buf...)
 	}
 	typedLeafListInt64 := TypedLeafListInt64{
 		Value: bytes,
@@ -709,9 +702,7 @@ func NewLeafListUint64(values []uint) *TypedLeafListUint {
 	for _, v := range values {
 		buf := make([]byte, 8)
 		binary.LittleEndian.PutUint64(buf, uint64(v))
-		for _, b := range buf {
-			bytes = append(bytes, b)
-		}
+		bytes = append(bytes, buf...)
 	}
 	typedLeafListUint := TypedLeafListUint{
 		Value: bytes,
@@ -814,9 +805,7 @@ func NewLeafListDecimal64(digits []int64, precision uint32) *TypedLeafListDecima
 	for _, d := range digits {
 		buf := make([]byte, 8)
 		binary.LittleEndian.PutUint64(buf, uint64(d))
-		for _, b := range buf {
-			bytes = append(bytes, b)
-		}
+		bytes = append(bytes, buf...)
 	}
 	typedLeafListDecimal := TypedLeafListDecimal{
 		Value:    bytes,
@@ -893,9 +882,7 @@ func NewLeafListFloat32(values []float32) *TypedLeafListFloat {
 	for _, f := range values {
 		buf := make([]byte, 8)
 		binary.LittleEndian.PutUint64(buf, math.Float64bits(float64(f)))
-		for _, b := range buf {
-			bytes = append(bytes, b)
-		}
+		bytes = append(bytes, buf...)
 	}
 	typedLeafListFloat := TypedLeafListFloat{
 		Value: bytes,
@@ -948,9 +935,7 @@ func NewLeafListBytes(values [][]byte) *TypedLeafListBytes {
 	bytes := make([]byte, 0)
 	typeopts := make([]int, 0)
 	for _, v := range values {
-		for _, b := range []byte(v) {
-			bytes = append(bytes, b)
-		}
+		bytes = append(bytes, []byte(v)...)
 		typeopts = append(typeopts, len(v))
 	}
 	typedLeafListBytes := TypedLeafListBytes{

--- a/pkg/store/jsonToValues.go
+++ b/pkg/store/jsonToValues.go
@@ -45,20 +45,14 @@ func extractValuesIntermediate(f interface{}, parentPath string) []*change.Confi
 	switch value := f.(type) {
 	case map[string]interface{}:
 		for key, v := range value {
-			var objs []*change.ConfigValue
-			objs = extractValuesIntermediate(v, fmt.Sprintf("%s/%s", parentPath, key))
-			for _, o := range objs {
-				changes = append(changes, o)
-			}
+			objs := extractValuesIntermediate(v, fmt.Sprintf("%s/%s", parentPath, key))
+			changes = append(changes, objs...)
 		}
 	case []interface{}:
 		// Iterate through to look for indexes first
 		for idx, v := range value {
-			var objs []*change.ConfigValue
-			objs = extractValuesIntermediate(v, fmt.Sprintf("%s[%d]", parentPath, idx))
-			for _, o := range objs {
-				changes = append(changes, o)
-			}
+			objs := extractValuesIntermediate(v, fmt.Sprintf("%s[%d]", parentPath, idx))
+			changes = append(changes, objs...)
 		}
 	case string:
 		newCv := change.ConfigValue{Path: parentPath, TypedValue: *change.CreateTypedValueString(value)}

--- a/pkg/store/store-api_test.go
+++ b/pkg/store/store-api_test.go
@@ -77,15 +77,15 @@ var Config1Paths = [11]string{
 var Config1Values = [11][]byte{
 	make([]byte, 0), // 0
 	make([]byte, 0),
-	[]byte{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
-	[]byte{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
-	[]byte{100, 101, 102},              // ValueLeaf2CDef
-	[]byte{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
+	{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
+	{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
+	{100, 101, 102},              // ValueLeaf2CDef
+	{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
 	make([]byte, 0),
-	[]byte{8, 0, 0, 0, 0, 0, 0, 0},         // ValueTxout1Txpwr8
-	make([]byte, 0),                        // 10
-	[]byte{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout3Txpwr16
-	[]byte{87, 88, 89, 45, 49, 50, 51, 52}, // ValueLeaftopWxy1234
+	{8, 0, 0, 0, 0, 0, 0, 0},         // ValueTxout1Txpwr8
+	make([]byte, 0),                  // 10
+	{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout3Txpwr16
+	{87, 88, 89, 45, 49, 50, 51, 52}, // ValueLeaftopWxy1234
 }
 
 var Config1Types = [11]change.ValueType{
@@ -119,19 +119,19 @@ var Config1PreviousPaths = [13]string{
 }
 
 var Config1PreviousValues = [13][]byte{
-	[]byte{}, // 0
-	[]byte{},
-	[]byte{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
-	[]byte{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
-	[]byte{97, 98, 99},                 // ValueLeaf2CAbc
-	[]byte{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
-	[]byte{},
-	[]byte{8, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
-	[]byte{},
-	[]byte{10, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
-	[]byte{},                               // 10
-	[]byte{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout3Txpwr16,
-	[]byte{87, 88, 89, 45, 49, 50, 51, 52}, // ValueLeaftopWxy1234,
+	{}, // 0
+	{},
+	{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
+	{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
+	{97, 98, 99},                 // ValueLeaf2CAbc
+	{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
+	{},
+	{8, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
+	{},
+	{10, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
+	{},                               // 10
+	{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout3Txpwr16,
+	{87, 88, 89, 45, 49, 50, 51, 52}, // ValueLeaftopWxy1234,
 }
 
 var Config1PreviousTypes = [13]change.ValueType{
@@ -165,17 +165,17 @@ var Config1FirstPaths = [11]string{
 }
 
 var Config1FirstValues = [11][]byte{
-	[]byte{}, // 0
-	[]byte{},
-	[]byte{13, 0, 0, 0, 0, 0, 0, 0},        // ValueLeaf2A13
-	[]byte{0, 0, 0, 128, 149, 67, 249, 63}, // ValueLeaf2B159 3
-	[]byte{97, 98, 99},                     // ValueLeaf2CAbc
-	[]byte{97, 98, 99, 100, 101, 102},      // ValueLeaf1AAbcdef 5
-	[]byte{},
-	[]byte{8, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
-	[]byte{},
-	[]byte{10, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
-	[]byte{87, 88, 89, 45, 49, 50, 51, 52}, //ValueLeaftopWxy1234, 10
+	{}, // 0
+	{},
+	{13, 0, 0, 0, 0, 0, 0, 0},        // ValueLeaf2A13
+	{0, 0, 0, 128, 149, 67, 249, 63}, // ValueLeaf2B159 3
+	{97, 98, 99},                     // ValueLeaf2CAbc
+	{97, 98, 99, 100, 101, 102},      // ValueLeaf1AAbcdef 5
+	{},
+	{8, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
+	{},
+	{10, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
+	{87, 88, 89, 45, 49, 50, 51, 52}, //ValueLeaftopWxy1234, 10
 }
 
 var Config1FirstTypes = [11]change.ValueType{
@@ -207,17 +207,17 @@ var Config2Paths = [11]string{
 }
 
 var Config2Values = [11][]byte{
-	[]byte{}, // 0
-	[]byte{},
-	[]byte{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
-	[]byte{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
-	[]byte{103, 104, 105},              // ValueLeaf2CGhi
-	[]byte{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
-	[]byte{},
-	[]byte{10, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
-	[]byte{},
-	[]byte{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
-	[]byte{87, 88, 89, 45, 49, 50, 51, 52}, //ValueLeaftopWxy1234, 10
+	{}, // 0
+	{},
+	{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
+	{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
+	{103, 104, 105},              // ValueLeaf2CGhi
+	{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
+	{},
+	{10, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
+	{},
+	{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
+	{87, 88, 89, 45, 49, 50, 51, 52}, //ValueLeaftopWxy1234, 10
 }
 
 var Config2Types = [11]change.ValueType{
@@ -498,7 +498,7 @@ func Test_convertChangeToGnmi(t *testing.T) {
 func Test_writeOutChangeFile(t *testing.T) {
 	_, _, changeStore := setUp()
 	if _, err := os.Stat("testout"); os.IsNotExist(err) {
-		os.Mkdir("testout", os.ModePerm)
+		_ = os.Mkdir("testout", os.ModePerm)
 	}
 	changeStoreFile, err := os.Create("testout/changeStore-sample.json")
 	if err != nil {
@@ -715,8 +715,8 @@ func BenchmarkCreateChange(b *testing.B) {
 		changeValues = append(changeValues, cv)
 	}
 
-	change, _ := change.CreateChange(changeValues, "Benchmarked Change")
+	newChange, _ := change.CreateChange(changeValues, "Benchmarked Change")
 
-	err := change.IsValid()
+	err := newChange.IsValid()
 	assert.NilError(b, err, "Invalid change %s", err)
 }

--- a/pkg/store/stores.go
+++ b/pkg/store/stores.go
@@ -50,7 +50,7 @@ func LoadConfigStore(file string) (ConfigurationStore, error) {
 
 	jsonDecoder := json.NewDecoder(storeFile)
 	var configStore = ConfigurationStore{}
-	jsonDecoder.Decode(&configStore)
+	_ = jsonDecoder.Decode(&configStore)
 	if configStore.Storetype != StoreTypeConfig {
 		return ConfigurationStore{},
 			fmt.Errorf("Store type invalid: " + configStore.Storetype)
@@ -99,7 +99,7 @@ func LoadChangeStore(file string) (ChangeStore, error) {
 
 	jsonDecoder := json.NewDecoder(storeFile)
 	var changeStore = ChangeStore{}
-	jsonDecoder.Decode(&changeStore)
+	_ = jsonDecoder.Decode(&changeStore)
 	if changeStore.Storetype != StoreTypeChange {
 		return ChangeStore{},
 			fmt.Errorf("Store type invalid: " + changeStore.Storetype)
@@ -143,7 +143,7 @@ func LoadNetworkStore(file string) (*NetworkStore, error) {
 
 	jsonDecoder := json.NewDecoder(storeFile)
 	var networkStore = NetworkStore{}
-	jsonDecoder.Decode(&networkStore)
+	_ = jsonDecoder.Decode(&networkStore)
 	if networkStore.Storetype != StoreTypeNetwork {
 		return nil,
 			fmt.Errorf("Store type invalid: " + networkStore.Storetype)

--- a/pkg/utils/values/gnmiValueUtil_test.go
+++ b/pkg/utils/values/gnmiValueUtil_test.go
@@ -26,13 +26,8 @@ import (
 const testString = "This is a test"
 const (
 	testNegativeInt = -9223372036854775808
-	testZeroInt     = 0
 	testPositiveInt = 9223372036854775807
-)
-const (
-	testZeroUint   = uint(0)
-	testElevenUint = uint(11)
-	testMaxUint    = uint(18446744073709551615)
+	testMaxUint     = uint(18446744073709551615)
 )
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/cli/cli.go
+++ b/test/cli/cli.go
@@ -127,7 +127,7 @@ func getCreateClusterCommand() *cobra.Command {
 			}
 
 			// Store the cluster before setting it up to ensure other shell sessions can debug setup
-			setDefaultCluster(clusterID)
+			_ = setDefaultCluster(clusterID)
 
 			// Setup the cluster
 			if status := cluster.Setup(); status.Failed() {
@@ -316,7 +316,7 @@ func getDeleteClusterCommand() *cobra.Command {
 
 			// Delete the cluster
 			status := controller.DeleteCluster(clusterID)
-			setDefaultCluster("")
+			_ = setDefaultCluster("")
 			if status.Failed() {
 				exitStatus(status)
 			}
@@ -367,7 +367,7 @@ func getRemoveNetworkCommand() *cobra.Command {
 			if err != nil {
 				exitError(err)
 			}
-			if Contains(networks, name) == false {
+			if !Contains(networks, name) {
 				exitError(errors.New("The given network name does not exist"))
 			}
 
@@ -417,7 +417,7 @@ func getRemoveSimulatorCommand() *cobra.Command {
 				exitError(err)
 			}
 
-			if Contains(simulators, name) == false {
+			if !Contains(simulators, name) {
 				exitError(errors.New("The given simulator name does not exist"))
 			}
 
@@ -584,12 +584,12 @@ func printClusters(clusters map[string]*runner.ClusterConfig, includeHeaders boo
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
 	if includeHeaders {
-		fmt.Fprintln(writer, "ID\tSIZE\tPARTITIONS")
+		_, _ = fmt.Fprintln(writer, "ID\tSIZE\tPARTITIONS")
 	}
 	for id, config := range clusters {
 		fmt.Fprintln(writer, fmt.Sprintf("%s\t%d\t%d\t%d", id, config.ConfigNodes, config.TopoNodes, config.Partitions))
 	}
-	writer.Flush()
+	_ = writer.Flush()
 }
 
 // getGetDevicePresetsCommand returns a cobra command to get a list of available device simulator configurations
@@ -661,11 +661,11 @@ func getGetPartitionsCommand() *cobra.Command {
 func printPartitions(partitions []runner.PartitionInfo) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
-	fmt.Fprintln(writer, "ID\tGROUP\tNODES")
+	_, _ = fmt.Fprintln(writer, "ID\tGROUP\tNODES")
 	for _, partition := range partitions {
-		fmt.Fprintln(writer, fmt.Sprintf("%d\t%s\t%s", partition.Partition, partition.Group, strings.Join(partition.Nodes, ",")))
+		_, _ = fmt.Fprintln(writer, fmt.Sprintf("%d\t%s\t%s", partition.Partition, partition.Group, strings.Join(partition.Nodes, ",")))
 	}
-	writer.Flush()
+	_ = writer.Flush()
 }
 
 // getGetPartitionCommand returns a cobra command to get the nodes in a partition
@@ -792,7 +792,7 @@ func printNodes(nodes []runner.NodeInfo, includeHeaders bool) {
 	for _, node := range nodes {
 		fmt.Fprintln(writer, fmt.Sprintf("%s\t%s\t%s", node.ID, node.Type, node.Status))
 	}
-	writer.Flush()
+	_ = writer.Flush()
 }
 
 // getGetTestsCommand returns a cobra command to get a list of available tests
@@ -828,12 +828,12 @@ func printTestSuites(registry *runner.TestRegistry, includeHeaders bool) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
 	if includeHeaders {
-		fmt.Fprintln(writer, "SUITE\tTESTS")
+		_, _ = fmt.Fprintln(writer, "SUITE\tTESTS")
 	}
 	for name, suite := range registry.TestSuites {
-		fmt.Fprintln(writer, fmt.Sprintf("%s\t%s", name, strings.Join(suite.GetTestNames(), ", ")))
+		_, _ = fmt.Fprintln(writer, fmt.Sprintf("%s\t%s", name, strings.Join(suite.GetTestNames(), ", ")))
 	}
-	writer.Flush()
+	_ = writer.Flush()
 }
 
 // getGetHistoryCommand returns a cobra command to get the history of tests
@@ -881,7 +881,7 @@ func getGetHistoryCommand() *cobra.Command {
 func printHistory(records []runner.TestRecord) {
 	writer := new(tabwriter.Writer)
 	writer.Init(os.Stdout, 0, 0, 3, ' ', tabwriter.FilterHTML)
-	fmt.Fprintln(writer, "ID\tTESTS\tSTATUS\tEXIT CODE\tMESSAGE")
+	_, _ = fmt.Fprintln(writer, "ID\tTESTS\tSTATUS\tEXIT CODE\tMESSAGE")
 	for _, record := range records {
 		var args string
 		if len(record.Args) > 0 {
@@ -889,9 +889,9 @@ func printHistory(records []runner.TestRecord) {
 		} else {
 			args = "*"
 		}
-		fmt.Fprintln(writer, fmt.Sprintf("%s\t%s\t%s\t%d\t%s", record.TestID, args, record.Status, record.ExitCode, record.Message))
+		_, _ = fmt.Fprintln(writer, fmt.Sprintf("%s\t%s\t%s\t%d\t%s", record.TestID, args, record.Status, record.ExitCode, record.Message))
 	}
-	writer.Flush()
+	_ = writer.Flush()
 }
 
 // getGetLogsCommand returns a cobra command to output the logs for a specific resource
@@ -954,7 +954,7 @@ To output the logs from a test, get the test ID from the test run or from 'onit 
 					if err != nil {
 						exitError(err)
 					}
-					os.Stdout.Write(logs)
+					_, _ = os.Stdout.Write(logs)
 					if i+1 < numResources {
 						fmt.Println("----")
 					}
@@ -1262,10 +1262,10 @@ func getTestTestLocalCommand(registry *runner.TestRegistry) *cobra.Command {
 		Use:   "test [tests]",
 		Short: "Run integration tests",
 		Run: func(cmd *cobra.Command, args []string) {
-			runner := &runner.TestRunner{
+			testRunner := &runner.TestRunner{
 				Registry: registry,
 			}
-			err := runner.RunTests(args)
+			err := testRunner.RunTests(args)
 			if err != nil {
 				exitError(err)
 			} else {
@@ -1281,10 +1281,10 @@ func getTestSuiteLocalCommand(registry *runner.TestRegistry) *cobra.Command {
 		Use:   "suite [suite]",
 		Short: "Run integration test suites on Kubernetes",
 		Run: func(cmd *cobra.Command, args []string) {
-			runner := &runner.TestRunner{
+			testRunner := &runner.TestRunner{
 				Registry: registry,
 			}
-			err := runner.RunTestSuites(args)
+			err := testRunner.RunTestSuites(args)
 			if err != nil {
 				exitError(err)
 			} else {

--- a/test/cli/completion.go
+++ b/test/cli/completion.go
@@ -154,7 +154,7 @@ func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
 func runCompletionZsh(out io.Writer, cmd *cobra.Command) error {
 	header := "#compdef onit\n"
 
-	out.Write([]byte(header))
+	_, _ = out.Write([]byte(header))
 
 	init := `
 __onit_bash_source() {
@@ -281,11 +281,11 @@ __onit_convert_bash_to_zsh() {
 	-e "s/\\\$(type${RWORD}/\$(__onit_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `
-	out.Write([]byte(init))
+	_, _ = out.Write([]byte(init))
 
 	buf := new(bytes.Buffer)
-	cmd.GenBashCompletion(buf)
-	out.Write(buf.Bytes())
+	_ = cmd.GenBashCompletion(buf)
+	_, _ = out.Write(buf.Bytes())
 
 	tail := `
 BASH_COMPLETION_EOF
@@ -293,6 +293,6 @@ BASH_COMPLETION_EOF
 __onit_bash_source <(__onit_convert_bash_to_zsh)
 _complete onit 2>/dev/null
 `
-	out.Write([]byte(tail))
+	_, _ = out.Write([]byte(tail))
 	return nil
 }

--- a/test/cli/config.go
+++ b/test/cli/config.go
@@ -31,7 +31,7 @@ var (
 // getSimulatorPresets returns a list of store configurations from the configs/store directory
 func getSimulatorPresets() []string {
 	configs := []string{}
-	filepath.Walk(deviceConfigsPath, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(deviceConfigsPath, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
 		}
@@ -48,7 +48,7 @@ func getSimulatorPresets() []string {
 // getStorePresets returns a list of store configurations from the configs/store directory
 func getStorePresets() []string {
 	configs := []string{}
-	filepath.Walk(storeConfigsPath, func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(storeConfigsPath, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			return nil
 		}
@@ -94,7 +94,7 @@ func initConfig() error {
 			if err != nil {
 				return err
 			}
-			f.Close()
+			_ = f.Close()
 		} else {
 			return err
 		}
@@ -113,5 +113,5 @@ func init() {
 	viper.AddConfigPath("/etc/onos")
 	viper.AddConfigPath(".")
 
-	viper.ReadInConfig()
+	_ = viper.ReadInConfig()
 }

--- a/test/console/spinner.go
+++ b/test/console/spinner.go
@@ -44,11 +44,11 @@ var spinnerFrames = []string{
 // It is simplistic and assumes that the line length will not change.
 // It is best used indirectly via log.Status (see parent package)
 type Spinner struct {
-	frames []string
-	stop   chan struct{}
-	ticker *time.Ticker
-	writer io.Writer
-	mu     *sync.Mutex
+	frames  []string
+	stop    chan struct{}
+	ticker  *time.Ticker
+	writer  io.Writer
+	mu      *sync.Mutex
 	message string
 }
 

--- a/test/env/env.go
+++ b/test/env/env.go
@@ -62,8 +62,8 @@ func GetCredentials() (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		RootCAs:      certPool,
-		Certificates: []tls.Certificate{cert},
+		RootCAs:            certPool,
+		Certificates:       []tls.Certificate{cert},
 		InsecureSkipVerify: true,
 	}, nil
 }
@@ -75,10 +75,10 @@ func GetDestination(target string) (client.Destination, error) {
 		return client.Destination{}, err
 	}
 	return client.Destination{
-		Addrs:  []string{address},
-		Target: target,
-		TLS:    tlsConfig,
-		Timeout:  10 * time.Second,
+		Addrs:   []string{address},
+		Target:  target,
+		TLS:     tlsConfig,
+		Timeout: 10 * time.Second,
 	}, nil
 }
 
@@ -89,10 +89,10 @@ func GetDestinationForDevice(addr string, target string) (client.Destination, er
 		return client.Destination{}, err
 	}
 	return client.Destination{
-		Addrs:  []string{addr},
-		Target: target,
-		TLS:    tlsConfig,
-		Timeout:  10 * time.Second,
+		Addrs:   []string{addr},
+		Target:  target,
+		TLS:     tlsConfig,
+		Timeout: 10 * time.Second,
 	}, nil
 }
 

--- a/test/integration/gnmiutils.go
+++ b/test/integration/gnmiutils.go
@@ -66,8 +66,7 @@ func extractSetTransactionID(response *gpb.SetResponse) string {
 
 // GNMIGet generates a GET request on the given client for a path on a device
 func GNMIGet(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePath, error) {
-	var protoString string
-	protoString = ""
+	protoString := ""
 	for _, devicePath := range paths {
 		protoString = protoString + MakeProtoPath(devicePath.deviceName, devicePath.path)
 	}

--- a/test/integration/modelstest.go
+++ b/test/integration/modelstest.go
@@ -22,7 +22,7 @@ import (
 )
 
 func init() {
-	Registry.RegisterTest("models", TestModels, []*runner.TestSuite{AllTests,SomeTests,IntegrationTests})
+	Registry.RegisterTest("models", TestModels, []*runner.TestSuite{AllTests, SomeTests, IntegrationTests})
 }
 
 // TestModels tests GNMI operation involving unknown or illegal paths
@@ -80,4 +80,3 @@ func TestModels(t *testing.T) {
 			})
 	}
 }
-

--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -68,5 +68,5 @@ func TestSinglePath(t *testing.T) {
 }
 
 func init() {
-	Registry.RegisterTest("single-path", TestSinglePath, []*runner.TestSuite{AllTests,IntegrationTests})
+	Registry.RegisterTest("single-path", TestSinglePath, []*runner.TestSuite{AllTests, IntegrationTests})
 }

--- a/test/integration/singlestatetest.go
+++ b/test/integration/singlestatetest.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	stateValue = "192.0.2.10"
-	stateControllersPath  = "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/address"
+	stateValue           = "192.0.2.10"
+	stateControllersPath = "/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/address"
 )
 
 // TestSingleState tests query of a single GNMI path of a read/only value to a single device
@@ -44,5 +44,5 @@ func TestSingleState(t *testing.T) {
 }
 
 func init() {
-	Registry.RegisterTest("single-state", TestSingleState, []*runner.TestSuite{AllTests,IntegrationTests})
+	Registry.RegisterTest("single-state", TestSingleState, []*runner.TestSuite{AllTests, IntegrationTests})
 }

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -35,7 +35,7 @@ const (
 
 func init() {
 	//example of registering groups
-	Registry.RegisterTest("subscribe", TestSubscribe, []*runner.TestSuite{AllTests,SomeTests,IntegrationTests})
+	Registry.RegisterTest("subscribe", TestSubscribe, []*runner.TestSuite{AllTests, SomeTests, IntegrationTests})
 }
 
 // TestSubscribe tests a stream subscription to updates to a device

--- a/test/integration/suites.go
+++ b/test/integration/suites.go
@@ -28,7 +28,7 @@ var (
 	IntegrationTests = runner.NewTestSuite("integration-tests")
 )
 
-func init(){
+func init() {
 	//example of registering groups
 	Registry.RegisterTestSuite(*AllTests)
 	Registry.RegisterTestSuite(*SomeTests)

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -32,16 +32,16 @@ const (
 )
 
 var (
-	paths = []string {path1, path2}
-	values = []string {value1, value2}
+	paths  = []string{path1, path2}
+	values = []string{value1, value2}
 )
 
 func init() {
-	Registry.RegisterTest("transaction", TestTransaction, []*runner.TestSuite{AllTests,SomeTests,IntegrationTests})
+	Registry.RegisterTest("transaction", TestTransaction, []*runner.TestSuite{AllTests, SomeTests, IntegrationTests})
 }
 
 func getDevicePaths(devices []string, paths []string) []DevicePath {
-	var devicePaths = make([]DevicePath, len(paths) * len(devices))
+	var devicePaths = make([]DevicePath, len(paths)*len(devices))
 	pathIndex := 0
 	for _, device := range devices {
 		for _, path := range paths {
@@ -53,7 +53,7 @@ func getDevicePaths(devices []string, paths []string) []DevicePath {
 	return devicePaths
 }
 
-func getDevicePathsWithValues(devices []string, paths []string, values[]string) []DevicePath {
+func getDevicePathsWithValues(devices []string, paths []string, values []string) []DevicePath {
 	var devicePaths = getDevicePaths(devices, paths)
 	valueIndex := 0
 	for range devices {
@@ -73,7 +73,7 @@ func checkDeviceValue(t *testing.T, deviceGnmiClient client.Impl, devicePaths []
 }
 
 func getDeviceGNMIClient(t *testing.T, device string) client.Impl {
-	deviceGnmiClient, deviceGnmiClientError := env.NewGnmiClientForDevice(MakeContext(), device + ":10161", "gnmi")
+	deviceGnmiClient, deviceGnmiClientError := env.NewGnmiClientForDevice(MakeContext(), device+":10161", "gnmi")
 	assert.NoError(t, deviceGnmiClientError)
 	assert.True(t, deviceGnmiClient != nil, "Fetching device client returned nil")
 	return deviceGnmiClient
@@ -132,4 +132,3 @@ func TestTransaction(t *testing.T) {
 	assert.Equal(t, "", getValuesAfterRollback[0].pathDataValue, "Query after rollback returned the wrong value: %s\n", getValuesAfterRollback)
 	assert.Equal(t, "", getValuesAfterRollback[1].pathDataValue, "Query after rollback returned the wrong value: %s\n", getValuesAfterRollback)
 }
-

--- a/test/runner/atomix.go
+++ b/test/runner/atomix.go
@@ -215,7 +215,7 @@ func (c *ClusterController) createAtomixClusterRoleBinding() error {
 	_, err := c.kubeclient.RbacV1().ClusterRoleBindings().Create(roleBinding)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			c.deleteAtomixClusterRoleBinding()
+			_ = c.deleteAtomixClusterRoleBinding()
 			return c.createAtomixClusterRoleBinding()
 		}
 		return err

--- a/test/runner/common.go
+++ b/test/runner/common.go
@@ -114,7 +114,7 @@ func (c *ClusterController) createOnosSecret() error {
 		StringData: map[string]string{},
 	}
 
-	err := filepath.Walk(certsPath, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(certsPath, func(path string, info os.FileInfo, walkError error) error {
 		if info.IsDir() {
 			return nil
 		}

--- a/test/runner/onos-config.go
+++ b/test/runner/onos-config.go
@@ -180,7 +180,7 @@ func (c *ClusterController) removeNetworkFromConfig(name string, configMap *core
 	}
 	dataMap := configMap.Items[0].BinaryData["config"]
 	m := make(map[string]interface{})
-	yaml.Unmarshal(dataMap, &m)
+	_ = yaml.Unmarshal(dataMap, &m)
 	numDevices := m["numdevices"].(int)
 
 	for _, pod := range pods.Items {

--- a/test/runner/runner.go
+++ b/test/runner/runner.go
@@ -32,14 +32,13 @@ func NewRegistry() *TestRegistry {
 //NewTestSuite returns a pointer to a new TestSuite
 func NewTestSuite(name string) *TestSuite {
 	return &TestSuite{
-		name: name,
+		name:  name,
 		tests: make(map[string]Test),
 	}
 }
 
 // Test is a test function
 type Test func(t *testing.T)
-
 
 // TestRegistry contains a mapping of named test groups
 type TestRegistry struct {
@@ -49,7 +48,7 @@ type TestRegistry struct {
 
 //TestSuite to run multiple tests
 type TestSuite struct {
-	name string
+	name  string
 	tests map[string]Test
 }
 
@@ -114,7 +113,6 @@ type TestRunner struct {
 	Registry *TestRegistry
 }
 
-
 // RunTests Runs the tests
 func (r *TestRunner) RunTests(args []string) error {
 	tests := make([]testing.InternalTest, 0, len(args))
@@ -149,7 +147,6 @@ func (r *TestRunner) RunTests(args []string) error {
 	return nil
 }
 
-
 // RunTestSuites Runs the tests groups
 func (r *TestRunner) RunTestSuites(args []string) error {
 	tests := make([]testing.InternalTest, 0, len(args))
@@ -163,9 +160,9 @@ func (r *TestRunner) RunTestSuites(args []string) error {
 			testNames := []string{}
 
 			for testName := range testSuite.tests {
-				testNames = append(testNames,testName)
+				testNames = append(testNames, testName)
 			}
-			r.RunTests(testNames)
+			_ = r.RunTests(testNames)
 		}
 	} else {
 		return nil

--- a/test/runner/test.go
+++ b/test/runner/test.go
@@ -270,8 +270,6 @@ func (c *ClusterController) getDeviceIds() ([]string, error) {
 	}
 
 	// Add each simulator to the devices
-	for _, name := range simulators {
-		devices = append(devices, name)
-	}
+	devices = append(devices, simulators...)
 	return devices, nil
 }


### PR DESCRIPTION
This change adds the golangci-lint meta linter to onos-config builds.

golangci-lint allows us to use a number of different linters, and configure how they run.

A standard set of linters are enabled, and the problems they found have been addressed.