### PR TITLE
Convert CLI Run() methods to RunE() to allow for execution in tests

### DIFF
--- a/pkg/cli/changes.go
+++ b/pkg/cli/changes.go
@@ -43,12 +43,12 @@ func getGetChangesCommand() *cobra.Command {
 		Use:   "changes [<changeId>]",
 		Short: "Lists records of configuration changes",
 		Args:  cobra.MaximumNArgs(1),
-		Run:   runChangesCommand,
+		RunE:  runChangesCommand,
 	}
 	return cmd
 }
 
-func runChangesCommand(cmd *cobra.Command, args []string) {
+func runChangesCommand(cmd *cobra.Command, args []string) error {
 	client := diags.NewConfigDiagsClient(getConnection())
 	changesReq := &diags.ChangesRequest{ChangeIDs: make([]string, 0)}
 	if len(args) == 1 {
@@ -59,29 +59,31 @@ func runChangesCommand(cmd *cobra.Command, args []string) {
 
 	stream, err := client.GetChanges(context.Background(), changesReq)
 	if err != nil {
-		ExitWithErrorMessage("Failed to send request: %v", err)
+		return err
 	}
-	waitc := make(chan struct{})
+	waitc := make(chan error)
 	go func() {
 		for {
 			in, err := stream.Recv()
 			if err == io.EOF {
 				// read done.
+				waitc <- nil
 				close(waitc)
 				return
 			}
 			if err != nil {
-				ExitWithErrorMessage("Failed to receive response : %v", err)
+				waitc <- err
+				close(waitc)
+				return
 			}
 			_ = tmplChanges.Execute(os.Stdout, in)
 		}
 	}()
 	err = stream.CloseSend()
 	if err != nil {
-		ExitWithErrorMessage("Failed to close: %v", err)
+		return err
 	}
-	<-waitc
-	ExitWithSuccess()
+	return <-waitc
 }
 
 func wrapPath(path string, lineLen int, tabs int) string {

--- a/pkg/cli/changes.go
+++ b/pkg/cli/changes.go
@@ -61,29 +61,17 @@ func runChangesCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	waitc := make(chan error)
-	go func() {
-		for {
-			in, err := stream.Recv()
-			if err == io.EOF {
-				// read done.
-				waitc <- nil
-				close(waitc)
-				return
-			}
-			if err != nil {
-				waitc <- err
-				close(waitc)
-				return
-			}
-			_ = tmplChanges.Execute(os.Stdout, in)
+
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			return nil
 		}
-	}()
-	err = stream.CloseSend()
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		_ = tmplChanges.Execute(os.Stdout, in)
 	}
-	return <-waitc
 }
 
 func wrapPath(path string, lineLen int, tabs int) string {

--- a/pkg/cli/configs.go
+++ b/pkg/cli/configs.go
@@ -43,32 +43,21 @@ func runGetConfigsCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	waitc := make(chan error)
-	go func() {
-		for {
-			in, err := stream.Recv()
-			if err == io.EOF {
-				// read done.
-				waitc <- nil
-				close(waitc)
-				return
-			}
-			if err != nil {
-				waitc <- err
-				close(waitc)
-				return
-			}
-			Output("%s\t(%s)\t%s\t%s\t%s\n", in.Name, in.DeviceID, in.Version, in.DeviceType,
-				in.Updated.Format(time.RFC3339))
-			for _, cid := range in.ChangeIDs {
-				Output("\t%s", cid)
-			}
-			Output("\n")
+
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			// read done.
+			return nil
 		}
-	}()
-	err = stream.CloseSend()
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		Output("%s\t(%s)\t%s\t%s\t%s\n", in.Name, in.DeviceID, in.Version, in.DeviceType,
+			in.Updated.Format(time.RFC3339))
+		for _, cid := range in.ChangeIDs {
+			Output("\t%s", cid)
+		}
+		Output("\n")
 	}
-	return <-waitc
 }

--- a/pkg/cli/devicetree.go
+++ b/pkg/cli/devicetree.go
@@ -57,9 +57,9 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
 
 	layer, err := cmd.Flags().GetInt16("layer")
 	if err != nil {
-		return fmt.Errorf("Failed to parse 'layer': %v\n", err)
+		return fmt.Errorf("failed to parse 'layer': %v", err)
 	} else if layer > 0 {
-		return fmt.Errorf("Layer must be less than or equal 0.\n")
+		return fmt.Errorf("layer must be less than or equal 0")
 	}
 
 	stream, err := client.GetConfigurations(context.Background(), configReq)
@@ -131,7 +131,7 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
 
 	stream2, err := client.GetChanges(context.Background(), changesReq)
 	if err != nil {
-		return fmt.Errorf("Failed to send request: %v", err)
+		return fmt.Errorf("failed to send request: %v", err)
 	}
 	waitc2 := make(chan error)
 	go func() {
@@ -144,7 +144,7 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
 				return
 			}
 			if err != nil {
-				waitc2 <- fmt.Errorf("Failed to receive response : %v", err)
+				waitc2 <- fmt.Errorf("failed to receive response : %v", err)
 				close(waitc2)
 				return
 			}

--- a/pkg/cli/models.go
+++ b/pkg/cli/models.go
@@ -62,30 +62,18 @@ func runListPluginsCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to send request: %v", err)
 	}
-	waitc := make(chan error)
-	go func() {
-		for {
-			in, err := stream.Recv()
-			if err == io.EOF {
-				// read done.
-				waitc <- nil
-				close(waitc)
-				return
-			}
-			if err != nil {
-				waitc <- fmt.Errorf("Failed to receive response : %v", err)
-				close(waitc)
-				return
-			}
-			_ = tmplModelList.Execute(os.Stdout, in)
-			Output("\n")
+
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			return nil
 		}
-	}()
-	err = stream.CloseSend()
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		_ = tmplModelList.Execute(os.Stdout, in)
+		Output("\n")
 	}
-	return <-waitc
 }
 
 func getAddPluginCommand() *cobra.Command {

--- a/pkg/cli/opstate.go
+++ b/pkg/cli/opstate.go
@@ -51,28 +51,17 @@ func runOpstateCommand(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		ExitWithErrorMessage("Failed to send request: %v", err)
 	}
-	waitc := make(chan error)
-	go func() {
-		for {
-			in, err := stream.Recv()
-			if err == io.EOF {
-				// read done.
-				waitc <- nil
-				close(waitc)
-				return
-			}
-			if err != nil {
-				waitc <- err
-				close(waitc)
-				return
-			}
-			_ = tmplGetOpState.Execute(os.Stdout, in)
-			Output("\n")
+
+	for {
+		in, err := stream.Recv()
+		if err == io.EOF {
+			// read done.
+			return nil
 		}
-	}()
-	err = stream.CloseSend()
-	if err != nil {
-		return err
+		if err != nil {
+			return err
+		}
+		_ = tmplGetOpState.Execute(os.Stdout, in)
+		Output("\n")
 	}
-	return <-waitc
 }

--- a/pkg/cli/rollback.go
+++ b/pkg/cli/rollback.go
@@ -25,12 +25,12 @@ func getRollbackCommand() *cobra.Command {
 		Use:   "rollback <changeId>",
 		Short: "Rolls-back a network configuration change",
 		Args:  cobra.MaximumNArgs(1),
-		Run:   runRollbackCommand,
+		RunE:  runRollbackCommand,
 	}
 	return cmd
 }
 
-func runRollbackCommand(cmd *cobra.Command, args []string) {
+func runRollbackCommand(cmd *cobra.Command, args []string) error {
 	client := admin.NewConfigAdminServiceClient(getConnection())
 	changeID := ""
 	if len(args) == 1 {
@@ -40,8 +40,8 @@ func runRollbackCommand(cmd *cobra.Command, args []string) {
 	resp, err := client.RollbackNetworkChange(
 		context.Background(), &admin.RollbackRequest{Name: changeID})
 	if err != nil {
-		ExitWithErrorMessage("Failed to send request: %v", err)
+		return err
 	}
 	Output("Rollback success %s\n", resp.Message)
-	ExitWithSuccess()
+	return nil
 }


### PR DESCRIPTION
In this PR I changed the instances of Run() methods in the CLI to RunE() methods. Run() methods simply exit when they complete, making testing impossible. With this change, we can drive these methods via unit tests.