### PR TITLE
Enable slash char in the key name 

### DIFF
--- a/configs/changeStore-sample.json
+++ b/configs/changeStore-sample.json
@@ -106,8 +106,8 @@
         }
       ]
     },
-    "m9jEA7cfJXhYyFZEyKfnqs9zQho=": {
-      "ID": "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+    "Ic0FLA5vVnTqL6893OtyNvzMpss=": {
+      "ID": "Ic0FLA5vVnTqL6893OtyNvzMpss=",
       "Description": "Original configuration for devicesim",
       "Created": "2019-05-21T08:43:01Z",
       "Config": [
@@ -130,6 +130,11 @@
           "Path": "/interfaces/interface[name=eth1]/config/enabled",
           "Value": "AQ==",
           "Type": 4
+        },
+        {
+          "Path": "/interfaces/interface[name=eth1/1]/config/name",
+          "Value": "ZXRoMS8x",
+          "Type": 1
         },
         {
           "Path": "/interfaces/interface[name=eth1/1]/config/enabled",

--- a/configs/changeStore-sample.json
+++ b/configs/changeStore-sample.json
@@ -106,8 +106,8 @@
         }
       ]
     },
-    "IONQSGxVn7XY5/KZI+/407mGk6c=": {
-      "ID": "IONQSGxVn7XY5/KZI+/407mGk6c=",
+    "m9jEA7cfJXhYyFZEyKfnqs9zQho=": {
+      "ID": "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
       "Description": "Original configuration for devicesim",
       "Created": "2019-05-21T08:43:01Z",
       "Config": [
@@ -128,6 +128,11 @@
         },
         {
           "Path": "/interfaces/interface[name=eth1]/config/enabled",
+          "Value": "AQ==",
+          "Type": 4
+        },
+        {
+          "Path": "/interfaces/interface[name=eth1/1]/config/enabled",
           "Value": "AQ==",
           "Type": 4
         },

--- a/configs/configStore-sample.json
+++ b/configs/configStore-sample.json
@@ -47,7 +47,7 @@
       "Created": "2019-05-21T08:43:17Z",
       "Updated": "2019-05-21T08:43:17Z",
       "Changes": [
-        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+        "Ic0FLA5vVnTqL6893OtyNvzMpss=",
         "6u5DggH8SyMQaikerhclgBmneO0="
       ]
     },
@@ -59,7 +59,7 @@
       "Created": "2019-05-21T08:43:18Z",
       "Updated": "2019-05-21T08:43:18Z",
       "Changes": [
-        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+        "Ic0FLA5vVnTqL6893OtyNvzMpss=",
         "wRmAtg1c8ATNeFK8Shiwc1N0gdw="
       ]
     },
@@ -71,7 +71,7 @@
       "Created": "2019-05-21T08:43:19Z",
       "Updated": "2019-05-21T08:43:19Z",
       "Changes": [
-        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+        "Ic0FLA5vVnTqL6893OtyNvzMpss=",
         "z/uj5QRBaxP9ndgko8XUDkQR6kM="
       ]
     },
@@ -83,7 +83,7 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+        "Ic0FLA5vVnTqL6893OtyNvzMpss=",
         "HSG6Jf6bM1vfexEnSoMcNGJ68QE="
       ]
     },
@@ -95,7 +95,7 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+        "Ic0FLA5vVnTqL6893OtyNvzMpss=",
         "aJIBGic9ci3G3KmJpuJxHEkteso="
       ]
     },
@@ -107,7 +107,7 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
+        "Ic0FLA5vVnTqL6893OtyNvzMpss=",
         "EgnVE0n7/B6EF+GY/ismFIcbTbk="
       ]
     },

--- a/configs/configStore-sample.json
+++ b/configs/configStore-sample.json
@@ -47,7 +47,7 @@
       "Created": "2019-05-21T08:43:17Z",
       "Updated": "2019-05-21T08:43:17Z",
       "Changes": [
-        "IONQSGxVn7XY5/KZI+/407mGk6c=",
+        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
         "6u5DggH8SyMQaikerhclgBmneO0="
       ]
     },
@@ -59,7 +59,7 @@
       "Created": "2019-05-21T08:43:18Z",
       "Updated": "2019-05-21T08:43:18Z",
       "Changes": [
-        "IONQSGxVn7XY5/KZI+/407mGk6c=",
+        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
         "wRmAtg1c8ATNeFK8Shiwc1N0gdw="
       ]
     },
@@ -71,7 +71,7 @@
       "Created": "2019-05-21T08:43:19Z",
       "Updated": "2019-05-21T08:43:19Z",
       "Changes": [
-        "IONQSGxVn7XY5/KZI+/407mGk6c=",
+        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
         "z/uj5QRBaxP9ndgko8XUDkQR6kM="
       ]
     },
@@ -83,7 +83,7 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "IONQSGxVn7XY5/KZI+/407mGk6c=",
+        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
         "HSG6Jf6bM1vfexEnSoMcNGJ68QE="
       ]
     },
@@ -95,7 +95,7 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "IONQSGxVn7XY5/KZI+/407mGk6c=",
+        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
         "aJIBGic9ci3G3KmJpuJxHEkteso="
       ]
     },
@@ -107,7 +107,7 @@
       "Created": "2019-05-30T18:03:17Z",
       "Updated": "2019-05-30T18:03:17Z",
       "Changes": [
-        "IONQSGxVn7XY5/KZI+/407mGk6c=",
+        "m9jEA7cfJXhYyFZEyKfnqs9zQho=",
         "EgnVE0n7/B6EF+GY/ismFIcbTbk="
       ]
     },

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -416,7 +416,7 @@ func doRollback(changes mapNetworkChanges, mgr *manager.Manager, target string,
 }
 
 func buildUpdateResult(pathStr string, target string, op gnmi.UpdateResult_Operation) (*gnmi.UpdateResult, error) {
-	path, errInPath := utils.ParseGNMIElements(strings.Split(pathStr, "/")[1:])
+	path, errInPath := utils.ParseGNMIElements(utils.SplitPath(pathStr))
 	if errInPath != nil {
 		log.Error("ERROR: Unable to parse path ", pathStr)
 		return nil, errInPath

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -110,6 +110,86 @@ func Test_doSingleSet(t *testing.T) {
 	assert.Equal(t, (*change.TypedUint64)(&newChange.Config[0].TypedValue).Uint(), uint(16))
 }
 
+// Test_doSingleSet shows how a value of 1 list can be set on a target
+func Test_doSingleSetList(t *testing.T) {
+	server, _ := setUp()
+	var deletePaths = make([]*gnmi.Path, 0)
+	var replacedPaths = make([]*gnmi.Update, 0)
+	var updatedPaths = make([]*gnmi.Update, 0)
+	pathElemsRefs, _ := utils.ParseGNMIElements(utils.SplitPath("/cont1a/cont2a[lista/b=c]/leafList"))
+	typedValue := gnmi.TypedValue_UintVal{UintVal: 16}
+	value := gnmi.TypedValue{Value: &typedValue}
+	updatePath := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "Device1"}
+	updatedPaths = append(updatedPaths, &gnmi.Update{Path: &updatePath, Val: &value})
+
+	ext100Name := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  GnmiExtensionNetwkChangeID,
+			Msg: []byte("TestChange"),
+		},
+	}
+
+	var setRequest = gnmi.SetRequest{
+		Delete:  deletePaths,
+		Replace: replacedPaths,
+		Update:  updatedPaths,
+		Extension: []*gnmi_ext.Extension{{
+			Ext: &ext100Name,
+		}},
+	}
+
+	setResponse, setError := server.Set(context.Background(), &setRequest)
+
+	assert.NilError(t, setError, "Unexpected error from gnmi Set")
+
+	// Check that Response is correct
+	assert.Assert(t, setResponse != nil, "Expected setResponse to have a value")
+
+	assert.Equal(t, len(setResponse.Response), 1)
+
+	assert.Assert(t, setResponse.Message == nil, "Unexpected gnmi error message")
+
+	assert.Equal(t, setResponse.Response[0].Op.String(), gnmi.UpdateResult_UPDATE.String())
+
+	path := setResponse.Response[0].Path
+
+	assert.Equal(t, path.Target, "Device1")
+	assert.Equal(t, len(path.Elem), 3, "Expected 3 path elements")
+
+	assert.Equal(t, path.Elem[0].Name, "cont1a")
+	assert.Equal(t, path.Elem[1].Name, "cont2a")
+	assert.Equal(t, path.Elem[2].Name, "leafList")
+
+	// Check that an the network change ID is given in extension 10
+	assert.Equal(t, len(setResponse.Extension), 1)
+
+	extension := setResponse.Extension[0].GetRegisteredExt()
+	assert.Equal(t, extension.Id.String(), strconv.Itoa(GnmiExtensionNetwkChangeID))
+	assert.Equal(t, string(extension.Msg), "TestChange")
+
+	//Now check the store that the change was made correctly
+	assert.Equal(t, len(manager.GetManager().NetworkStore.Store), 2)
+	var nwChange store.NetworkConfiguration
+	for _, n := range manager.GetManager().NetworkStore.Store {
+		if n.Name == "TestChange" {
+			nwChange = n
+		}
+	}
+	assert.Equal(t, nwChange.User, "User1")
+	assert.Equal(t, len(nwChange.ConfigurationChanges), 1)
+
+	changeID, ok := nwChange.ConfigurationChanges["Device1-1.0.0"]
+	assert.Assert(t, ok)
+	assert.Equal(t, store.B64(changeID), "R8uX5L2ieSzqKjJZVGh8pWvLIl4=")
+
+	assert.Equal(t, len(manager.GetManager().ChangeStore.Store), 13)
+	newChange, ok := manager.GetManager().ChangeStore.Store[store.B64(changeID)]
+	assert.Assert(t, ok)
+	assert.Equal(t, len(newChange.Config), 1)
+	assert.Equal(t, newChange.Config[0].Path, "/cont1a/cont2a[lista/b=c]/leafList")
+	assert.Equal(t, (*change.TypedUint64)(&newChange.Config[0].TypedValue).Uint(), uint(16))
+}
+
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target
 func Test_do2SetsOnSameTarget(t *testing.T) {
 	server, _ := setUp()

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -116,7 +116,7 @@ func Test_doSingleSetList(t *testing.T) {
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
-	pathElemsRefs, _ := utils.ParseGNMIElements(utils.SplitPath("/cont1a/cont2a[lista/b=c]/leafList"))
+	pathElemsRefs, _ := utils.ParseGNMIElements(utils.SplitPath("/cont1a/list2a[name=a/b]/tx-power"))
 	typedValue := gnmi.TypedValue_UintVal{UintVal: 16}
 	value := gnmi.TypedValue{Value: &typedValue}
 	updatePath := gnmi.Path{Elem: pathElemsRefs.Elem, Target: "Device1"}
@@ -157,8 +157,8 @@ func Test_doSingleSetList(t *testing.T) {
 	assert.Equal(t, len(path.Elem), 3, "Expected 3 path elements")
 
 	assert.Equal(t, path.Elem[0].Name, "cont1a")
-	assert.Equal(t, path.Elem[1].Name, "cont2a")
-	assert.Equal(t, path.Elem[2].Name, "leafList")
+	assert.Equal(t, path.Elem[1].Name, "list2a")
+	assert.Equal(t, path.Elem[2].Name, "tx-power")
 
 	// Check that an the network change ID is given in extension 10
 	assert.Equal(t, len(setResponse.Extension), 1)
@@ -180,13 +180,13 @@ func Test_doSingleSetList(t *testing.T) {
 
 	changeID, ok := nwChange.ConfigurationChanges["Device1-1.0.0"]
 	assert.Assert(t, ok)
-	assert.Equal(t, store.B64(changeID), "R8uX5L2ieSzqKjJZVGh8pWvLIl4=")
+	assert.Equal(t, store.B64(changeID), "q4PV/7tyqIiflh6NIpgRiDis5ms=")
 
 	assert.Equal(t, len(manager.GetManager().ChangeStore.Store), 13)
 	newChange, ok := manager.GetManager().ChangeStore.Store[store.B64(changeID)]
 	assert.Assert(t, ok)
 	assert.Equal(t, len(newChange.Config), 1)
-	assert.Equal(t, newChange.Config[0].Path, "/cont1a/cont2a[lista/b=c]/leafList")
+	assert.Equal(t, newChange.Config[0].Path, "/cont1a/list2a[name=a/b]/tx-power")
 	assert.Equal(t, (*change.TypedUint64)(&newChange.Config[0].TypedValue).Uint(), uint(16))
 }
 

--- a/pkg/utils/gnmiPathUtils_test.go
+++ b/pkg/utils/gnmiPathUtils_test.go
@@ -28,8 +28,10 @@ const (
 	elemNameEscaped1a = "netwo\\r\\k\\-\\instances"
 	elemNameEscaped1b = "net\\w\\o\\r\\k-instance"
 	elemKeyName1      = "name"
+	elemKeyNameSlash  = "name/value"
 	elemKeyValue1     = "DEFAULT"
 	path1             = "/" + elemName1a + "[" + elemKeyName1 + "=" + elemKeyValue1 + "]/" + elemName1b
+	pathSlashKey      = "/" + elemName1a + "[" + elemKeyNameSlash + "=" + elemKeyValue1 + "]/" + elemName1b
 	escapedPath1      = "/" + elemNameEscaped1a + "[" + elemKeyName1 + "=" + elemKeyValue1 + "]/" + elemNameEscaped1b
 
 	pathSegment1 = "1"
@@ -66,6 +68,16 @@ func Test_ParseSimple(t *testing.T) {
 	assert.Assert(t, parsed != nil && err == nil, "path returned an error")
 
 	checkElement(t, parsed, 0, elemName1a, elemKeyName1, elemKeyValue1)
+}
+
+func Test_ParseSimpleSlash(t *testing.T) {
+	print(pathSlashKey)
+	elements := SplitPath(pathSlashKey)
+	parsed, err := ParseGNMIElements(elements)
+
+	assert.Assert(t, parsed != nil && err == nil, "path returned an error")
+
+	checkElement(t, parsed, 0, elemName1a, elemKeyNameSlash, elemKeyValue1)
 }
 
 func Test_ParseEscape(t *testing.T) {
@@ -122,6 +134,15 @@ func Test_StrPath(t *testing.T) {
 
 	generatedPath := StrPath(parsed)
 	assert.Equal(t, generatedPath, path1)
+}
+
+func Test_StrPathSlash(t *testing.T) {
+	elements := SplitPath(pathSlashKey)
+	parsed, err := ParseGNMIElements(elements)
+	assert.NilError(t, err)
+
+	generatedPath := StrPath(parsed)
+	assert.Equal(t, generatedPath, pathSlashKey)
 }
 
 func Test_StrPathV03(t *testing.T) {


### PR DESCRIPTION
Allows the key to have a `/` in it, e.g. eth1/0.
Remove two usages of `strings.split(path, "/")` in favour of utils.StrPath, which takes into account the `/`