### PR TITLE
Device state propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onosproject/onos-control v0.0.0-20190715190020-706a2ee0d37b // indirect
-	github.com/onosproject/onos-topo v0.0.0-20191003071657-8bcd1fd812c5
+	github.com/onosproject/onos-topo v0.0.0-20191007162302-b2f95b144981
 	github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029
 	github.com/openconfig/goyang v0.0.0-20190408185115-e8b0ed2cbb0c
 	github.com/openconfig/ygot v0.5.1-0.20190427030428-68346f97239f

--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,8 @@ github.com/onosproject/onos-topo v0.0.0-20190814235916-567580ff7720 h1:Y59IT1BUJ
 github.com/onosproject/onos-topo v0.0.0-20190814235916-567580ff7720/go.mod h1:OdpECWGQ3Fm96sQjse0E9hatoBiCga4VD8jnxadi5Ik=
 github.com/onosproject/onos-topo v0.0.0-20191003071657-8bcd1fd812c5 h1:lYGzzyQFOvxiUAJ58XvVKEZknSGIV720iFP5fOXom+8=
 github.com/onosproject/onos-topo v0.0.0-20191003071657-8bcd1fd812c5/go.mod h1:ERGGodzAwonAl7LnSQQ7JnYQzV1mcXzvgDtqWGq86NA=
+github.com/onosproject/onos-topo v0.0.0-20191007162302-b2f95b144981 h1:+mYayGgZkHZvKLYLNlyNTJGb1jr//vEMkTvk79VF2hk=
+github.com/onosproject/onos-topo v0.0.0-20191007162302-b2f95b144981/go.mod h1:ERGGodzAwonAl7LnSQQ7JnYQzV1mcXzvgDtqWGq86NA=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -32,6 +32,7 @@ const ( // For event types
 	EventTypeOperationalState
 	EventTypeAchievedSetConfig
 	EventTypeSubscribeNotificationSetConfig
+	EventTypeDeviceConnected
 	EventTypeErrorSetConfig
 	EventTypeSubscribeErrorNotificationSetConfig
 	EventTypeErrorParseConfig

--- a/pkg/events/responseevent.go
+++ b/pkg/events/responseevent.go
@@ -82,6 +82,23 @@ func NewResponseEvent(eventType EventType, subject string, changeID change.ID, r
 	return &dr
 }
 
+// NewDeviceConnected creates a new response event object
+func NewDeviceConnectedEvent(eventType EventType, subject string) DeviceResponse {
+	dr := deviceResponseImpl{
+		eventImpl: eventImpl{
+			subject:   subject,
+			time:      time.Now(),
+			eventType: eventType,
+			object: deviceResponseObj{
+				changeID: "",
+				error:    nil,
+				response: "",
+			},
+		},
+	}
+	return &dr
+}
+
 // NewErrorEvent creates a new error event object
 func NewErrorEvent(eventType EventType, subject string, changeID change.ID, err error) DeviceResponse {
 	dr := deviceResponseImpl{

--- a/pkg/events/responseevent.go
+++ b/pkg/events/responseevent.go
@@ -82,7 +82,7 @@ func NewResponseEvent(eventType EventType, subject string, changeID change.ID, r
 	return &dr
 }
 
-// NewDeviceConnected creates a new response event object
+// NewDeviceConnectedEvent creates a new response event object
 func NewDeviceConnectedEvent(eventType EventType, subject string) DeviceResponse {
 	dr := deviceResponseImpl{
 		eventImpl: eventImpl{

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -254,7 +254,7 @@ func listenOnResponseChannel(respChan chan events.DeviceResponse, deviceStore *t
 			}
 			//TODO unblock config
 		case events.EventTypeErrorDeviceConnect:
-			err := deviceStore.DeviceDisconnected(subject)
+			err := deviceStore.DeviceDisconnected(subject, event.Error())
 			if err != nil {
 				log.Error("Can't notify disconnection", err)
 			}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -223,9 +223,7 @@ func (m *Manager) Run() {
 	go m.Dispatcher.Listen(m.ChangesChannel)
 	go m.Dispatcher.ListenOperationalState(m.OperationalStateChannel)
 	// Listening for errors in the Southbound
-	go listenOnResponseChannel(m.SouthboundErrorChan)
-	//TODO listen on the deviceResponseListener for events of device connected and call method on topochace.go to notify
-	// topo of success connectivity
+	go listenOnResponseChannel(m.SouthboundErrorChan, m.DeviceStore)
 	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
 	go synchronizer.Factory(m.ChangeStore, m.ConfigStore, m.TopoChannel,
 		m.OperationalStateChannel, m.SouthboundErrorChan, m.Dispatcher, m.ModelRegistry, m.OperationalStateCache)
@@ -244,17 +242,31 @@ func GetManager() *Manager {
 	return &mgr
 }
 
-func listenOnResponseChannel(respChan chan events.DeviceResponse) {
+func listenOnResponseChannel(respChan chan events.DeviceResponse, deviceStore *topocache.DeviceStore) {
 	log.Info("Listening for Errors in Manager")
-	for err := range respChan {
-		//TODO hande connection errors by calling topo method to report connection faliure
-		if strings.Contains(err.Error().Error(), "desc =") {
-			log.Errorf("Error reported to channel %s",
-				strings.Split(err.Error().Error(), " desc = ")[1])
-		} else {
-			log.Error("Response reported to channel ", err.Error().Error())
+	for event := range respChan {
+		subject := device.ID(event.Subject())
+		switch event.EventType() {
+		case events.EventTypeDeviceConnected:
+			err := deviceStore.DeviceConnected(subject)
+			if err != nil {
+				log.Error("Can't notify connection", err)
+			}
+			//TODO unblock config
+		case events.EventTypeErrorDeviceConnect:
+			err := deviceStore.DeviceDisconnected(subject)
+			if err != nil {
+				log.Error("Can't notify disconnection", err)
+			}
+			//TODO unblock config
+		default:
+			if strings.Contains(event.Error().Error(), "desc =") {
+				log.Errorf("Error reported to channel %s",
+					strings.Split(event.Error().Error(), " desc = ")[1])
+			} else {
+				log.Error("Response reported to channel ", event.Error().Error())
+			}
 		}
-		//TODO handle device connection errors accordingly
 	}
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -224,6 +224,8 @@ func (m *Manager) Run() {
 	go m.Dispatcher.ListenOperationalState(m.OperationalStateChannel)
 	// Listening for errors in the Southbound
 	go listenOnResponseChannel(m.SouthboundErrorChan)
+	//TODO listen on the deviceResponseListener for events of device connected and call method on topochace.go to notify
+	// topo of success connectivity
 	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
 	go synchronizer.Factory(m.ChangeStore, m.ConfigStore, m.TopoChannel,
 		m.OperationalStateChannel, m.SouthboundErrorChan, m.Dispatcher, m.ModelRegistry, m.OperationalStateCache)
@@ -245,6 +247,7 @@ func GetManager() *Manager {
 func listenOnResponseChannel(respChan chan events.DeviceResponse) {
 	log.Info("Listening for Errors in Manager")
 	for err := range respChan {
+		//TODO hande connection errors by calling topo method to report connection faliure
 		if strings.Contains(err.Error().Error(), "desc =") {
 			log.Errorf("Error reported to channel %s",
 				strings.Split(err.Error().Error(), " desc = ")[1])

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -79,6 +79,11 @@ func (m *Manager) SetNetworkConfig(deviceName string, version string,
 	deviceType string, updates change.TypedValueMap,
 	deletes []string, description string) (change.ID, *store.ConfigName, error) {
 
+	//TODO check with topo that the device is available and connected
+	// if available and conencted send down
+	// if available and connecting blok
+	// if not available send down
+
 	deviceConfig, configName, err := m.getStoredConfig(deviceName, version, deviceType, false)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/southbound/topocache/topocache.go
+++ b/pkg/southbound/topocache/topocache.go
@@ -147,14 +147,17 @@ func (s *DeviceStore) DeviceConnected(id device.ID) error {
 
 func (s *DeviceStore) updateDevice(id device.ID, state string) error {
 	connectedDevice := s.Cache[id]
-	var attributes map[string] string
-	if connectedDevice.Attributes == nil {
-		attributes = make(map[string] string)
+	var states []*device.ProtocolState
+	if connectedDevice.Protocols == nil {
+		states = make([]*device.ProtocolState, 0)
 	} else {
-		attributes = connectedDevice.Attributes
+		states = connectedDevice.Protocols
 	}
-	attributes[STATE] = state
-	connectedDevice.Attributes = attributes
+	states = append(states, &device.ProtocolState{
+		Protocol:device.Protocol_GNMI,
+		State:device.State_CONNECTED,
+	})
+	connectedDevice.Protocols = states
 	updateReq := device.UpdateRequest{
 		Device: connectedDevice,
 	}

--- a/pkg/southbound/topocache/topocache.go
+++ b/pkg/southbound/topocache/topocache.go
@@ -125,3 +125,5 @@ func (s *DeviceStore) watchEvents(ch chan<- events.TopoEvent) error {
 func getTopoConn(opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	return grpc.Dial(topoAddress, opts...)
 }
+
+//TODO use device updated method of onos-topo-service

--- a/pkg/southbound/topocache/topocache.go
+++ b/pkg/southbound/topocache/topocache.go
@@ -126,4 +126,19 @@ func getTopoConn(opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	return grpc.Dial(topoAddress, opts...)
 }
 
-//TODO use device updated method of onos-topo-service
+// DeviceConnected signal the local cache and the corresponding topology service that the device connected.
+func (s *DeviceStore) DeviceConnected(id device.ID) error {
+	//TODO update local cache
+	//TODO use device updated method of onos-topo-service
+	log.Infof("Device %s connected", id)
+	return nil
+}
+
+// DeviceDisconnected signal the local cache and the corresponding topology service that the device disconnected.
+func (s *DeviceStore) DeviceDisconnected(id device.ID) error {
+	//TODO update local cache
+	//TODO use device updated method of onos-topo-service
+	log.Infof("Device %s not connected or disconnected", id)
+	return nil
+}
+

--- a/pkg/southbound/topocache/topocache.go
+++ b/pkg/southbound/topocache/topocache.go
@@ -24,6 +24,7 @@ package topocache
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/cenkalti/backoff"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-topo/pkg/northbound/device"
@@ -145,19 +146,46 @@ func (s *DeviceStore) DeviceConnected(id device.ID) error {
 func (s *DeviceStore) updateDevice(id device.ID, state device.State) error {
 	connectedDevice := s.Cache[id]
 	var states []*device.ProtocolState
-	if connectedDevice.Protocols == nil {
-		states = make([]*device.ProtocolState, 0)
-	} else {
-		states = connectedDevice.Protocols
-	}
-	states = append(states, &device.ProtocolState{
+	log.Info("state", state)
+	log.Info("previous protocols ", connectedDevice.Protocols)
+	//if connectedDevice.Protocols == nil {
+	//	log.Info("nil value.", connectedDevice.Protocols)
+	//	states = make([]*device.ProtocolState, 0)
+	//	log.Info("nil value. initialized state", states)
+	//} else {
+	//	states = connectedDevice.Protocols
+	//	log.Info("not nil value. initialized state", states)
+	//}
+	//if connectedDevice.Protocols == nil {
+	//	log.Info("nil value", connectedDevice.Protocols)
+	//	connectedDevice.Protocols = make([]*device.ProtocolState, 0)
+	//}
+	//connectedDevice.Protocols = append(connectedDevice.Protocols, &device.ProtocolState{
+	//	Protocol: device.Protocol_GNMI,
+	//	State:    state,
+	//})
+	//log.Info("current protocols ", connectedDevice.Protocols)
+	protocol := device.ProtocolState{
 		Protocol: device.Protocol_GNMI,
 		State:    state,
-	})
+	}
+	log.Info("protocol ", protocol)
+	log.Infof("pointer to protocol with format %v", &protocol)
+	log.Info("pointer to protocol ", &protocol)
+	log.Info("pointer nil check ", &protocol != nil)
+	log.Infof("pointer +v %+v", &protocol)
+	println(fmt.Sprintf("%v", &protocol))
+	protocolPointer := &protocol
+	log.Info("prtocolPointer", protocolPointer)
+	log.Info("prtocolPointer nil check ", protocolPointer != nil)
+	println(fmt.Sprintf("%v", protocolPointer))
+	states = append(states, protocolPointer)
+	log.Info("states", states)
 	connectedDevice.Protocols = states
 	updateReq := device.UpdateRequest{
 		Device: connectedDevice,
 	}
+	log.Info("Updated req", updateReq)
 	response, err := s.requestClient.Update(context.Background(), &updateReq)
 	if err != nil {
 		log.Errorf("Device %s is not updated locally %s", id, err.Error())


### PR DESCRIPTION
Propagates device state from config to topo, introducing notion of state.
Needs probably porting to protobuf with enum for state. 

Partially fixes #700 