### PR TITLE
Add device mastership store and tests

### DIFF
--- a/pkg/store/mastership/election.go
+++ b/pkg/store/mastership/election.go
@@ -1,0 +1,179 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mastership
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/atomix/atomix-go-client/pkg/client"
+	"github.com/atomix/atomix-go-client/pkg/client/election"
+	"github.com/atomix/atomix-go-client/pkg/client/primitive"
+	"github.com/atomix/atomix-go-client/pkg/client/session"
+	"github.com/onosproject/onos-config/pkg/store/cluster"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	"google.golang.org/grpc"
+	"io"
+	"sync"
+	"time"
+)
+
+// newAtomixElection returns a new persistent device mastership election
+func newAtomixElection(deviceID device.ID, group *client.PartitionGroup) (deviceMastershipElection, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	election, err := group.GetElection(ctx, fmt.Sprintf("mastership-%s", deviceID), session.WithID(string(cluster.GetNodeID())), session.WithTimeout(15*time.Second))
+	cancel()
+	if err != nil {
+		return nil, err
+	}
+	return newDeviceMastershipElection(deviceID, election)
+}
+
+// newLocalElection returns a new local device mastership election
+func newLocalElection(deviceID device.ID, nodeID cluster.NodeID, conn *grpc.ClientConn) (deviceMastershipElection, error) {
+	name := primitive.Name{
+		Namespace: "local",
+		Name:      fmt.Sprintf("mastership-%s", deviceID),
+	}
+	election, err := election.New(context.Background(), name, []*grpc.ClientConn{conn}, session.WithID(string(nodeID)), session.WithTimeout(15*time.Second))
+	if err != nil {
+		return nil, err
+	}
+	return newDeviceMastershipElection(deviceID, election)
+}
+
+// newDeviceMastershipElection creates and enters a new device mastership election
+func newDeviceMastershipElection(deviceID device.ID, election election.Election) (deviceMastershipElection, error) {
+	deviceElection := &atomixDeviceMastershipElection{
+		deviceID: deviceID,
+		election: election,
+		watchers: make([]chan<- Mastership, 0, 1),
+	}
+	if err := deviceElection.enter(); err != nil {
+		return nil, err
+	}
+	return deviceElection, nil
+}
+
+// deviceMastershipElection is an election for a single device mastership
+type deviceMastershipElection interface {
+	io.Closer
+
+	// DeviceID returns the device for which this election provides mastership
+	DeviceID() device.ID
+
+	// isMaster returns a bool indicating whether the local node is the master for the device
+	isMaster() (bool, error)
+
+	// watch watches the election for changes
+	watch(ch chan<- Mastership) error
+}
+
+// atomixDeviceMastershipElection is a persistent device mastership election
+type atomixDeviceMastershipElection struct {
+	deviceID   device.ID
+	election   election.Election
+	mastership *Mastership
+	watchers   []chan<- Mastership
+	mu         sync.RWMutex
+}
+
+func (e *atomixDeviceMastershipElection) DeviceID() device.ID {
+	return e.deviceID
+}
+
+// enter enters the election
+func (e *atomixDeviceMastershipElection) enter() error {
+	ch := make(chan *election.Event)
+	if err := e.election.Watch(context.Background(), ch); err != nil {
+		return err
+	}
+
+	// Enter the election to get the current leadership term
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	term, err := e.election.Enter(ctx)
+	cancel()
+	if err != nil {
+		_ = e.election.Close()
+		return err
+	}
+
+	// Set the mastership term
+	e.mu.Lock()
+	e.mastership = &Mastership{
+		Device: e.deviceID,
+		Master: cluster.NodeID(term.Leader),
+		Term:   Term(term.ID),
+	}
+	e.mu.Unlock()
+
+	// Wait for the election event to be received before returning
+	for event := range ch {
+		if event.Term.ID == term.ID {
+			go e.watchElection(ch)
+			return nil
+		}
+	}
+
+	_ = e.election.Close()
+	return errors.New("failed to enter election")
+}
+
+// watchElection watches the election events and updates mastership info
+func (e *atomixDeviceMastershipElection) watchElection(ch <-chan *election.Event) {
+	for event := range ch {
+		var mastership *Mastership
+		e.mu.Lock()
+		if uint64(e.mastership.Term) != event.Term.ID {
+			mastership = &Mastership{
+				Device: e.deviceID,
+				Term:   Term(event.Term.ID),
+				Master: cluster.NodeID(event.Term.Leader),
+			}
+			e.mastership = mastership
+		}
+		e.mu.Unlock()
+
+		if mastership != nil {
+			e.mu.RLock()
+			for _, watcher := range e.watchers {
+				watcher <- *mastership
+			}
+			e.mu.RUnlock()
+		}
+	}
+}
+
+func (e *atomixDeviceMastershipElection) isMaster() (bool, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	if e.mastership == nil || string(e.mastership.Master) != e.election.ID() {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (e *atomixDeviceMastershipElection) watch(ch chan<- Mastership) error {
+	e.mu.Lock()
+	e.watchers = append(e.watchers, ch)
+	e.mu.Unlock()
+	return nil
+}
+
+func (e *atomixDeviceMastershipElection) Close() error {
+	return e.election.Close()
+}
+
+var _ deviceMastershipElection = &atomixDeviceMastershipElection{}

--- a/pkg/store/mastership/election_test.go
+++ b/pkg/store/mastership/election_test.go
@@ -1,0 +1,86 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mastership
+
+import (
+	"github.com/onosproject/onos-config/pkg/store/cluster"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMastershipElection(t *testing.T) {
+	node, conn := startLocalNode()
+
+	store1, err := newLocalElection(device.ID("test"), "a", conn)
+	assert.NoError(t, err)
+
+	store2, err := newLocalElection(device.ID("test"), "b", conn)
+	assert.NoError(t, err)
+
+	store2Ch := make(chan Mastership)
+	err = store2.watch(store2Ch)
+	assert.NoError(t, err)
+
+	store3, err := newLocalElection(device.ID("test"), "c", conn)
+	assert.NoError(t, err)
+
+	store3Ch := make(chan Mastership)
+	err = store3.watch(store3Ch)
+	assert.NoError(t, err)
+
+	master, err := store1.isMaster()
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	master, err = store2.isMaster()
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	master, err = store3.isMaster()
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	err = store1.Close()
+	assert.NoError(t, err)
+
+	mastership := <-store2Ch
+	assert.Equal(t, cluster.NodeID("b"), mastership.Master)
+
+	master, err = store2.isMaster()
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	mastership = <-store3Ch
+	assert.Equal(t, cluster.NodeID("b"), mastership.Master)
+
+	master, err = store3.isMaster()
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	err = store2.Close()
+	assert.NoError(t, err)
+
+	mastership = <-store3Ch
+	assert.Equal(t, cluster.NodeID("c"), mastership.Master)
+
+	master, err = store3.isMaster()
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	_ = store3.Close()
+	_ = conn.Close()
+	_ = node.Stop()
+}

--- a/pkg/store/mastership/store.go
+++ b/pkg/store/mastership/store.go
@@ -1,0 +1,166 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mastership
+
+import (
+	"context"
+	"github.com/atomix/atomix-go-local/pkg/atomix/local"
+	"github.com/atomix/atomix-go-node/pkg/atomix"
+	"github.com/atomix/atomix-go-node/pkg/atomix/registry"
+	"github.com/onosproject/onos-config/pkg/store/cluster"
+	"github.com/onosproject/onos-config/pkg/store/utils"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"io"
+	"net"
+	"sync"
+)
+
+// Term is a monotonically increasing mastership term
+type Term uint64
+
+// Store is the device mastership store
+type Store interface {
+	io.Closer
+
+	// IsMaster returns a boolean indicating whether the local node is the master for the given device
+	IsMaster(id device.ID) (bool, error)
+
+	// Watch watches the store for mastership changes
+	Watch(device.ID, chan<- Mastership) error
+}
+
+// Mastership contains information about a device mastership term
+type Mastership struct {
+	// Device is the identifier of the device to which this mastership related
+	Device device.ID
+
+	// Term is the mastership term
+	Term Term
+
+	// Master is the NodeID of the master for the device
+	Master cluster.NodeID
+}
+
+// NewAtomixStore returns a new persistent Store
+func NewAtomixStore() (Store, error) {
+	client, err := utils.GetAtomixClient()
+	if err != nil {
+		return nil, err
+	}
+
+	group, err := client.GetGroup(context.Background(), utils.GetAtomixRaftGroup())
+	if err != nil {
+		return nil, err
+	}
+
+	return &atomixStore{
+		newElection: func(id device.ID) (deviceMastershipElection, error) {
+			return newAtomixElection(id, group)
+		},
+		elections: make(map[device.ID]deviceMastershipElection),
+	}, nil
+}
+
+// NewLocalStore returns a new local election store
+func NewLocalStore(nodeID cluster.NodeID) (Store, error) {
+	_, conn := startLocalNode()
+	return newLocalStore(nodeID, conn)
+}
+
+// newLocalStore returns a new local device store
+func newLocalStore(nodeID cluster.NodeID, conn *grpc.ClientConn) (Store, error) {
+	return &atomixStore{
+		newElection: func(id device.ID) (deviceMastershipElection, error) {
+			return newLocalElection(id, nodeID, conn)
+		},
+		elections: make(map[device.ID]deviceMastershipElection),
+	}, nil
+}
+
+// startLocalNode starts a single local node
+func startLocalNode() (*atomix.Node, *grpc.ClientConn) {
+	lis := bufconn.Listen(1024 * 1024)
+	node := local.NewNode(lis, registry.Registry)
+	_ = node.Start()
+
+	dialer := func(ctx context.Context, address string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	conn, err := grpc.DialContext(context.Background(), "mastership", grpc.WithContextDialer(dialer), grpc.WithInsecure())
+	if err != nil {
+		panic("Failed to dial network configurations")
+	}
+	return node, conn
+}
+
+// atomixStore is the default implementation of the NetworkConfig store
+type atomixStore struct {
+	newElection func(device.ID) (deviceMastershipElection, error)
+	elections   map[device.ID]deviceMastershipElection
+	mu          sync.RWMutex
+}
+
+// getElection gets the mastership election for the given device
+func (s *atomixStore) getElection(deviceID device.ID) (deviceMastershipElection, error) {
+	s.mu.RLock()
+	election, ok := s.elections[deviceID]
+	s.mu.RUnlock()
+	if !ok {
+		s.mu.Lock()
+		election, ok = s.elections[deviceID]
+		if !ok {
+			e, err := s.newElection(deviceID)
+			if err != nil {
+				s.mu.Unlock()
+				return nil, err
+			}
+			election = e
+			s.elections[deviceID] = election
+		}
+		s.mu.Unlock()
+	}
+	return election, nil
+}
+
+func (s *atomixStore) IsMaster(deviceID device.ID) (bool, error) {
+	election, err := s.getElection(deviceID)
+	if err != nil {
+		return false, err
+	}
+	return election.isMaster()
+}
+
+func (s *atomixStore) Watch(deviceID device.ID, ch chan<- Mastership) error {
+	election, err := s.getElection(deviceID)
+	if err != nil {
+		return err
+	}
+	return election.watch(ch)
+}
+
+func (s *atomixStore) Close() error {
+	var returnErr error
+	for _, election := range s.elections {
+		if err := election.Close(); err != nil && returnErr == nil {
+			returnErr = err
+		}
+	}
+	return returnErr
+}
+
+var _ Store = &atomixStore{}

--- a/pkg/store/mastership/store_test.go
+++ b/pkg/store/mastership/store_test.go
@@ -1,0 +1,140 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mastership
+
+import (
+	"github.com/onosproject/onos-config/pkg/store/cluster"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMastershipStore(t *testing.T) {
+	node, conn := startLocalNode()
+
+	node1 := cluster.NodeID("node1")
+	node2 := cluster.NodeID("node2")
+	node3 := cluster.NodeID("node3")
+
+	device1 := device.ID("device1")
+	device2 := device.ID("device2")
+
+	// Create three stores for three different nodes
+	store1, err := newLocalStore(node1, conn)
+	assert.NoError(t, err)
+
+	store2, err := newLocalStore(node2, conn)
+	assert.NoError(t, err)
+
+	store3, err := newLocalStore(node3, conn)
+	assert.NoError(t, err)
+
+	// Verify that the first node that checks mastership for a device wins the election
+	// and no other node believes itself to be the master
+	master, err := store1.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	master, err = store2.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	master, err = store3.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	// Verify that listening for events for a device enters a node into the device mastership election
+	store2Ch2 := make(chan Mastership)
+	err = store2.Watch(device2, store2Ch2)
+	assert.NoError(t, err)
+
+	// Verify that the watching node is the master
+	master, err = store2.IsMaster(device2)
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	master, err = store1.IsMaster(device2)
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	master, err = store3.IsMaster(device2)
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	// Watch device2 mastership on an additional node and verify that it does not cause a mastership change
+	store3Ch2 := make(chan Mastership)
+	err = store3.Watch(device2, store3Ch2)
+	assert.NoError(t, err)
+
+	master, err = store3.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	// Listen for device1 events on remaining nodes
+	store2Ch1 := make(chan Mastership)
+	err = store2.Watch(device1, store2Ch1)
+	assert.NoError(t, err)
+	store3Ch1 := make(chan Mastership)
+	err = store3.Watch(device1, store3Ch1)
+	assert.NoError(t, err)
+
+	// Close node 1 (the master for device 1) and verify a mastership change occurs on nodes 2 and 3
+	err = store1.Close()
+	assert.NoError(t, err)
+
+	// node2 should now be the master for device1
+	mastership := <-store2Ch1
+	assert.Equal(t, device1, mastership.Device)
+	assert.Equal(t, node2, mastership.Master)
+
+	master, err = store2.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	// node3 should not be the master for device1
+	mastership = <-store3Ch1
+	assert.Equal(t, device1, mastership.Device)
+	assert.Equal(t, node2, mastership.Master)
+
+	master, err = store3.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.False(t, master)
+
+	// Close node2 and verify mastership for both devices changes
+	err = store2.Close()
+	assert.NoError(t, err)
+
+	// node3 should now be the master for device1
+	mastership = <-store3Ch1
+	assert.Equal(t, device1, mastership.Device)
+	assert.Equal(t, node3, mastership.Master)
+
+	master, err = store3.IsMaster(device1)
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	// node3 should also be the master for device2
+	mastership = <-store3Ch2
+	assert.Equal(t, device2, mastership.Device)
+	assert.Equal(t, node3, mastership.Master)
+
+	master, err = store3.IsMaster(device2)
+	assert.NoError(t, err)
+	assert.True(t, master)
+
+	_ = store3.Close()
+	_ = conn.Close()
+	_ = node.Stop()
+}


### PR DESCRIPTION
This PR adds the device mastership store. The mastership store creates an independent Atomix `Election` for each device. Mastership is cached locally using watches to receive device events on streams from the Atomix cluster. Mastership lookups are always local reads and so won't block control loops.

Note that this implementation does not account for balancing of mastership. That may need to be addressed at some point in the future. This implementation assigns mastership priority on a first-come-first-serve basis.