### PR TITLE
Refactor change stores to use IndexedMap primitives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,11 @@ require (
 	github.com/atomix/atomix-go-client v0.0.0-20191015014733-9a44b435e975
 	github.com/atomix/atomix-go-local v0.0.0-20191015014655-c79f6afd1662
 	github.com/atomix/atomix-go-node v0.0.0-20191015014638-64dd6c85416c
-	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/onosproject/onos-topo v0.0.0-20191007162302-b2f95b144981
 	github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029
 	github.com/openconfig/goyang v0.0.0-20190408185115-e8b0ed2cbb0c

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/onosproject/onos-config
 go 1.12
 
 require (
-	github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5
-	github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2
-	github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25
+	github.com/atomix/atomix-go-client v0.0.0-20191015014733-9a44b435e975
+	github.com/atomix/atomix-go-local v0.0.0-20191015014655-c79f6afd1662
+	github.com/atomix/atomix-go-node v0.0.0-20191015014638-64dd6c85416c
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/onosproject/onos-config
 go 1.12
 
 require (
-	github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310
-	github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308
-	github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1
+	github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5
+	github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2
+	github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d

--- a/go.sum
+++ b/go.sum
@@ -22,12 +22,9 @@ github.com/atomix/atomix-go-client v0.0.0-20190827234201-188602d4e780/go.mod h1:
 github.com/atomix/atomix-go-client v0.0.0-20191002230120-837d618e27c5/go.mod h1:MoPkrAL33saKe2GbTi+NJgLzW7ejCwrrLDrYIwGYNcE=
 github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0 h1:6y8Pwwd2Rk34E6wuXBf1+Twzs3rkY91Alu2Vg6w2boo=
 github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0/go.mod h1:a/bqs5eosD+gOEGOWNScuf132W/WfCzshGe+afOoCaw=
-github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310 h1:rC8EI8qd8ab8vXtJhx8WxwMdYfRf7KhrhwnAEemwBQQ=
-github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310/go.mod h1:OJHBatYnC3NkjfQl59ecAM+3UjJRN1KmjmBd5E6O4bg=
 github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd h1:Sc9WyuRLcGW40pqLobkDihQ8wilKdkeODI+vifQELuE=
 github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
-github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5 h1:SxwyAzPeDq74sIBWF6IdSCgd0HSM4JQoOP4PLuF3Qag=
-github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
+github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
 github.com/atomix/atomix-go-client v0.0.0-20191015014733-9a44b435e975 h1:yWLOQvkUymC1C4jiQdyR2X60fST98K4TNsXOt0KaxH0=
 github.com/atomix/atomix-go-client v0.0.0-20191015014733-9a44b435e975/go.mod h1:2lFeNblTWlDXGEg/CmtBpTqFXtTyhQQXrkYRRHLWD+M=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
@@ -40,8 +37,6 @@ github.com/atomix/atomix-go-local v0.0.0-20191005004851-a9403b577637 h1:QKjLoFkg
 github.com/atomix/atomix-go-local v0.0.0-20191005004851-a9403b577637/go.mod h1:syI/GoUBKhGASfFqx9sCqoSLCopSC4mEpzxCI7sLjDU=
 github.com/atomix/atomix-go-local v0.0.0-20191005233404-a691d226511f h1:yaILV01XYXzKuFUZsw5qE6g0YiqT5WldKw40kEMv7eQ=
 github.com/atomix/atomix-go-local v0.0.0-20191005233404-a691d226511f/go.mod h1:6uWLpSvA1yC0uJvG46qQ93jhGsYxjUJA+c2Mw6rts4c=
-github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308 h1:QWpyYbgb7u0e3OthZqtsZOi/OVoFfqalQ8eB6TW/Pf0=
-github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308/go.mod h1:D85CC0duo5gTqw9Hv+0VsixHvoViqSQ8Y2Xz6Uc+S7Y=
 github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2 h1:Rp6ozmJbFAntOy7EcTBnW5TxzPtnWjk1qhaxT5r4vVw=
 github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2/go.mod h1:ujkEG47qSxq/VPEs/iz9SXA9zhuHrzkADfta8Px7l6s=
 github.com/atomix/atomix-go-local v0.0.0-20191015014655-c79f6afd1662 h1:/EvkN8EZ4r7BJjRrO2zQOKesd4ZO96g+b4Ax19QsVWU=
@@ -56,8 +51,6 @@ github.com/atomix/atomix-go-node v0.0.0-20191002230317-dabfbb700511/go.mod h1:qk
 github.com/atomix/atomix-go-node v0.0.0-20191005004840-a11d88ec22cd/go.mod h1:m3BU2Yn1nJ/inhJS9I7Epqra4RfjIR2nkTheX8UGcs0=
 github.com/atomix/atomix-go-node v0.0.0-20191005232742-ebda59622853 h1:gKRVpzS3fKmQTRXFM21Y9cl+Jzz4oRv0ZJ5VLp3n2ps=
 github.com/atomix/atomix-go-node v0.0.0-20191005232742-ebda59622853/go.mod h1:eQpS42TVM24rJW+9lJRl1EJIi3YGPjTv1xsNYxuMrf0=
-github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1 h1:MVqKyW2HiPGp4rg+g/7FqYx1PAv8MAqkig6e+Mgch+4=
-github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1/go.mod h1:eQpS42TVM24rJW+9lJRl1EJIi3YGPjTv1xsNYxuMrf0=
 github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25 h1:YN2hZn/FkaIpx1QcD0CNG5foSV6x0JdfMIbWaSNqIMg=
 github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25/go.mod h1:Lt3xjBCH/uWpcoz5n/7j8oquhUJtzmF6qh0dUmFu4Ro=
 github.com/atomix/atomix-go-node v0.0.0-20191015014638-64dd6c85416c h1:ETGyHjdj2dQQOSN5BrkTtK0TO9NhES2cU5Uy5fjMNAc=

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,18 @@ github.com/atomix/atomix-api v0.0.0-20191002225141-1ee9c98c7dfd h1:D1Gsxu6L0UyPK
 github.com/atomix/atomix-api v0.0.0-20191002225141-1ee9c98c7dfd/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
 github.com/atomix/atomix-api v0.0.0-20191005223910-aa620357faa0 h1:XHJB3g6Xkxj0GAyKNC5xOfqrJeGqFLFfVGqRaCeIxFM=
 github.com/atomix/atomix-api v0.0.0-20191005223910-aa620357faa0/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
+github.com/atomix/atomix-api v0.0.0-20191014233757-4786daa5a314 h1:P5nVDVOjAOF9JDkw+q9MhThb5MO2isfPH/FMH5x/d4Y=
+github.com/atomix/atomix-api v0.0.0-20191014233757-4786daa5a314/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
 github.com/atomix/atomix-go-client v0.0.0-20190827234201-188602d4e780/go.mod h1:/UAIApUE5+Ghzu8oBVcYUoz6nCosrRPa0eUlluBtKz0=
 github.com/atomix/atomix-go-client v0.0.0-20191002230120-837d618e27c5/go.mod h1:MoPkrAL33saKe2GbTi+NJgLzW7ejCwrrLDrYIwGYNcE=
 github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0 h1:6y8Pwwd2Rk34E6wuXBf1+Twzs3rkY91Alu2Vg6w2boo=
 github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0/go.mod h1:a/bqs5eosD+gOEGOWNScuf132W/WfCzshGe+afOoCaw=
 github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310 h1:rC8EI8qd8ab8vXtJhx8WxwMdYfRf7KhrhwnAEemwBQQ=
 github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310/go.mod h1:OJHBatYnC3NkjfQl59ecAM+3UjJRN1KmjmBd5E6O4bg=
+github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd h1:Sc9WyuRLcGW40pqLobkDihQ8wilKdkeODI+vifQELuE=
+github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
+github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5 h1:SxwyAzPeDq74sIBWF6IdSCgd0HSM4JQoOP4PLuF3Qag=
+github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:lt/qUsFF29yT2ofmxOXfFzIz0poN22/Qa5SPdalgTKw=
@@ -34,6 +40,8 @@ github.com/atomix/atomix-go-local v0.0.0-20191005233404-a691d226511f h1:yaILV01X
 github.com/atomix/atomix-go-local v0.0.0-20191005233404-a691d226511f/go.mod h1:6uWLpSvA1yC0uJvG46qQ93jhGsYxjUJA+c2Mw6rts4c=
 github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308 h1:QWpyYbgb7u0e3OthZqtsZOi/OVoFfqalQ8eB6TW/Pf0=
 github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308/go.mod h1:D85CC0duo5gTqw9Hv+0VsixHvoViqSQ8Y2Xz6Uc+S7Y=
+github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2 h1:Rp6ozmJbFAntOy7EcTBnW5TxzPtnWjk1qhaxT5r4vVw=
+github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2/go.mod h1:ujkEG47qSxq/VPEs/iz9SXA9zhuHrzkADfta8Px7l6s=
 github.com/atomix/atomix-go-node v0.0.0-20190827191929-2d3dc9c550d9/go.mod h1:PL1T5R78itch1QC1CN4JmbRL/2XQlg4R95R14822C6Q=
 github.com/atomix/atomix-go-node v0.0.0-20190828183436-fc30340cd8db/go.mod h1:dyh8Bb50qKfMlpqDE6X+dQ1tZ399WKEABa3ntDYImnA=
 github.com/atomix/atomix-go-node v0.0.0-20190830183721-649263a17223/go.mod h1:KJxB/MAgndAbyCOqTV2hatw7lExiZZs7QCOr45IfC9U=
@@ -46,6 +54,8 @@ github.com/atomix/atomix-go-node v0.0.0-20191005232742-ebda59622853 h1:gKRVpzS3f
 github.com/atomix/atomix-go-node v0.0.0-20191005232742-ebda59622853/go.mod h1:eQpS42TVM24rJW+9lJRl1EJIi3YGPjTv1xsNYxuMrf0=
 github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1 h1:MVqKyW2HiPGp4rg+g/7FqYx1PAv8MAqkig6e+Mgch+4=
 github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1/go.mod h1:eQpS42TVM24rJW+9lJRl1EJIi3YGPjTv1xsNYxuMrf0=
+github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25 h1:YN2hZn/FkaIpx1QcD0CNG5foSV6x0JdfMIbWaSNqIMg=
+github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25/go.mod h1:Lt3xjBCH/uWpcoz5n/7j8oquhUJtzmF6qh0dUmFu4Ro=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd h1:Sc9WyuR
 github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
 github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5 h1:SxwyAzPeDq74sIBWF6IdSCgd0HSM4JQoOP4PLuF3Qag=
 github.com/atomix/atomix-go-client v0.0.0-20191015004301-02521808eff5/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
+github.com/atomix/atomix-go-client v0.0.0-20191015014733-9a44b435e975 h1:yWLOQvkUymC1C4jiQdyR2X60fST98K4TNsXOt0KaxH0=
+github.com/atomix/atomix-go-client v0.0.0-20191015014733-9a44b435e975/go.mod h1:2lFeNblTWlDXGEg/CmtBpTqFXtTyhQQXrkYRRHLWD+M=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:lt/qUsFF29yT2ofmxOXfFzIz0poN22/Qa5SPdalgTKw=
@@ -42,6 +44,8 @@ github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308 h1:QWpyYbgb
 github.com/atomix/atomix-go-local v0.0.0-20191008000547-914a96b91308/go.mod h1:D85CC0duo5gTqw9Hv+0VsixHvoViqSQ8Y2Xz6Uc+S7Y=
 github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2 h1:Rp6ozmJbFAntOy7EcTBnW5TxzPtnWjk1qhaxT5r4vVw=
 github.com/atomix/atomix-go-local v0.0.0-20191015003449-684edaca8be2/go.mod h1:ujkEG47qSxq/VPEs/iz9SXA9zhuHrzkADfta8Px7l6s=
+github.com/atomix/atomix-go-local v0.0.0-20191015014655-c79f6afd1662 h1:/EvkN8EZ4r7BJjRrO2zQOKesd4ZO96g+b4Ax19QsVWU=
+github.com/atomix/atomix-go-local v0.0.0-20191015014655-c79f6afd1662/go.mod h1:fuaAr7j5tYivrOw3asENUUT3dTqjBmDZSGki5hWljcU=
 github.com/atomix/atomix-go-node v0.0.0-20190827191929-2d3dc9c550d9/go.mod h1:PL1T5R78itch1QC1CN4JmbRL/2XQlg4R95R14822C6Q=
 github.com/atomix/atomix-go-node v0.0.0-20190828183436-fc30340cd8db/go.mod h1:dyh8Bb50qKfMlpqDE6X+dQ1tZ399WKEABa3ntDYImnA=
 github.com/atomix/atomix-go-node v0.0.0-20190830183721-649263a17223/go.mod h1:KJxB/MAgndAbyCOqTV2hatw7lExiZZs7QCOr45IfC9U=
@@ -56,6 +60,8 @@ github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1 h1:MVqKyW2Hi
 github.com/atomix/atomix-go-node v0.0.0-20191008000533-254ed34bd1d1/go.mod h1:eQpS42TVM24rJW+9lJRl1EJIi3YGPjTv1xsNYxuMrf0=
 github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25 h1:YN2hZn/FkaIpx1QcD0CNG5foSV6x0JdfMIbWaSNqIMg=
 github.com/atomix/atomix-go-node v0.0.0-20191015003435-f70de243fb25/go.mod h1:Lt3xjBCH/uWpcoz5n/7j8oquhUJtzmF6qh0dUmFu4Ro=
+github.com/atomix/atomix-go-node v0.0.0-20191015014638-64dd6c85416c h1:ETGyHjdj2dQQOSN5BrkTtK0TO9NhES2cU5Uy5fjMNAc=
+github.com/atomix/atomix-go-node v0.0.0-20191015014638-64dd6c85416c/go.mod h1:RYBKVIL64s0IJXL9HtoF3Wgc6KRXzdaa2KqCvPEuwhI=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/controller/change/device/controller_test.go
+++ b/pkg/controller/change/device/controller_test.go
@@ -36,8 +36,8 @@ const (
 )
 
 const (
-	change1 = devicechange.ID("device-1:1")
-	change2 = devicechange.ID("device-2:1")
+	change1 = devicechange.ID("device-1:device-1")
+	change2 = devicechange.ID("device-2:device-2")
 )
 
 func TestReconcilerChangeSuccess(t *testing.T) {
@@ -238,6 +238,7 @@ func newStores(t *testing.T) (devicestore.Store, devicechanges.Store) {
 
 func newChange(device device.ID) *devicechange.DeviceChange {
 	return &devicechange.DeviceChange{
+		NetworkChangeID: types.ID(device),
 		Change: &devicechange.Change{
 			DeviceID: device,
 			Values: []*devicechange.Value{

--- a/pkg/controller/change/device/partitioner_test.go
+++ b/pkg/controller/change/device/partitioner_test.go
@@ -17,7 +17,7 @@ package device
 import (
 	"github.com/onosproject/onos-config/pkg/controller"
 	"github.com/onosproject/onos-config/pkg/types"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
+	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
 	"github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -25,7 +25,7 @@ import (
 
 func TestDevicePartitioner(t *testing.T) {
 	partitioner := &Partitioner{}
-	key, err := partitioner.Partition(types.ID(devicechange.Index(1).GetChangeID(device.ID("device-1"))))
+	key, err := partitioner.Partition(types.ID(networkchange.ID("change-1").GetDeviceChangeID(device.ID("device-1"))))
 	assert.NoError(t, err)
 	assert.Equal(t, controller.PartitionKey("device-1"), key)
 }

--- a/pkg/controller/change/network/controller_test.go
+++ b/pkg/controller/change/network/controller_test.go
@@ -37,7 +37,7 @@ const (
 )
 
 const (
-	network1 = networkchange.ID("network:1")
+	change1 = networkchange.ID("change-1")
 )
 
 // TestReconcilerChangeRollback tests applying and then rolling back a change
@@ -52,7 +52,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	}
 
 	// Create a network change
-	networkChange := newChange(device1, device2)
+	networkChange := newChange(change1, device1, device2)
 	err := networkChanges.Create(networkChange)
 	assert.NoError(t, err)
 
@@ -77,7 +77,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// The reconciler should have changed its state to RUNNING
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
@@ -118,7 +118,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify the network change was not completed
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
@@ -134,7 +134,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify the network change is complete
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_COMPLETE, networkChange.Status.State)
@@ -151,7 +151,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that the rollback is running
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, networkChange.Status.Phase)
 	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
@@ -172,7 +172,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that the rollback is running
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, networkChange.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
@@ -205,7 +205,7 @@ func TestReconcilerError(t *testing.T) {
 	}
 
 	// Create a network change
-	networkChange := newChange(device1, device2)
+	networkChange := newChange(change1, device1, device2)
 	err := networkChanges.Create(networkChange)
 	assert.NoError(t, err)
 
@@ -230,7 +230,7 @@ func TestReconcilerError(t *testing.T) {
 	assert.True(t, ok)
 
 	// The reconciler should have changed its state to RUNNING
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
@@ -271,7 +271,7 @@ func TestReconcilerError(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify the network change was not completed
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
@@ -290,7 +290,7 @@ func TestReconcilerError(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify the network change is still RUNNING
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
@@ -316,7 +316,7 @@ func TestReconcilerError(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that the network change returned to PENDING
-	networkChange, err = networkChanges.Get(network1)
+	networkChange, err = networkChanges.Get(change1)
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
 	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
@@ -344,7 +344,7 @@ func newStores(t *testing.T) (devicestore.Store, networkchanges.Store, devicecha
 	return devices, networkChanges, deviceChanges
 }
 
-func newChange(devices ...device.ID) *networkchange.NetworkChange {
+func newChange(id networkchange.ID, devices ...device.ID) *networkchange.NetworkChange {
 	changes := make([]*devicechange.Change, len(devices))
 	for i, device := range devices {
 		changes[i] = &devicechange.Change{
@@ -361,6 +361,7 @@ func newChange(devices ...device.ID) *networkchange.NetworkChange {
 		}
 	}
 	return &networkchange.NetworkChange{
+		ID:      id,
 		Changes: changes,
 	}
 }

--- a/pkg/controller/change/network/controller_test.go
+++ b/pkg/controller/change/network/controller_test.go
@@ -62,11 +62,11 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that device changes were created
-	deviceChange1, err := deviceChanges.Get("device-1:1")
+	deviceChange1, err := deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err := deviceChanges.Get("device-2:1")
+	deviceChange2, err := deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
@@ -83,11 +83,11 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
 
 	// But device change states should remain in PENDING state
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
@@ -98,11 +98,11 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that device change states were changed to RUNNING
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange2.Status.State)
@@ -157,11 +157,11 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
 
 	// Verify that device change phases were changed to ROLLBACK
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
@@ -183,11 +183,11 @@ func TestReconcilerChangeRollback(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that device change states were changed to RUNNING
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange2.Status.State)
@@ -215,11 +215,11 @@ func TestReconcilerError(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that device changes were created
-	deviceChange1, err := deviceChanges.Get("device-1:1")
+	deviceChange1, err := deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err := deviceChanges.Get("device-2:1")
+	deviceChange2, err := deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
@@ -236,11 +236,11 @@ func TestReconcilerError(t *testing.T) {
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
 
 	// But device change states should remain in PENDING state
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
@@ -251,11 +251,11 @@ func TestReconcilerError(t *testing.T) {
 	assert.True(t, ok)
 
 	// Verify that device change states were changed to RUNNING
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange2.Status.State)
@@ -277,7 +277,7 @@ func TestReconcilerError(t *testing.T) {
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
 
 	// Fail the other device
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	deviceChange2.Status.State = change.State_FAILED
 	deviceChange2.Status.Reason = change.Reason_ERROR
@@ -296,11 +296,11 @@ func TestReconcilerError(t *testing.T) {
 	assert.Equal(t, change.State_RUNNING, networkChange.Status.State)
 
 	// Verify the change to device-1 is being rolled back
-	deviceChange1, err = deviceChanges.Get("device-1:1")
+	deviceChange1, err = deviceChanges.Get("change-1:device-1")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
 	assert.Equal(t, change.State_RUNNING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("device-2:1")
+	deviceChange2, err = deviceChanges.Get("change-1:device-2")
 	assert.NoError(t, err)
 	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
 	assert.Equal(t, change.State_FAILED, deviceChange2.Status.State)

--- a/pkg/controller/change/network/watcher_test.go
+++ b/pkg/controller/change/network/watcher_test.go
@@ -44,6 +44,7 @@ func TestNetworkWatcher(t *testing.T) {
 	assert.NoError(t, err)
 
 	change1 := &networkchange.NetworkChange{
+		ID: "change-1",
 		Changes: []*devicechange.Change{
 			{
 
@@ -91,6 +92,7 @@ func TestNetworkWatcher(t *testing.T) {
 	}
 
 	change2 := &networkchange.NetworkChange{
+		ID: "change-2",
 		Changes: []*devicechange.Change{
 			{
 				DeviceID: device.ID("device-1"),

--- a/pkg/store/change/device/store_test.go
+++ b/pkg/store/change/device/store_test.go
@@ -90,22 +90,22 @@ func TestDeviceStore(t *testing.T) {
 	// Create a new change
 	err = store1.Create(change1)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("device-1:1"), change1.ID)
+	assert.Equal(t, devicechange.ID("network-change-1:device-1"), change1.ID)
 	assert.Equal(t, devicechange.Index(1), change1.Index)
 	assert.NotEqual(t, devicechange.Revision(0), change1.Revision)
 
 	// Get the change
-	change1, err = store2.Get(devicechange.ID("device-1:1"))
+	change1, err = store2.Get(devicechange.ID("network-change-1:device-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, change1)
-	assert.Equal(t, devicechange.ID("device-1:1"), change1.ID)
+	assert.Equal(t, devicechange.ID("network-change-1:device-1"), change1.ID)
 	assert.Equal(t, devicechange.Index(1), change1.Index)
 	assert.NotEqual(t, devicechange.Revision(0), change1.Revision)
 
 	// Append another change
 	err = store2.Create(change2)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("device-1:2"), change2.ID)
+	assert.Equal(t, devicechange.ID("network-change-2:device-1"), change2.ID)
 	assert.Equal(t, devicechange.Index(2), change2.Index)
 	assert.NotEqual(t, devicechange.Revision(0), change2.Revision)
 
@@ -125,7 +125,7 @@ func TestDeviceStore(t *testing.T) {
 	// Append another change
 	err = store1.Create(change3)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("device-1:3"), change3.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-1"), change3.ID)
 	assert.Equal(t, devicechange.Index(3), change3.Index)
 	assert.NotEqual(t, devicechange.Revision(0), change3.Revision)
 
@@ -149,19 +149,19 @@ func TestDeviceStore(t *testing.T) {
 	// Append another change
 	err = store1.Create(change4)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("device-2:1"), change4.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-2"), change4.ID)
 	assert.Equal(t, devicechange.Index(1), change4.Index)
 	assert.NotEqual(t, devicechange.Revision(0), change4.Revision)
 
 	// Verify events were received for the changes
 	changeEvent := nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("device-1:1"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-1:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("device-1:2"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("device-1:3"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch2)
-	assert.Equal(t, devicechange.ID("device-2:1"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-2"), changeEvent.ID)
 
 	// Update one of the changes
 	change2.Status.State = change.State_RUNNING
@@ -171,7 +171,7 @@ func TestDeviceStore(t *testing.T) {
 	assert.NotEqual(t, revision, change2.Revision)
 
 	// Read and then update the change
-	change2, err = store2.Get(devicechange.ID("device-1:2"))
+	change2, err = store2.Get(devicechange.ID("network-change-2:device-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, change2)
 	change2.Status.State = change.State_RUNNING
@@ -181,9 +181,9 @@ func TestDeviceStore(t *testing.T) {
 	assert.NotEqual(t, revision, change2.Revision)
 
 	// Verify that concurrent updates fail
-	change31, err := store1.Get(devicechange.ID("device-1:3"))
+	change31, err := store1.Get(devicechange.ID("network-change-3:device-1"))
 	assert.NoError(t, err)
-	change32, err := store2.Get(devicechange.ID("device-1:3"))
+	change32, err := store2.Get(devicechange.ID("network-change-3:device-1"))
 	assert.NoError(t, err)
 
 	change31.Status.State = change.State_RUNNING
@@ -196,11 +196,11 @@ func TestDeviceStore(t *testing.T) {
 
 	// Verify device events were received again
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("device-1:2"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("device-1:2"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("device-1:3"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-1"), changeEvent.ID)
 
 	// List the changes for a device
 	changes := make(chan *devicechange.DeviceChange)
@@ -208,11 +208,11 @@ func TestDeviceStore(t *testing.T) {
 	assert.NoError(t, err)
 
 	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("device-1:1"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-1:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("device-1:2"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("device-1:3"), changeEvent.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-1"), changeEvent.ID)
 
 	select {
 	case _, ok := <-changes:
@@ -224,7 +224,7 @@ func TestDeviceStore(t *testing.T) {
 	// Delete a change
 	err = store1.Delete(change2)
 	assert.NoError(t, err)
-	change2, err = store2.Get("device-1:2")
+	change2, err = store2.Get("network-change-2:device-1")
 	assert.NoError(t, err)
 	assert.Nil(t, change2)
 
@@ -234,9 +234,9 @@ func TestDeviceStore(t *testing.T) {
 	assert.NoError(t, err)
 
 	change := nextDeviceChange(t, watches)
-	assert.Equal(t, devicechange.ID("device-1:1"), change.ID)
+	assert.Equal(t, devicechange.ID("network-change-1:device-1"), change.ID)
 	change = nextDeviceChange(t, watches)
-	assert.Equal(t, devicechange.ID("device-1:3"), change.ID)
+	assert.Equal(t, devicechange.ID("network-change-3:device-1"), change.ID)
 }
 
 func nextDeviceChange(t *testing.T, ch chan *devicechange.DeviceChange) *devicechange.DeviceChange {

--- a/pkg/store/change/device/store_test.go
+++ b/pkg/store/change/device/store_test.go
@@ -40,14 +40,6 @@ func TestDeviceStore(t *testing.T) {
 	device1 := device.ID("device-1")
 	device2 := device.ID("device-2")
 
-	lastIndex, err := store1.LastIndex(device1)
-	assert.NoError(t, err)
-	assert.Equal(t, devicechange.Index(0), lastIndex)
-
-	lastIndex, err = store1.LastIndex(device2)
-	assert.NoError(t, err)
-	assert.Equal(t, devicechange.Index(0), lastIndex)
-
 	ch1 := make(chan *devicechange.DeviceChange)
 	err = store2.Watch(device1, ch1)
 	assert.NoError(t, err)
@@ -217,23 +209,6 @@ func TestDeviceStore(t *testing.T) {
 
 	changeEvent = nextDeviceChange(t, changes)
 	assert.Equal(t, devicechange.ID("device-1:1"), changeEvent.ID)
-	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("device-1:2"), changeEvent.ID)
-	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("device-1:3"), changeEvent.ID)
-
-	select {
-	case _, ok := <-changes:
-		assert.False(t, ok)
-	case <-time.After(5 * time.Second):
-		t.FailNow()
-	}
-
-	// Replay changes from a specific index
-	changes = make(chan *devicechange.DeviceChange)
-	err = store1.Replay(device1, 2, changes)
-	assert.NoError(t, err)
-
 	changeEvent = nextDeviceChange(t, changes)
 	assert.Equal(t, devicechange.ID("device-1:2"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, changes)

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -17,14 +17,12 @@ package network
 import (
 	"context"
 	"errors"
-	"github.com/atomix/atomix-go-client/pkg/client/counter"
-	"github.com/atomix/atomix-go-client/pkg/client/map"
+	"github.com/atomix/atomix-go-client/pkg/client/indexedmap"
 	"github.com/atomix/atomix-go-client/pkg/client/primitive"
 	"github.com/atomix/atomix-go-client/pkg/client/session"
 	"github.com/atomix/atomix-go-local/pkg/atomix/local"
 	"github.com/atomix/atomix-go-node/pkg/atomix"
 	"github.com/atomix/atomix-go-node/pkg/atomix/registry"
-	"github.com/cenkalti/backoff"
 	"github.com/gogo/protobuf/proto"
 	"github.com/onosproject/onos-config/pkg/store/utils"
 	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
@@ -35,8 +33,7 @@ import (
 	"time"
 )
 
-const counterName = "network-change-indexes"
-const configsName = "network-changes"
+const changesName = "network-changes"
 
 const maxRetries = 5
 
@@ -52,20 +49,13 @@ func NewAtomixStore() (Store, error) {
 		return nil, err
 	}
 
-	ids, err := group.GetCounter(context.Background(), counterName, session.WithTimeout(30*time.Second))
-	if err != nil {
-		return nil, err
-	}
-
-	configs, err := group.GetMap(context.Background(), configsName, session.WithTimeout(30*time.Second))
+	changes, err := group.GetIndexedMap(context.Background(), changesName, session.WithTimeout(30*time.Second))
 	if err != nil {
 		return nil, err
 	}
 
 	return &atomixStore{
-		indexes: ids,
-		configs: configs,
-		closer:  configs,
+		changes: changes,
 	}, nil
 }
 
@@ -77,27 +67,17 @@ func NewLocalStore() (Store, error) {
 
 // newLocalStore creates a new local network change store
 func newLocalStore(conn *grpc.ClientConn) (Store, error) {
-	counterName := primitive.Name{
-		Namespace: "local",
-		Name:      counterName,
-	}
-	ids, err := counter.New(context.Background(), counterName, []*grpc.ClientConn{conn})
-	if err != nil {
-		return nil, err
-	}
-
 	configsName := primitive.Name{
 		Namespace: "local",
-		Name:      configsName,
+		Name:      changesName,
 	}
-	configs, err := _map.New(context.Background(), configsName, []*grpc.ClientConn{conn})
+	changes, err := indexedmap.New(context.Background(), configsName, []*grpc.ClientConn{conn})
 	if err != nil {
 		return nil, err
 	}
 
 	return &atomixStore{
-		indexes: ids,
-		configs: configs,
+		changes: changes,
 	}, nil
 }
 
@@ -111,7 +91,7 @@ func startLocalNode() (*atomix.Node, *grpc.ClientConn) {
 		return lis.Dial()
 	}
 
-	conn, err := grpc.DialContext(context.Background(), configsName, grpc.WithContextDialer(dialer), grpc.WithInsecure())
+	conn, err := grpc.DialContext(context.Background(), changesName, grpc.WithContextDialer(dialer), grpc.WithInsecure())
 	if err != nil {
 		panic("Failed to dial network configurations")
 	}
@@ -121,9 +101,6 @@ func startLocalNode() (*atomix.Node, *grpc.ClientConn) {
 // Store stores NetworkConfig changes
 type Store interface {
 	io.Closer
-
-	// LastIndex gets the last index in the store
-	LastIndex() (networkchange.Index, error)
 
 	// Get gets a network configuration
 	Get(id networkchange.ID) (*networkchange.NetworkChange, error)
@@ -149,51 +126,33 @@ type Store interface {
 
 // atomixStore is the default implementation of the NetworkConfig store
 type atomixStore struct {
-	indexes counter.Counter
-	configs _map.Map
-	closer  io.Closer
-}
-
-func (s *atomixStore) LastIndex() (networkchange.Index, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	index, err := s.indexes.Get(ctx)
-	if err != nil {
-		return 0, err
-	}
-	return networkchange.Index(index), nil
-}
-
-func (s *atomixStore) setIndex(index networkchange.Index) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	return s.indexes.Set(ctx, int64(index))
+	changes indexedmap.IndexedMap
 }
 
 func (s *atomixStore) Get(id networkchange.ID) (*networkchange.NetworkChange, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	entry, err := s.configs.Get(ctx, string(id))
+	entry, err := s.changes.Get(ctx, string(id))
 	if err != nil {
 		return nil, err
 	} else if entry == nil {
 		return nil, nil
 	}
-	return decodeConfig(entry)
+	return decodeChange(entry)
 }
 
 func (s *atomixStore) GetByIndex(index networkchange.Index) (*networkchange.NetworkChange, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	entry, err := s.configs.Get(ctx, string(index.GetChangeID()))
+	entry, err := s.changes.GetIndex(ctx, indexedmap.Index(index))
 	if err != nil {
 		return nil, err
 	} else if entry == nil {
 		return nil, nil
 	}
-	return decodeConfig(entry)
+	return decodeChange(entry)
 }
 
 func (s *atomixStore) Create(config *networkchange.NetworkChange) error {
@@ -201,45 +160,23 @@ func (s *atomixStore) Create(config *networkchange.NetworkChange) error {
 		return errors.New("not a new object")
 	}
 
+	bytes, err := proto.Marshal(config)
+	if err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	return backoff.Retry(func() error {
-		lastIndex, err := s.LastIndex()
-		if err != nil {
-			return err
-		}
 
-		index := lastIndex + 1
-		config.Index = index
-		config.ID = index.GetChangeID()
+	entry, err := s.changes.Put(ctx, string(config.ID), bytes, indexedmap.IfNotSet())
+	if err != nil {
+		return err
+	}
 
-		bytes, err := proto.Marshal(config)
-		if err != nil {
-			return err
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-
-		// Attempt to set the change at the next index
-		entry, err := s.configs.Put(ctx, string(config.ID), bytes, _map.IfNotSet())
-
-		// If the write fails because a change has already been stored, increment the last index and retry
-		if err != nil {
-			if change, err := s.configs.Get(ctx, string(config.ID)); err == nil && change != nil {
-				_ = s.setIndex(index)
-			}
-			return err
-		}
-
-		config.Revision = networkchange.Revision(entry.Version)
-		config.Created = entry.Created
-		config.Updated = entry.Updated
-
-		// Store the updated index without failing the change
-		_ = s.setIndex(index)
-		return nil
-	}, backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), maxRetries), ctx))
+	config.Revision = networkchange.Revision(entry.Version)
+	config.Created = entry.Created
+	config.Updated = entry.Updated
+	return nil
 }
 
 func (s *atomixStore) Update(config *networkchange.NetworkChange) error {
@@ -255,7 +192,7 @@ func (s *atomixStore) Update(config *networkchange.NetworkChange) error {
 		return err
 	}
 
-	entry, err := s.configs.Put(ctx, string(config.ID), bytes, _map.IfVersion(int64(config.Revision)))
+	entry, err := s.changes.Put(ctx, string(config.ID), bytes, indexedmap.IfVersion(indexedmap.Version(config.Revision)))
 	if err != nil {
 		return err
 	}
@@ -273,7 +210,7 @@ func (s *atomixStore) Delete(config *networkchange.NetworkChange) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	entry, err := s.configs.Remove(ctx, string(config.ID), _map.IfVersion(int64(config.Revision)))
+	entry, err := s.changes.Remove(ctx, string(config.ID), indexedmap.IfVersion(indexedmap.Version(config.Revision)))
 	if err != nil {
 		return err
 	}
@@ -284,16 +221,16 @@ func (s *atomixStore) Delete(config *networkchange.NetworkChange) error {
 }
 
 func (s *atomixStore) List(ch chan<- *networkchange.NetworkChange) error {
-	lastIndex, err := s.LastIndex()
-	if err != nil {
+	mapCh := make(chan *indexedmap.Entry)
+	if err := s.changes.Entries(context.Background(), mapCh); err != nil {
 		return err
 	}
 
 	go func() {
 		defer close(ch)
-		for i := networkchange.Index(1); i <= lastIndex; i++ {
-			if device, err := s.GetByIndex(i); err == nil && device != nil {
-				ch <- device
+		for entry := range mapCh {
+			if config, err := decodeChange(entry); err == nil {
+				ch <- config
 			}
 		}
 	}()
@@ -301,25 +238,15 @@ func (s *atomixStore) List(ch chan<- *networkchange.NetworkChange) error {
 }
 
 func (s *atomixStore) Watch(ch chan<- *networkchange.NetworkChange) error {
-	lastIndex, err := s.LastIndex()
-	if err != nil {
-		return err
-	}
-
-	mapCh := make(chan *_map.Event)
-	if err := s.configs.Watch(context.Background(), mapCh); err != nil {
+	mapCh := make(chan *indexedmap.Event)
+	if err := s.changes.Watch(context.Background(), mapCh, indexedmap.WithReplay()); err != nil {
 		return err
 	}
 
 	go func() {
 		defer close(ch)
-		for i := networkchange.Index(1); i <= lastIndex; i++ {
-			if device, err := s.GetByIndex(i); err == nil && device != nil {
-				ch <- device
-			}
-		}
 		for event := range mapCh {
-			if config, err := decodeConfig(event.Entry); err == nil {
+			if config, err := decodeChange(event.Entry); err == nil {
 				ch <- config
 			}
 		}
@@ -328,17 +255,18 @@ func (s *atomixStore) Watch(ch chan<- *networkchange.NetworkChange) error {
 }
 
 func (s *atomixStore) Close() error {
-	return s.configs.Close()
+	return s.changes.Close()
 }
 
-func decodeConfig(entry *_map.Entry) (*networkchange.NetworkChange, error) {
-	conf := &networkchange.NetworkChange{}
-	if err := proto.Unmarshal(entry.Value, conf); err != nil {
+func decodeChange(entry *indexedmap.Entry) (*networkchange.NetworkChange, error) {
+	change := &networkchange.NetworkChange{}
+	if err := proto.Unmarshal(entry.Value, change); err != nil {
 		return nil, err
 	}
-	conf.ID = networkchange.ID(entry.Key)
-	conf.Revision = networkchange.Revision(entry.Version)
-	conf.Created = entry.Created
-	conf.Updated = entry.Updated
-	return conf, nil
+	change.ID = networkchange.ID(entry.Key)
+	change.Index = networkchange.Index(entry.Index)
+	change.Revision = networkchange.Revision(entry.Version)
+	change.Created = entry.Created
+	change.Updated = entry.Updated
+	return change, nil
 }

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -154,6 +154,9 @@ func (s *atomixStore) GetByIndex(index networkchange.Index) (*networkchange.Netw
 }
 
 func (s *atomixStore) Create(change *networkchange.NetworkChange) error {
+	if change.ID == "" {
+		return errors.New("no change ID specified")
+	}
 	if change.Revision != 0 {
 		return errors.New("not a new object")
 	}

--- a/pkg/store/change/network/store_test.go
+++ b/pkg/store/change/network/store_test.go
@@ -45,6 +45,7 @@ func TestNetworkChangeStore(t *testing.T) {
 	assert.NoError(t, err)
 
 	change1 := &networkchange.NetworkChange{
+		ID: "change-1",
 		Changes: []*devicechange.Change{
 			{
 
@@ -82,6 +83,7 @@ func TestNetworkChangeStore(t *testing.T) {
 	}
 
 	change2 := &networkchange.NetworkChange{
+		ID: "change-2",
 		Changes: []*devicechange.Change{
 			{
 				DeviceID: device1,
@@ -98,30 +100,30 @@ func TestNetworkChangeStore(t *testing.T) {
 	// Create a new change
 	err = store1.Create(change1)
 	assert.NoError(t, err)
-	assert.Equal(t, networkchange.ID("network:1"), change1.ID)
+	assert.Equal(t, networkchange.ID("change-1"), change1.ID)
 	assert.Equal(t, networkchange.Index(1), change1.Index)
 	assert.NotEqual(t, networkchange.Revision(0), change1.Revision)
 
 	// Get the change
-	change1, err = store2.Get("network:1")
+	change1, err = store2.Get("change-1")
 	assert.NoError(t, err)
 	assert.NotNil(t, change1)
-	assert.Equal(t, networkchange.ID("network:1"), change1.ID)
+	assert.Equal(t, networkchange.ID("change-1"), change1.ID)
 	assert.Equal(t, networkchange.Index(1), change1.Index)
 	assert.NotEqual(t, networkchange.Revision(0), change1.Revision)
 
 	// Create another change
 	err = store2.Create(change2)
 	assert.NoError(t, err)
-	assert.Equal(t, networkchange.ID("network:2"), change2.ID)
+	assert.Equal(t, networkchange.ID("change-2"), change2.ID)
 	assert.Equal(t, networkchange.Index(2), change2.Index)
 	assert.NotEqual(t, networkchange.Revision(0), change2.Revision)
 
 	// Verify events were received for the changes
 	changeEvent := nextChange(t, ch)
-	assert.Equal(t, networkchange.ID("network:1"), changeEvent.ID)
+	assert.Equal(t, networkchange.ID("change-1"), changeEvent.ID)
 	changeEvent = nextChange(t, ch)
-	assert.Equal(t, networkchange.ID("network:2"), changeEvent.ID)
+	assert.Equal(t, networkchange.ID("change-2"), changeEvent.ID)
 
 	// Update one of the changes
 	change2.Status.State = change.State_RUNNING
@@ -131,7 +133,7 @@ func TestNetworkChangeStore(t *testing.T) {
 	assert.NotEqual(t, revision, change2.Revision)
 
 	// Read and then update the change
-	change2, err = store2.Get("network:2")
+	change2, err = store2.Get("change-2")
 	assert.NoError(t, err)
 	assert.NotNil(t, change2)
 	change2.Status.State = change.State_COMPLETE
@@ -141,9 +143,9 @@ func TestNetworkChangeStore(t *testing.T) {
 	assert.NotEqual(t, revision, change2.Revision)
 
 	// Verify that concurrent updates fail
-	change11, err := store1.Get("network:1")
+	change11, err := store1.Get("change-1")
 	assert.NoError(t, err)
-	change12, err := store2.Get("network:1")
+	change12, err := store2.Get("change-1")
 	assert.NoError(t, err)
 
 	change11.Status.State = change.State_COMPLETE
@@ -156,11 +158,11 @@ func TestNetworkChangeStore(t *testing.T) {
 
 	// Verify events were received again
 	changeEvent = nextChange(t, ch)
-	assert.Equal(t, networkchange.ID("network:2"), changeEvent.ID)
+	assert.Equal(t, networkchange.ID("change-2"), changeEvent.ID)
 	changeEvent = nextChange(t, ch)
-	assert.Equal(t, networkchange.ID("network:2"), changeEvent.ID)
+	assert.Equal(t, networkchange.ID("change-2"), changeEvent.ID)
 	changeEvent = nextChange(t, ch)
-	assert.Equal(t, networkchange.ID("network:1"), changeEvent.ID)
+	assert.Equal(t, networkchange.ID("change-1"), changeEvent.ID)
 
 	// List the changes
 	changes := make(chan *networkchange.NetworkChange)
@@ -177,11 +179,12 @@ func TestNetworkChangeStore(t *testing.T) {
 	// Delete a change
 	err = store1.Delete(change2)
 	assert.NoError(t, err)
-	change2, err = store2.Get("network:2")
+	change2, err = store2.Get("change-2")
 	assert.NoError(t, err)
 	assert.Nil(t, change2)
 
 	change := &networkchange.NetworkChange{
+		ID: "change-3",
 		Changes: []*devicechange.Change{
 			{
 				DeviceID: device1,
@@ -202,6 +205,7 @@ func TestNetworkChangeStore(t *testing.T) {
 	assert.NoError(t, err)
 
 	change = &networkchange.NetworkChange{
+		ID: "change-4",
 		Changes: []*devicechange.Change{
 			{
 				DeviceID: device2,

--- a/pkg/types/change/device/types.go
+++ b/pkg/types/change/device/types.go
@@ -15,10 +15,8 @@
 package device
 
 import (
-	"fmt"
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-topo/pkg/northbound/device"
-	"strconv"
 	"strings"
 )
 
@@ -27,24 +25,18 @@ const separator = ":"
 // ID is a device change identifier type
 type ID types.ID
 
-// GetDeviceID returns the Device ID to which the change is targeted
-func (i ID) GetDeviceID() device.ID {
-	return device.ID(string(i)[:strings.Index(string(i), separator)])
+// GetNetworkChangeID returns the NetworkChange ID for the DeviceChange
+func (i ID) GetNetworkChangeID() types.ID {
+	return types.ID(string(i)[:strings.Index(string(i), separator)])
 }
 
-// GetIndex returns the Index
-func (i ID) GetIndex() Index {
-	index, _ := strconv.Atoi(string(i)[strings.LastIndex(string(i), separator)+1:])
-	return Index(index)
+// GetDeviceID returns the Device ID to which the change is targeted
+func (i ID) GetDeviceID() device.ID {
+	return device.ID(string(i)[strings.Index(string(i), separator)+1:])
 }
 
 // Index is the index of a network configuration
 type Index uint64
-
-// GetChangeID returns the device change ID for the index given a device/version
-func (i Index) GetChangeID(deviceID device.ID) ID {
-	return ID(fmt.Sprintf("%s%s%d", deviceID, separator, i))
-}
 
 // Revision is a network configuration revision number
 type Revision types.Revision

--- a/pkg/types/change/network/types.go
+++ b/pkg/types/change/network/types.go
@@ -17,8 +17,8 @@ package network
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/types"
-	"strconv"
-	"strings"
+	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
 )
 
 const separator = ":"
@@ -26,11 +26,9 @@ const separator = ":"
 // ID is a network configuration identifier type
 type ID types.ID
 
-// GetIndex returns the Index
-func (i ID) GetIndex() Index {
-	indexStr := string(i)[strings.LastIndex(string(i), separator)+1:]
-	index, _ := strconv.Atoi(indexStr)
-	return Index(index)
+// GetDeviceChangeID returns a device change ID for the given device ID
+func (i ID) GetDeviceChangeID(deviceID device.ID) devicechange.ID {
+	return devicechange.ID(fmt.Sprintf("%s:%s", i, deviceID))
 }
 
 // Index is the index of a network configuration

--- a/pkg/types/change/network/types.go
+++ b/pkg/types/change/network/types.go
@@ -28,16 +28,11 @@ type ID types.ID
 
 // GetDeviceChangeID returns a device change ID for the given device ID
 func (i ID) GetDeviceChangeID(deviceID device.ID) devicechange.ID {
-	return devicechange.ID(fmt.Sprintf("%s:%s", i, deviceID))
+	return devicechange.ID(fmt.Sprintf("%s%s%s", i, separator, deviceID))
 }
 
 // Index is the index of a network configuration
 type Index uint64
-
-// GetChangeID returns the network change ID for the index
-func (i Index) GetChangeID() ID {
-	return ID(fmt.Sprintf("network%s%d", separator, i))
-}
 
 // Revision is a network configuration revision number
 type Revision types.Revision


### PR DESCRIPTION
This PR modifies the implementation of the `Store`s for `NetworkChange`s and `DeviceChange`s to use a more efficient primitives. #753 

The current implementations use a `Counter` primitive and a `Map` primitive to create ordered maps by generating a monotonically increasing keys from the counter. But because operations on the two primitives are not atomic, this can introduce inconsistencies into the stores. Additionally, the current implementations cannot preserve consistency when replaying changes from the stores.

This PR uses a new `IndexedMap` primitive to guarantee all operations are atomic, the stores contain a sequential history of changes, and changes can be replayed in sequential order and `Watch`ed without duplicating or reordering events.

The `IndexedMap` is something like a doubly linked map that also assigns sequential indexes to keys when inserted. So, the map maintains insertion order, and entries in the map are assigned a static, unique `Index` that is representative of the insertion order. This data structure allows the store to use single atomic operations for all methods while still providing enough metadata to navigate the history of changes.