### PR TITLE
Hold for device reply before notifying subscribers of a change.

### DIFF
--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -383,13 +383,13 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 	//blocking until we receive something from the channel or for 5 seconds, whatever comes first.
 	select {
 	case response := <-respChan:
+		go func() {
+			respChan <- response
+		}()
 		switch eventType := response.EventType(); eventType {
 		case events.EventTypeAchievedSetConfig:
 			log.Info("Set is properly configured ", response.ChangeID())
 			//Passing by the event to subscribe subsystem
-			go func() {
-				respChan <- response
-			}()
 			return nil
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -386,6 +386,10 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 		switch eventType := response.EventType(); eventType {
 		case events.EventTypeAchievedSetConfig:
 			log.Info("Set is properly configured ", response.ChangeID())
+			//Passing by the event to subscribe subsystem
+			go func() {
+				respChan <- response
+			}()
 			return nil
 		case events.EventTypeErrorSetConfig:
 			//Removing previously applied config

--- a/pkg/southbound/topocache/topocache.go
+++ b/pkg/southbound/topocache/topocache.go
@@ -39,7 +39,7 @@ const (
 // DeviceStore is the model of the Device store
 type DeviceStore struct {
 	client device.DeviceServiceClient
-	cache  map[device.ID]*device.Device
+	Cache  map[device.ID]*device.Device
 }
 
 // LoadDeviceStore loads a device store
@@ -56,7 +56,7 @@ func LoadDeviceStore(topoChannel chan<- events.TopoEvent, opts ...grpc.DialOptio
 	client := device.NewDeviceServiceClient(conn)
 	deviceStore := &DeviceStore{
 		client: client,
-		cache:  make(map[device.ID]*device.Device),
+		Cache:  make(map[device.ID]*device.Device),
 	}
 	go deviceStore.start(topoChannel)
 	return deviceStore, nil
@@ -105,15 +105,15 @@ func (s *DeviceStore) watchEvents(ch chan<- events.TopoEvent) error {
 
 		switch response.Type {
 		case device.ListResponse_NONE:
-			if _, ok := s.cache[response.Device.ID]; !ok {
-				s.cache[response.Device.ID] = response.Device
+			if _, ok := s.Cache[response.Device.ID]; !ok {
+				s.Cache[response.Device.ID] = response.Device
 				ch <- events.NewTopoEvent(response.Device.ID, events.EventItemNone, response.Device)
 			}
 		case device.ListResponse_ADDED:
-			s.cache[response.Device.ID] = response.Device
+			s.Cache[response.Device.ID] = response.Device
 			ch <- events.NewTopoEvent(response.Device.ID, events.EventItemAdded, response.Device)
 		case device.ListResponse_UPDATED:
-			s.cache[response.Device.ID] = response.Device
+			s.Cache[response.Device.ID] = response.Device
 			ch <- events.NewTopoEvent(response.Device.ID, events.EventItemUpdated, response.Device)
 		case device.ListResponse_REMOVED:
 			ch <- events.NewTopoEvent(response.Device.ID, events.EventItemDeleted, response.Device)


### PR DESCRIPTION
Leveraging the double listener mechanism (ChangesChannel and subscribe response from device channel) in NB subscribe.
If the device is there we wait for the reply from it. 
If the device is not replying we do not report any notification for the subscriptions.
If the device for which the subscription and the change arrive is not connected we immediately return.
Fixes #437