### PR TITLE
Extension for Disconnected devices

### DIFF
--- a/docs/gnmi_extensions.md
+++ b/docs/gnmi_extensions.md
@@ -92,3 +92,19 @@ required - the device name, the device type and the version (see diagram above).
 Extension 102 is used to set the `device type`. If a Configuration already exists
 for this device name and version and its device type is different to what's
 given in extension 101, then an error is returned.
+
+## Use of Extension 103 (list of devices disconnected) in GetResponse, SetResponse, SubscribeResponse
+In onos-config the gNMI extension number 103 has been reserved for the
+`list of devices disconnected`. The changes and device configuration is still valid and held 
+by onos-config until the device arrives in the network. 
+
+### GetResponse and SetResponse
+In the GetResponse and GetRequest the `103` extension has an attached message containing a comma separated
+list of devices, e.g `device1,device2,device3` signaling which devices in the request are not
+yet connected to onos-config. 
+
+### SubscribeResponse
+In the SubscribeResponse the `103` extension has an attached message containing a single device, 
+e.g `device1` signaling that the device in the request is not yet connected to onos-config but 
+a configuration object has been changed. in Subscribe there is one device per response since it's
+a 1:1 relationship path to update, where the path include one device. 

--- a/pkg/northbound/gnmi/extensions.go
+++ b/pkg/northbound/gnmi/extensions.go
@@ -24,4 +24,9 @@ const (
 	// GnmiExtensionDeviceType is used in Set only when creating a device the first time
 	// It can be used as a discriminator on Get when wildcard target is given
 	GnmiExtensionDeviceType = 102
+
+	// GnmiExtensionDevicesNotConnected is returned by onos-config in the Set response when the configuration
+	// was requested for one or more device which is currently not connected.
+	// Not Connected devices are included in the message.
+	GnmiExtensionDevicesNotConnected = 103
 )

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -76,14 +76,17 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 
 		notifications = append(notifications, notification)
 	}
-	disconnectedDevices := make([]string, 0)
-	for k := range disconnectedDevicesMap {
-		disconnectedDevices = append(disconnectedDevices, string(k))
-	}
-	disconnectedDeviceString := strings.Join(disconnectedDevices, ", ")
+
 	response := gnmi.GetResponse{
 		Notification: notifications,
-		Extension: []*gnmi_ext.Extension{
+	}
+	if len(disconnectedDevicesMap) != 0 {
+		disconnectedDevices := make([]string, 0)
+		for k := range disconnectedDevicesMap {
+			disconnectedDevices = append(disconnectedDevices, string(k))
+		}
+		disconnectedDeviceString := strings.Join(disconnectedDevices, ", ")
+		response.Extension = []*gnmi_ext.Extension{
 			{
 				Ext: &gnmi_ext.Extension_RegisteredExt{
 					RegisteredExt: &gnmi_ext.RegisteredExtension{
@@ -92,7 +95,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 					},
 				},
 			},
-		},
+		}
 	}
 	return &response, nil
 }

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -85,7 +85,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		for k := range disconnectedDevicesMap {
 			disconnectedDevices = append(disconnectedDevices, string(k))
 		}
-		disconnectedDeviceString := strings.Join(disconnectedDevices, ", ")
+		disconnectedDeviceString := strings.Join(disconnectedDevices, ",")
 		response.Extension = []*gnmi_ext.Extension{
 			{
 				Ext: &gnmi_ext.Extension_RegisteredExt{

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -16,6 +16,7 @@ package gnmi
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/onosproject/onos-config/pkg/utils"
@@ -158,6 +159,9 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 	assert.Equal(t, utils.StrPath(result.Notification[1].Update[0].Path),
 		"/leaf2b")
 	assert.Equal(t, result.Notification[1].Update[0].GetVal().GetFloatVal(), float32(1.14159))
+
+	assert.Equal(t, result.Extension[0].GetRegisteredExt().Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
+	assert.Equal(t, string(result.Extension[0].GetRegisteredExt().Msg), "Device1")
 }
 
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/manager"
+	"github.com/onosproject/onos-config/pkg/southbound/topocache"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"os"
 	"sync"
@@ -46,6 +48,10 @@ func setUp() (*Server, *manager.Manager) {
 		log.Error("Expected manager to be loaded ", err)
 		os.Exit(-1)
 	}
+	deviceStore := &topocache.DeviceStore{
+		Cache: make(map[device.ID]*device.Device),
+	}
+	mgr.DeviceStore = deviceStore
 
 	log.Infof("Dispatcher pointer %p", &mgr.Dispatcher)
 	go listenToTopoLoading(mgr.TopoChannel)

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -174,7 +174,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	if len(disconnectedDevices) != 0 {
-		disconnectedDeviceString := strings.Join(disconnectedDevices, ", ")
+		disconnectedDeviceString := strings.Join(disconnectedDevices, ",")
 		disconnectedExt := &gnmi_ext.Extension{
 			Ext: &gnmi_ext.Extension_RegisteredExt{
 				RegisteredExt: &gnmi_ext.RegisteredExtension{

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -283,7 +283,7 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 
 	extensionDeviceState := setResponse.Extension[1].GetRegisteredExt()
 	assert.Equal(t, extensionDeviceState.Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
-	assert.Equal(t, string(extensionDeviceState.Msg), "localhost-1, localhost-2")
+	assert.Equal(t, string(extensionDeviceState.Msg), "localhost-1,localhost-2")
 
 	// It's a map, so the order of element's is not guaranteed
 	for _, result := range setResponse.Response {

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -164,12 +164,16 @@ func Test_doSingleSetList(t *testing.T) {
 	assert.Equal(t, path.Elem[1].Name, "list2a")
 	assert.Equal(t, path.Elem[2].Name, "tx-power")
 
-	// Check that an the network change ID is given in extension 10
-	assert.Equal(t, len(setResponse.Extension), 1)
+	// Check that an the network change ID is given in extension 100 and that the device is currently disconnected
+	assert.Equal(t, len(setResponse.Extension), 2)
 
 	extension := setResponse.Extension[0].GetRegisteredExt()
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(GnmiExtensionNetwkChangeID))
 	assert.Equal(t, string(extension.Msg), "TestChange")
+
+	extensionDeviceState := setResponse.Extension[1].GetRegisteredExt()
+	assert.Equal(t, extensionDeviceState.Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
+	assert.Equal(t, string(extensionDeviceState.Msg), "Device1")
 
 	//Now check the store that the change was made correctly
 	assert.Equal(t, len(manager.GetManager().NetworkStore.Store), 2)
@@ -680,12 +684,16 @@ func Test_doSingleDelete(t *testing.T) {
 	assert.Equal(t, path.Elem[1].Name, "cont2a")
 	assert.Equal(t, path.Elem[2].Name, "leaf2a")
 
-	// Check that an the network change ID is given in extension 10
-	assert.Equal(t, len(setResponse.Extension), 1)
+	// Check that an the network change ID is given in extension 100 and that the device is currently disconnected
+	assert.Equal(t, len(setResponse.Extension), 2)
 
 	extension := setResponse.Extension[0].GetRegisteredExt()
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(GnmiExtensionNetwkChangeID))
 	assert.Equal(t, string(extension.Msg), "TestChange")
+
+	extensionDeviceState := setResponse.Extension[1].GetRegisteredExt()
+	assert.Equal(t, extensionDeviceState.Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
+	assert.Equal(t, string(extensionDeviceState.Msg), "Device1")
 }
 
 // Test_doUpdateDeleteSet shows how a request with a delete and an update can be applied on a target
@@ -756,12 +764,16 @@ func Test_doUpdateDeleteSet(t *testing.T) {
 	assert.Equal(t, pathDelete.Elem[1].Name, "cont2a")
 	assert.Equal(t, pathDelete.Elem[2].Name, "leaf2c")
 
-	// Check that an the network change ID is given in extension 10
-	assert.Equal(t, len(setResponse.Extension), 1)
+	// Check that an the network change ID is given in extension 100 and that the device is currently disconnected
+	assert.Equal(t, len(setResponse.Extension), 2)
 
 	extension := setResponse.Extension[0].GetRegisteredExt()
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(GnmiExtensionNetwkChangeID))
 	assert.Equal(t, string(extension.Msg), "TestChange")
+
+	extensionDeviceState := setResponse.Extension[1].GetRegisteredExt()
+	assert.Equal(t, extensionDeviceState.Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
+	assert.Equal(t, string(extensionDeviceState.Msg), "Device1")
 
 }
 

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -80,12 +80,16 @@ func Test_doSingleSet(t *testing.T) {
 	assert.Equal(t, path.Elem[1].Name, "cont2a")
 	assert.Equal(t, path.Elem[2].Name, "leaf2a")
 
-	// Check that an the network change ID is given in extension 10
-	assert.Equal(t, len(setResponse.Extension), 1)
+	// Check that an the network change ID is given in extension 100 and that devices show up as disconnected
+	assert.Equal(t, len(setResponse.Extension), 2)
 
-	extension := setResponse.Extension[0].GetRegisteredExt()
-	assert.Equal(t, extension.Id.String(), strconv.Itoa(GnmiExtensionNetwkChangeID))
-	assert.Equal(t, string(extension.Msg), "TestChange")
+	extensionChgID := setResponse.Extension[0].GetRegisteredExt()
+	assert.Equal(t, extensionChgID.Id.String(), strconv.Itoa(GnmiExtensionNetwkChangeID))
+	assert.Equal(t, string(extensionChgID.Msg), "TestChange")
+
+	extensionDeviceState := setResponse.Extension[1].GetRegisteredExt()
+	assert.Equal(t, extensionDeviceState.Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
+	assert.Equal(t, string(extensionDeviceState.Msg), "Device1")
 
 	//Now check the store that the change was made correctly
 	assert.Equal(t, len(manager.GetManager().NetworkStore.Store), 2)
@@ -272,6 +276,10 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 	assert.Equal(t, len(setResponse.Response), 2)
 
 	assert.Assert(t, setResponse.Message == nil, "Unexpected gnmi error message")
+
+	extensionDeviceState := setResponse.Extension[1].GetRegisteredExt()
+	assert.Equal(t, extensionDeviceState.Id.String(), strconv.Itoa(GnmiExtensionDevicesNotConnected))
+	assert.Equal(t, string(extensionDeviceState.Msg), "localhost-1, localhost-2")
 
 	// It's a map, so the order of element's is not guaranteed
 	for _, result := range setResponse.Response {


### PR DESCRIPTION
Provides capability for enos-config to report receiving request for no-connected devices.
In get and set the response had the disconnected device extension set.
For subscribe if the device is not connected and un update come the Subscribe response included the extension for device disconnected.

The devices for get and set are contained in the message as a comma separate list. 

Fixes #518 