### PR TITLE
Bug fix to deal with double index in paths

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -258,7 +258,11 @@ func (m *Manager) computeChange(updates change.TypedValueMap,
 	var newChanges = make([]*change.Value, 0)
 	//updates
 	for path, value := range updates {
-		changeValue, _ := change.CreateChangeValue(path, value, false)
+		changeValue, err := change.CreateChangeValue(path, value, false)
+		if err != nil {
+			log.Warningf("Error creating value for %s %v", path, err)
+			continue
+		}
 		newChanges = append(newChanges, changeValue)
 	}
 	//deletes

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -182,7 +182,7 @@ func (s *Server) formatUpdateOrReplace(u *gnmi.Update, targetUpdates mapTargetUp
 
 	jsonVal := u.GetVal().GetJsonVal()
 	if jsonVal != nil {
-		log.Warning("Processing Json Value in set", string(jsonVal))
+		log.Info("Processing Json Value in set", string(jsonVal))
 
 		intermediateConfigValues, err := store.DecomposeTree(jsonVal)
 		if err != nil {
@@ -452,6 +452,10 @@ func setChange(target string, version string, targetUpdates change.TypedValueMap
 
 func validateChange(target string, version string, targetUpdates change.TypedValueMap, targetRemoves []string) error {
 	configName := store.ConfigName(target)
+	if len(targetUpdates) == 0 && len(targetRemoves) == 0 {
+		return fmt.Errorf("no updates found in change on %s - invalid", target)
+	}
+
 	// target is a device name with no version
 	if version != "" {
 		configName = store.ConfigName(strings.Join([]string{target, version}, "-"))

--- a/pkg/store/change/change.go
+++ b/pkg/store/change/change.go
@@ -78,6 +78,10 @@ func CreateChange(config ValueCollections, desc string) (*Change, error) {
 	h := sha1.New()
 	t := time.Now()
 
+	if len(config) == 0 {
+		return nil, fmt.Errorf("invalid change %s - no config values found", desc)
+	}
+
 	sort.Slice(config, func(i, j int) bool {
 		return (*config[i]).Path < (*config[j]).Path
 	})

--- a/pkg/store/change/configvalue.go
+++ b/pkg/store/change/configvalue.go
@@ -32,7 +32,7 @@ type ConfigValue struct {
 // Two contiguous slashes are not allowed
 // Paths not starting with slash are not allowed
 func (c ConfigValue) IsPathValid() error {
-	r1 := regexp.MustCompile(`(/[a-zA-Z0-9:=\-_[\]]+)+`)
+	r1 := regexp.MustCompile(`(/[a-zA-Z0-9:=\-_,[\]]+)+`)
 
 	match := r1.FindString(c.Path)
 	if c.Path != match {


### PR DESCRIPTION
List items with more that one key have those keys separated by **,** character - had to update the RegExp to support this