### PR TITLE
Remove all explicit exit conditions and os.Stdout references from the onos-config CLI

### DIFF
--- a/pkg/cli/changes.go
+++ b/pkg/cli/changes.go
@@ -49,7 +49,12 @@ func getGetChangesCommand() *cobra.Command {
 }
 
 func runChangesCommand(cmd *cobra.Command, args []string) error {
-	client := diags.NewConfigDiagsClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := diags.NewConfigDiagsClient(clientConnection)
 	changesReq := &diags.ChangesRequest{ChangeIDs: make([]string, 0)}
 	if len(args) == 1 {
 		changesReq.ChangeIDs = append(changesReq.ChangeIDs, args[0])

--- a/pkg/cli/changes.go
+++ b/pkg/cli/changes.go
@@ -75,7 +75,7 @@ func runChangesCommand(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		_ = tmplChanges.Execute(os.Stdout, in)
+		_ = tmplChanges.Execute(GetOutput(), in)
 	}
 }
 

--- a/pkg/cli/changes.go
+++ b/pkg/cli/changes.go
@@ -109,7 +109,8 @@ func nativeType(cv admin.ChangeValue) string {
 	}
 	tv, err := change.CreateTypedValue(cv.Value, change.ValueType(cv.ValueType), to)
 	if err != nil {
-		ExitWithErrorMessage("Failed to convert value to TypedValue %s", err)
+		fmt.Fprintf(os.Stderr, "Failed to convert value to TypedValue %s", err)
+		os.Exit(1)
 	}
 	return tv.String()
 }

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -26,7 +26,7 @@ const (
 )
 
 // getConnection returns a gRPC client connection to the config service
-func getConnection() *grpc.ClientConn {
+func getConnection() (*grpc.ClientConn, error) {
 	address := getConfigOrDefault("address", defaultAddress).(string)
 	certPath := getConfigString("tls.certPath")
 	keyPath := getConfigString("tls.keyPath")
@@ -34,7 +34,7 @@ func getConnection() *grpc.ClientConn {
 	if certPath != "" && keyPath != "" {
 		cert, err := tls.LoadX509KeyPair(certPath, keyPath)
 		if err != nil {
-			ExitWithError(ExitBadArgs, err)
+			return nil, err
 		}
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
@@ -46,7 +46,7 @@ func getConnection() *grpc.ClientConn {
 		// Load default Certificates
 		cert, err := tls.X509KeyPair([]byte(certs.DefaultClientCrt), []byte(certs.DefaultClientKey))
 		if err != nil {
-			ExitWithError(ExitBadArgs, err)
+			return nil, err
 		}
 		opts = []grpc.DialOption{
 			grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{
@@ -58,7 +58,7 @@ func getConnection() *grpc.ClientConn {
 
 	conn, err := grpc.Dial(address, opts...)
 	if err != nil {
-		ExitWithError(ExitBadConnection, err)
+		return nil, err
 	}
-	return conn
+	return conn, nil
 }

--- a/pkg/cli/configs.go
+++ b/pkg/cli/configs.go
@@ -33,7 +33,12 @@ func getGetConfigsCommand() *cobra.Command {
 }
 
 func runGetConfigsCommand(cmd *cobra.Command, args []string) error {
-	client := diags.NewConfigDiagsClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := diags.NewConfigDiagsClient(clientConnection)
 
 	configReq := &diags.ConfigRequest{DeviceIDs: make([]string, 0)}
 	if len(args) == 1 {

--- a/pkg/cli/devicetree.go
+++ b/pkg/cli/devicetree.go
@@ -23,7 +23,6 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"github.com/spf13/cobra"
 	"io"
-	"os"
 	"text/template"
 )
 
@@ -159,7 +158,7 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
 
 	tmplDevicetreeList, _ := template.New("devices").Funcs(funcMapDeviceTree).Parse(devicetreeTemplate)
 	for _, configuration := range configurations {
-		_ = tmplDevicetreeList.Execute(os.Stdout, configuration)
+		_ = tmplDevicetreeList.Execute(GetOutput(), configuration)
 		fullDeviceConfigValues := configuration.ExtractFullConfig(nil, changes, 0) // Passing 0 as change set has already been reduced by n='layer'
 		jsonTree, _ := store.BuildTree(fullDeviceConfigValues, false)
 		Output("TREE:\n%s\n\n", string(jsonTree))

--- a/pkg/cli/devicetree.go
+++ b/pkg/cli/devicetree.go
@@ -49,7 +49,12 @@ func getGetDeviceTreeCommand() *cobra.Command {
 }
 
 func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
-	client := diags.NewConfigDiagsClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := diags.NewConfigDiagsClient(clientConnection)
 	configReq := &diags.ConfigRequest{DeviceIDs: make([]string, 0)}
 	if len(args) > 0 {
 		configReq.DeviceIDs = append(configReq.DeviceIDs, args[0])

--- a/pkg/cli/devicetree.go
+++ b/pkg/cli/devicetree.go
@@ -105,7 +105,7 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(configurations) == 0 {
-		ExitWithErrorMessage("Device(s) not found: %v\n", configReq.DeviceIDs)
+		return fmt.Errorf("device(s) not found: %v", configReq.DeviceIDs)
 	}
 
 	changes := make(map[string]*change.Change)

--- a/pkg/cli/models.go
+++ b/pkg/cli/models.go
@@ -56,7 +56,12 @@ func getGetPluginsCommand() *cobra.Command {
 func runListPluginsCommand(cmd *cobra.Command, args []string) error {
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	tmplModelList, _ := template.New("change").Parse(modellistTemplate)
-	client := admin.CreateConfigAdminServiceClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := admin.CreateConfigAdminServiceClient(clientConnection)
 
 	stream, err := client.ListRegisteredModels(context.Background(), &admin.ListModelsRequest{Verbose: verbose})
 	if err != nil {
@@ -87,7 +92,12 @@ func getAddPluginCommand() *cobra.Command {
 }
 
 func runAddPluginCommand(cmd *cobra.Command, args []string) error {
-	client := admin.CreateConfigAdminServiceClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := admin.CreateConfigAdminServiceClient(clientConnection)
 
 	pluginFileName := ""
 	if len(args) == 1 {

--- a/pkg/cli/models.go
+++ b/pkg/cli/models.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/admin"
 	"github.com/spf13/cobra"
 	"io"
-	"os"
 	"text/template"
 )
 
@@ -76,7 +75,7 @@ func runListPluginsCommand(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		_ = tmplModelList.Execute(os.Stdout, in)
+		_ = tmplModelList.Execute(GetOutput(), in)
 		Output("\n")
 	}
 }

--- a/pkg/cli/net-changes.go
+++ b/pkg/cli/net-changes.go
@@ -33,7 +33,12 @@ func getGetNetChangesCommand() *cobra.Command {
 }
 
 func runNetChangesCommand(cmd *cobra.Command, args []string) error {
-	client := admin.CreateConfigAdminServiceClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := admin.CreateConfigAdminServiceClient(clientConnection)
 
 	stream, err := client.GetNetworkChanges(context.Background(), &admin.NetworkChangesRequest{})
 	if err != nil {

--- a/pkg/cli/opstate.go
+++ b/pkg/cli/opstate.go
@@ -54,7 +54,7 @@ func runOpstateCommand(cmd *cobra.Command, args []string) error {
 
 	stream, err := client.GetOpState(context.Background(), &diags.OpStateRequest{DeviceId: deviceID, Subscribe: subscribe})
 	if err != nil {
-		ExitWithErrorMessage("Failed to send request: %v", err)
+		return fmt.Errorf("failed to send request: %v", err)
 	}
 
 	for {

--- a/pkg/cli/opstate.go
+++ b/pkg/cli/opstate.go
@@ -20,7 +20,6 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
 	"github.com/spf13/cobra"
 	"io"
-	"os"
 	"text/template"
 )
 
@@ -66,7 +65,7 @@ func runOpstateCommand(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		_ = tmplGetOpState.Execute(os.Stdout, in)
+		_ = tmplGetOpState.Execute(GetOutput(), in)
 		Output("\n")
 	}
 }

--- a/pkg/cli/opstate.go
+++ b/pkg/cli/opstate.go
@@ -42,7 +42,12 @@ func runOpstateCommand(cmd *cobra.Command, args []string) error {
 	deviceID := args[0]
 	subscribe, _ := cmd.Flags().GetBool("subscribe")
 	tmplGetOpState, _ := template.New("change").Funcs(funcMapChanges).Parse(opstateTemplate)
-	client := diags.NewOpStateDiagsClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := diags.NewOpStateDiagsClient(clientConnection)
 
 	fmt.Printf("OPSTATE CACHE: %s\n", deviceID)
 	fmt.Printf("%-82s|%-20s|\n", "PATH", "VALUE")

--- a/pkg/cli/output.go
+++ b/pkg/cli/output.go
@@ -50,12 +50,6 @@ func Output(msg string, args ...interface{}) {
 	_, _ = fmt.Fprintf(outputWriter, msg, args...)
 }
 
-// ExitWithError prints the specified error and exits program with the given error code.
-func ExitWithError(code int, err error) {
-	_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
-	os.Exit(code)
-}
-
 // ExitWithErrorMessage prints the specified message and exits program with the given error code.
 func ExitWithErrorMessage(msg string, args ...interface{}) {
 	_, _ = fmt.Fprintf(os.Stderr, msg, args...)

--- a/pkg/cli/output.go
+++ b/pkg/cli/output.go
@@ -50,17 +50,6 @@ func Output(msg string, args ...interface{}) {
 	fmt.Fprintf(outputWriter, msg, args...)
 }
 
-// ExitWithOutput prints the specified entity and exits program with success.
-func ExitWithOutput(msg string, output ...interface{}) {
-	fmt.Fprintf(outputWriter, msg, output...)
-	os.Exit(ExitSuccess)
-}
-
-// ExitWithSuccess exits program with success without any output.
-func ExitWithSuccess() {
-	os.Exit(ExitSuccess)
-}
-
 // ExitWithError prints the specified error and exits program with the given error code.
 func ExitWithError(code int, err error) {
 	fmt.Fprintln(os.Stderr, "Error:", err)

--- a/pkg/cli/output.go
+++ b/pkg/cli/output.go
@@ -49,9 +49,3 @@ func init() {
 func Output(msg string, args ...interface{}) {
 	_, _ = fmt.Fprintf(outputWriter, msg, args...)
 }
-
-// ExitWithErrorMessage prints the specified message and exits program with the given error code.
-func ExitWithErrorMessage(msg string, args ...interface{}) {
-	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
-	os.Exit(ExitError)
-}

--- a/pkg/cli/output.go
+++ b/pkg/cli/output.go
@@ -20,21 +20,12 @@ import (
 	"os"
 )
 
-const (
-	// ExitSuccess means nominal status
-	ExitSuccess = iota
-
-	// ExitError means general error
-	ExitError
-
-	// ExitBadConnection means failed connection to remote service
-	ExitBadConnection
-
-	// ExitBadArgs means invalid argument values were given
-	ExitBadArgs = 128
-)
-
 var outputWriter io.Writer
+
+// GetOutput returns the current output writer
+func GetOutput() io.Writer {
+	return outputWriter
+}
 
 // CaptureOutput allows a test harness to redirect output to an alternate source for testing
 func CaptureOutput(capture io.Writer) {

--- a/pkg/cli/output.go
+++ b/pkg/cli/output.go
@@ -47,17 +47,17 @@ func init() {
 
 // Output prints the specified format message with arguments to stdout.
 func Output(msg string, args ...interface{}) {
-	fmt.Fprintf(outputWriter, msg, args...)
+	_, _ = fmt.Fprintf(outputWriter, msg, args...)
 }
 
 // ExitWithError prints the specified error and exits program with the given error code.
 func ExitWithError(code int, err error) {
-	fmt.Fprintln(os.Stderr, "Error:", err)
+	_, _ = fmt.Fprintln(os.Stderr, "Error:", err)
 	os.Exit(code)
 }
 
 // ExitWithErrorMessage prints the specified message and exits program with the given error code.
 func ExitWithErrorMessage(msg string, args ...interface{}) {
-	fmt.Fprintf(os.Stderr, msg, args...)
+	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
 	os.Exit(ExitError)
 }

--- a/pkg/cli/rollback.go
+++ b/pkg/cli/rollback.go
@@ -31,7 +31,12 @@ func getRollbackCommand() *cobra.Command {
 }
 
 func runRollbackCommand(cmd *cobra.Command, args []string) error {
-	client := admin.CreateConfigAdminServiceClient(getConnection())
+	clientConnection, clientConnectionError := getConnection()
+
+	if clientConnectionError != nil {
+		return clientConnectionError
+	}
+	client := admin.CreateConfigAdminServiceClient(clientConnection)
 
 	changeID := ""
 	if len(args) == 1 {


### PR DESCRIPTION
This change removes some explicit references to os.Exit() and os.Stdout that make the onos-config CLI untestable.