### PR TITLE
Refactor Docker build to reduce build times and support the -race flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,12 @@ ONOS_BUILD_VERSION := stable
 MODELPLUGINS = build/_output/testdevice.so.1.0.0 build/_output/testdevice.so.2.0.0 build/_output/devicesim.so.1.0.0 build/_output/stratum.so.1.0.0
 
 build: # @HELP build the Go binaries and run all validations (default)
-build: $(MODELPLUGINS)
+build:
 	CGO_ENABLED=1 go build -o build/_output/onos-config ./cmd/onos-config
 	CGO_ENABLED=1 go build -gcflags "all=-N -l" -o build/_output/onos-config-debug ./cmd/onos-config
+
+build-plugins: # @HELP build plugin binaries
+build-plugins: $(MODELPLUGINS)
 
 build/_output/testdevice.so.1.0.0: modelplugin/TestDevice-1.0.0/modelmain.go modelplugin/TestDevice-1.0.0/testdevice_1_0_0/generated.go
 	-CGO_ENABLED=1 go build -o build/_output/testdevice.so.1.0.0 -buildmode=plugin -tags=modelplugin ./modelplugin/TestDevice-1.0.0
@@ -66,6 +69,14 @@ onos-config-base-docker: # @HELP build onos-config base Docker image
 		--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
 		-t onosproject/onos-config-base:${ONOS_CONFIG_VERSION}
 	@rm -rf vendor
+
+onos-config-plugins-docker: # @HELP build onos-config plugins Docker image
+onos-config-plugins-docker:
+	@go mod vendor
+		docker build . -f build/plugins/Dockerfile \
+			--build-arg ONOS_BUILD_VERSION=${ONOS_BUILD_VERSION} \
+			-t onosproject/onos-config-plugins:${ONOS_CONFIG_VERSION}
+		@rm -rf vendor
 
 onos-config-docker: onos-config-base-docker # @HELP build onos-config Docker image
 	docker build . -f build/onos-config/Dockerfile \

--- a/build/base/Dockerfile
+++ b/build/base/Dockerfile
@@ -1,6 +1,15 @@
 ARG ONOS_BUILD_VERSION=stable
 
 FROM onosproject/golang-build:$ONOS_BUILD_VERSION
+
+RUN go get -u github.com/go-delve/delve/cmd/dlv
+
 ENV GO111MODULE=on
-COPY . /go/src/github.com/onosproject/onos-config
+
+COPY Makefile go.mod go.sum /go/src/github.com/onosproject/onos-config/
+COPY cmd/ /go/src/github.com/onosproject/onos-config/cmd/
+COPY configs/ /go/src/github.com/onosproject/onos-config/configs/
+COPY pkg/ /go/src/github.com/onosproject/onos-config/pkg/
+COPY vendor/ /go/src/github.com/onosproject/onos-config/vendor/
+
 RUN cd /go/src/github.com/onosproject/onos-config && GOFLAGS=-mod=vendor make build

--- a/build/onos-config-debug/Dockerfile
+++ b/build/onos-config-debug/Dockerfile
@@ -1,33 +1,24 @@
 ARG ONOS_CONFIG_BASE_VERSION=latest
+ARG ONOS_CONFIG_PLUGINS_VERSION=latest
 
+# The base image contains the onos-config binaries
 FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
 
-FROM golang:1.12.6-alpine3.9 as debugBuilder
+# The plugins image contains plugin binaries
+FROM onosproject/onos-config-plugins:$ONOS_CONFIG_PLUGINS_VERSION as plugins
 
-RUN apk upgrade --update --no-cache && apk add git && \
-    go get -u github.com/go-delve/delve/cmd/dlv && \
-    go get -u github.com/openconfig/gnmi/cmd/gnmi_cli
-
-FROM alpine:3.9
-
-RUN apk upgrade --update --no-cache && apk add bash bash-completion libc6-compat
+FROM ubuntu:18.04
 
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos-config-debug /usr/local/bin/onos-config
-COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/*-debug.so.* /usr/local/lib/
-COPY --from=debugBuilder /go/bin/dlv /usr/local/bin/dlv
-COPY --from=debugBuilder /go/bin/gnmi_cli /usr/local/bin/gnmi_cli
+COPY --from=base /go/bin/dlv /usr/local/bin/dlv
+COPY --from=plugins /go/src/github.com/onosproject/onos-config/build/_output/*-debug.so.* /usr/local/lib/
 
 RUN echo "#!/bin/sh" >> /usr/local/bin/onos-config-debug && \
     echo "dlv --listen=:40000 --headless=true --accept-multiclient=true --continue --api-version=2 --log exec /usr/local/bin/onos-config -- \"\$@\"" >> /usr/local/bin/onos-config-debug && \
     chmod +x /usr/local/bin/onos-config-debug
 
-RUN addgroup -S onos-config && adduser -S -G onos-config onos-config
+RUN adduser onos-config
 USER onos-config
 WORKDIR /home/onos-config
-
-ENV ATOMIX_CONTROLLER=atomix-controller.kube-system.svc.cluster.local:5679
-ENV ATOMIX_NAMESPACE=default
-
-RUN cp /etc/profile /home/onos-config/.bashrc
 
 ENTRYPOINT ["onos-config-debug"]

--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,6 +1,11 @@
 ARG ONOS_CONFIG_BASE_VERSION=latest
+ARG ONOS_CONFIG_PLUGINS_VERSION=latest
 
+# The base image contains the onos-config binaries
 FROM onosproject/onos-config-base:$ONOS_CONFIG_BASE_VERSION as base
+
+# The plugins image contains plugin binaries
+FROM onosproject/onos-config-plugins:$ONOS_CONFIG_PLUGINS_VERSION as plugins
 
 FROM alpine:3.9
 RUN apk add libc6-compat
@@ -8,6 +13,6 @@ RUN apk add libc6-compat
 USER nobody
 
 COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/onos-config /usr/local/bin/onos-config
-COPY --from=base /go/src/github.com/onosproject/onos-config/build/_output/*.so.* /usr/local/lib/
+COPY --from=plugins /go/src/github.com/onosproject/onos-config/build/_output/*.so.* /usr/local/lib/
 
 ENTRYPOINT ["onos-config"]

--- a/build/plugins/Dockerfile
+++ b/build/plugins/Dockerfile
@@ -1,0 +1,10 @@
+ARG ONOS_BUILD_VERSION=stable
+
+FROM onosproject/golang-build:$ONOS_BUILD_VERSION
+ENV GO111MODULE=on
+
+COPY vendor /go/src/github.com/onosproject/onos-config/vendor/
+COPY Makefile go.mod go.sum /go/src/github.com/onosproject/onos-config/
+COPY modelplugin /go/src/github.com/onosproject/onos-config/modelplugin/
+
+RUN cd /go/src/github.com/onosproject/onos-config && GOFLAGS=-mod=vendor make build-plugins


### PR DESCRIPTION
This PR refactors the build for Docker images. It separates builds for the onos-config binary from builds for the plugins. By doing so, we can take advantage of Docker's support for incremental builds. By copying only the files relevant to each image, we ensure the plugins image will only be rebuilt when the plugin code has changed and the config image will only be rebuilt when the config code has changed.

This PR also switches the debug image to Ubuntu so we can use the `-race` flag. However, in debian the debugger requires privileged access, so we also need to make some changes to https://github.com/onosproject/onos-test to deploy debug images in privileged mode.