### PR TITLE
Filter out coverage for protoc generated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/_output
 *.DS_Store
 coverage.txt
 *.coverprofile
+*.coverprofile.orig
 .idea
 modelplugin/TestDevice-1.0.0/testdevice.so.1.0.0
 modelplugin/TestDevice-2.0.0/testdevice.so.2.0.0

--- a/build/bin/coveralls-coverage
+++ b/build/bin/coveralls-coverage
@@ -3,4 +3,6 @@
 go get github.com/go-playground/overalls && go get github.com/mattn/goveralls
 
 overalls -project=github.com/onosproject/onos-config -covermode=count -ignore=".git,vendor,models,tools"
+mv overalls.coverprofile overalls.coverprofile.orig
+grep -v .pb.go overalls.coverprofile.orig >overalls.coverprofile
 goveralls -coverprofile=overalls.coverprofile -service travis-ci


### PR DESCRIPTION
There is no point in collecting coverage information about generated code. Filter these out of the coverage file.