### PR TITLE
Added special handling of Stratum to synchronizer.go

### DIFF
--- a/build/bash_aliases
+++ b/build/bash_aliases
@@ -18,3 +18,6 @@ alias gr='git push origin $(git symbolic-ref HEAD)'
 # Inject shell auto-completion for the 'onos' command
 alias ocomp='eval "$(onos completion bash)"'
 ocomp
+
+# kubectl cluster-info... meaning show which cluster this terminal is pointing at
+alias ki='kubectl cluster-info'

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -60,6 +60,7 @@ const ( // For event types
 	EventTypeErrorSubscribe
 	EventTypeErrorMissingModelPlugin
 	EventTypeErrorTranslation
+	EventTypeErrorGetWithRoPaths
 )
 
 func (et EventType) String() string {


### PR DESCRIPTION
Add the real stratum device with:
```
onit onos-cli
```
Then from within:
```
onos topo add device realstratum1 -a 10.128.13.221:28000 --plain -v 1.0.0 -t  Stratum --insecure --attributes="lat=52.0425,long=-8.362"
```

See it with:
```
onos topo get devices
onos config get configs
onos config get opstate realstratum1
```
(Use -s after it for subscribe to further changes)

Expected output
```
~ $ onos config get opstate realstratum1
OPSTATE CACHE: realstratum1
PATH                                                                              |VALUE               |
/interfaces/interface[name=1/0]/state/admin-status                              |(STRING) UP         |
/interfaces/interface[name=1/0]/state/counters/in-errors                        |(UINT) 0            |
/interfaces/interface[name=1/0]/state/counters/in-multicast-pkts                |(UINT) 155          |
/interfaces/interface[name=1/0]/state/hardware-port                             |(STRING)            |
/interfaces/interface[name=2/0]/state/counters/in-fcs-errors                    |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/out-broadcast-pkts               |(UINT) 179938       |
/interfaces/interface[name=1/0]/state/ifindex                                   |(UINT) 188          |
/interfaces/interface[name=1/0]/state/counters/in-broadcast-pkts                |(UINT) 0            |
/interfaces/interface[name=1/0]/state/health-indicator                          |(STRING) UNKNOWN    |
/interfaces/interface[name=1/0]/state/last-change                               |(STRING) unsupported yet|
/interfaces/interface[name=2/0]/state/counters/out-multicast-pkts               |(UINT) 179938       |
/interfaces/interface[name=2/0]/state/hardware-port                             |(STRING)            |
/interfaces/interface[name=1/0]/state/counters/out-errors                       |(UINT) 0            |
/interfaces/interface[name=1/0]/state/counters/out-unicast-pkts                 |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/in-errors                        |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/in-unknown-protos                |(UINT) 0            |
/interfaces/interface[name=2/0]/state/name                                      |(STRING) 2/0        |
/interfaces/interface[name=1/0]/state/counters/in-octets                        |(UINT) 11510        |
/interfaces/interface[name=1/0]/state/counters/out-multicast-pkts               |(UINT) 179951       |
/interfaces/interface[name=2/0]/state/admin-status                              |(STRING) UP         |
/interfaces/interface[name=2/0]/state/counters/in-discards                      |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/in-multicast-pkts                |(UINT) 179929       |
/interfaces/interface[name=1/0]/state/counters/in-unicast-pkts                  |(UINT) 0            |
/interfaces/interface[name=1/0]/state/counters/out-discards                     |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/in-unicast-pkts                  |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/out-discards                     |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/out-octets                       |(UINT) 45704252     |
/interfaces/interface[name=2/0]/state/last-change                               |(STRING) unsupported yet|
/interfaces/interface[name=2/0]/state/ifindex                                   |(UINT) 184          |
/interfaces/interface[name=1/0]/state/counters/in-discards                      |(UINT) 0            |
/interfaces/interface[name=1/0]/state/counters/in-fcs-errors                    |(UINT) 0            |
/interfaces/interface[name=1/0]/state/counters/in-unknown-protos                |(UINT) 0            |
/interfaces/interface[name=2/0]/state/counters/in-octets                        |(UINT) 45701966     |
/interfaces/interface[name=2/0]/state/counters/out-errors                       |(UINT) 0            |
/interfaces/interface[name=1/0]/state/counters/out-broadcast-pkts               |(UINT) 179951       |
/interfaces/interface[name=2/0]/state/counters/in-broadcast-pkts                |(UINT) 179929       |
/interfaces/interface[name=2/0]/state/counters/out-unicast-pkts                 |(UINT) 0            |
/interfaces/interface[name=2/0]/state/oper-status                               |(STRING) UP         |
/interfaces/interface[name=1/0]/state/counters/out-octets                       |(UINT) 45707554     |
/interfaces/interface[name=1/0]/state/name                                      |(STRING) 1/0        |
/interfaces/interface[name=1/0]/state/oper-status                               |(STRING) UP         |
/interfaces/interface[name=2/0]/state/health-indicator                          |(STRING) UNKNOWN    |
~ $
```