### PR TITLE
Refactor store mocks so they are usable in multiple packages

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
+	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	types "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
@@ -58,7 +59,8 @@ func TestMain(m *testing.M) {
 }
 
 func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigName]store.Configuration,
-	*MockDeviceStore, *MockNetworkChangesStore, *MockDeviceChangesStore) {
+	*mockstore.MockDeviceStore, *mockstore.MockNetworkChangesStore, *mockstore.
+		MockDeviceChangesStore) {
 
 	var change1 *change.Change
 	var device1config *store.Configuration
@@ -95,9 +97,9 @@ func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigN
 
 	ctrl := gomock.NewController(t)
 
-	mockNetworkChangesStore := NewMockNetworkChangesStore(ctrl)
-	mockDeviceChangesStore := NewMockDeviceChangesStore(ctrl)
-	mockDeviceStore := NewMockDeviceStore(ctrl)
+	mockNetworkChangesStore := mockstore.NewMockNetworkChangesStore(ctrl)
+	mockDeviceChangesStore := mockstore.NewMockDeviceChangesStore(ctrl)
+	mockDeviceStore := mockstore.NewMockDeviceStore(ctrl)
 
 	mgrTest, err = NewManager(
 		&store.ConfigurationStore{
@@ -133,8 +135,8 @@ func Test_LoadManager(t *testing.T) {
 		"../../configs/configStore-sample.json",
 		"../../configs/changeStore-sample.json",
 		"../../configs/networkStore-sample.json",
-		NewMockDeviceChangesStore(gomock.NewController(t)),
-		NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
+		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
 	assert.NilError(t, err, "failed to load manager")
 }
 
@@ -143,8 +145,8 @@ func Test_LoadManagerBadConfigStore(t *testing.T) {
 		"../../configs/configStore-sampleX.json",
 		"../../configs/changeStore-sample.json",
 		"../../configs/networkStore-sample.json",
-		NewMockDeviceChangesStore(gomock.NewController(t)),
-		NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
+		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
 	assert.Assert(t, err != nil, "should have failed to load manager")
 }
 
@@ -153,8 +155,8 @@ func Test_LoadManagerBadChangeStore(t *testing.T) {
 		"../../configs/configStore-sample.json",
 		"../../configs/changeStore-sampleX.json",
 		"../../configs/networkStore-sample.json",
-		NewMockDeviceChangesStore(gomock.NewController(t)),
-		NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
+		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
 	assert.Assert(t, err != nil, "should have failed to load manager")
 }
 
@@ -163,8 +165,8 @@ func Test_LoadManagerBadNetworkStore(t *testing.T) {
 		"../../configs/configStore-sample.json",
 		"../../configs/changeStore-sample.json",
 		"../../configs/networkStore-sampleX.json",
-		NewMockDeviceChangesStore(gomock.NewController(t)),
-		NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
+		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
 	assert.Assert(t, err != nil, "should have failed to load manager")
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -131,42 +131,46 @@ func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigN
 }
 
 func Test_LoadManager(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	_, err := LoadManager(
 		"../../configs/configStore-sample.json",
 		"../../configs/changeStore-sample.json",
 		"../../configs/networkStore-sample.json",
-		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
-		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockNetworkChangesStore(ctrl))
 	assert.NilError(t, err, "failed to load manager")
 }
 
 func Test_LoadManagerBadConfigStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	_, err := LoadManager(
 		"../../configs/configStore-sampleX.json",
 		"../../configs/changeStore-sample.json",
 		"../../configs/networkStore-sample.json",
-		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
-		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockNetworkChangesStore(ctrl))
 	assert.Assert(t, err != nil, "should have failed to load manager")
 }
 
 func Test_LoadManagerBadChangeStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	_, err := LoadManager(
 		"../../configs/configStore-sample.json",
 		"../../configs/changeStore-sampleX.json",
 		"../../configs/networkStore-sample.json",
-		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
-		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockNetworkChangesStore(ctrl))
 	assert.Assert(t, err != nil, "should have failed to load manager")
 }
 
 func Test_LoadManagerBadNetworkStore(t *testing.T) {
+	ctrl := gomock.NewController(t)
 	_, err := LoadManager(
 		"../../configs/configStore-sample.json",
 		"../../configs/changeStore-sample.json",
 		"../../configs/networkStore-sampleX.json",
-		mockstore.NewMockDeviceChangesStore(gomock.NewController(t)),
-		mockstore.NewMockNetworkChangesStore(gomock.NewController(t)))
+		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockNetworkChangesStore(ctrl))
 	assert.Assert(t, err != nil, "should have failed to load manager")
 }
 

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -39,8 +39,9 @@ func TestMain(m *testing.M) {
 func setUp(t *testing.T) (*Server, *manager.Manager, *MockStore) {
 	var server = &Server{}
 
-	mockDeviceChangesStore := mockstore.NewMockDeviceChangesStore(gomock.NewController(t))
-	mockNetworkChangesStore := mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
+	ctrl := gomock.NewController(t)
+	mockDeviceChangesStore := mockstore.NewMockDeviceChangesStore(ctrl)
+	mockNetworkChangesStore := mockstore.NewMockNetworkChangesStore(ctrl)
 
 	mgr, err := manager.LoadManager(
 		"../../../configs/configStore-sample.json",
@@ -53,7 +54,6 @@ func setUp(t *testing.T) (*Server, *manager.Manager, *MockStore) {
 		log.Error("Expected manager to be loaded ", err)
 		os.Exit(-1)
 	}
-	ctrl := gomock.NewController(t)
 	mockDeviceStore := NewMockStore(ctrl)
 	mgr.DeviceStore = mockDeviceStore
 	mgr.DeviceChangesStore = mockDeviceChangesStore

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/manager"
+	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"os"
@@ -38,26 +39,25 @@ func TestMain(m *testing.M) {
 func setUp(t *testing.T) (*Server, *manager.Manager, *MockStore) {
 	var server = &Server{}
 
+	mockDeviceChangesStore := mockstore.NewMockDeviceChangesStore(gomock.NewController(t))
+	mockNetworkChangesStore := mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
+
 	mgr, err := manager.LoadManager(
 		"../../../configs/configStore-sample.json",
 		"../../../configs/changeStore-sample.json",
 		"../../../configs/networkStore-sample.json",
-		nil,
-		nil,
-	)
+		mockDeviceChangesStore,
+		mockNetworkChangesStore)
+
 	if err != nil {
 		log.Error("Expected manager to be loaded ", err)
 		os.Exit(-1)
 	}
 	ctrl := gomock.NewController(t)
-	//TODO create mock here.
-	// mockNetworkChangesStore :=
-	// mockDeviceChangesStore :=
-	//TODO assign here
-	//mgr.NetworkChangesStore := mockNetworkChangesStore
-	//mgr.ChangeStore := mockDeviceChangesStore
 	mockDeviceStore := NewMockStore(ctrl)
 	mgr.DeviceStore = mockDeviceStore
+	mgr.DeviceChangesStore = mockDeviceChangesStore
+	mgr.NetworkChangesStore = mockNetworkChangesStore
 
 	log.Infof("Dispatcher pointer %p", &mgr.Dispatcher)
 	go listenToTopoLoading(mgr.TopoChannel)

--- a/pkg/northbound/testUtils.go
+++ b/pkg/northbound/testUtils.go
@@ -41,12 +41,13 @@ var (
 // to which it registers the given service.
 func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) {
 	var err error
+	ctrl := gomock.NewController(nil)
 	_, err = manager.LoadManager(
 		"../../../configs/configStore-sample.json",
 		"../../../configs/changeStore-sample.json",
 		"../../../configs/networkStore-sample.json",
-		mockstore.NewMockDeviceChangesStore(gomock.NewController(nil)),
-		mockstore.NewMockNetworkChangesStore(gomock.NewController(nil)))
+		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockNetworkChangesStore(ctrl))
 	if err != nil {
 		log.Error("Unable to load manager")
 	}

--- a/pkg/northbound/testUtils.go
+++ b/pkg/northbound/testUtils.go
@@ -16,9 +16,11 @@ package northbound
 
 import (
 	"fmt"
+	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-config/pkg/certs"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/manager"
+	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	types "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
@@ -43,9 +45,8 @@ func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) {
 		"../../../configs/configStore-sample.json",
 		"../../../configs/changeStore-sample.json",
 		"../../../configs/networkStore-sample.json",
-		nil,
-		nil,
-	)
+		mockstore.NewMockDeviceChangesStore(gomock.NewController(nil)),
+		mockstore.NewMockNetworkChangesStore(gomock.NewController(nil)))
 	if err != nil {
 		log.Error("Unable to load manager")
 	}

--- a/pkg/test/mocks/store/device_chages_store_mock.go
+++ b/pkg/test/mocks/store/device_chages_store_mock.go
@@ -2,7 +2,7 @@
 // Source: github.com/onosproject/onos-config/pkg/store/change/device (interfaces: Store)
 
 // Package mock_device is a generated GoMock package.
-package manager
+package store
 
 import (
 	gomock "github.com/golang/mock/gomock"

--- a/pkg/test/mocks/store/device_store_mock.go
+++ b/pkg/test/mocks/store/device_store_mock.go
@@ -2,7 +2,7 @@
 // Source: github.com/onosproject/onos-config/pkg/store/device (interfaces: Store)
 
 // Package mock_device is a generated GoMock package.
-package manager
+package store
 
 import (
 	gomock "github.com/golang/mock/gomock"

--- a/pkg/test/mocks/store/network_chages_store_mock.go
+++ b/pkg/test/mocks/store/network_chages_store_mock.go
@@ -2,7 +2,7 @@
 // Source: github.com/onosproject/onos-config/pkg/store/change/network (interfaces: Store)
 
 // Package mock_network is a generated GoMock package.
-package manager
+package store
 
 import (
 	gomock "github.com/golang/mock/gomock"


### PR DESCRIPTION
This PR moves the store mocks from the manager package into the pkg/test/mocks/store package so they are accessible to other packages.