### PR TITLE
Add --continue to the debuger to continue the executation of onos-config

### DIFF
--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
 COPY --from=debugBuilder /go/bin/gnmi_cli /usr/local/bin/gnmi_cli
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
-    echo "dlv --listen=:40000 --headless=true --accept-multiclient=true --api-version=2 --log exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
+    echo "dlv --listen=:40000 --headless=true --accept-multiclient=true --continue --api-version=2 --log exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
     chmod +x /usr/local/bin/onos-config-debug
 
 RUN addgroup -S onos-config && adduser -S -G onos-config onos-config


### PR DESCRIPTION
@kuujo 
I had a quick test and I think --continue flag solves the issue of halting the debug images at startup. According to this PR: https://github.com/go-delve/delve/pull/1585