### PR TITLE
gNMI Set requests writes also to new atomix stores

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/store/change/network"
 	devicetopo "github.com/onosproject/onos-config/pkg/store/device"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	log "k8s.io/klog"
@@ -50,7 +50,7 @@ type Manager struct {
 	OperationalStateChannel chan events.OperationalStateEvent
 	SouthboundErrorChan     chan events.DeviceResponse
 	Dispatcher              *dispatcher.Dispatcher
-	OperationalStateCache   map[devicepb.ID]types.TypedValueMap
+	OperationalStateCache   map[devicepb.ID]devicechangetypes.TypedValueMap
 }
 
 // NewManager initializes the network config manager subsystem.
@@ -80,7 +80,7 @@ func NewManager(configStore *store.ConfigurationStore, deviceChangesStore device
 		OperationalStateChannel: make(chan events.OperationalStateEvent, 10),
 		SouthboundErrorChan:     make(chan events.DeviceResponse, 10),
 		Dispatcher:              dispatcher.NewDispatcher(),
-		OperationalStateCache:   make(map[devicepb.ID]types.TypedValueMap),
+		OperationalStateCache:   make(map[devicepb.ID]devicechangetypes.TypedValueMap),
 	}
 
 	changeIds := make([]string, 0)
@@ -289,12 +289,12 @@ func listenOnResponseChannel(respChan chan events.DeviceResponse, m *Manager) {
 	}
 }
 
-func (m *Manager) computeChange(updates types.TypedValueMap,
+func (m *Manager) computeChange(updates devicechangetypes.TypedValueMap,
 	deletes []string, description string) (*change.Change, error) {
-	var newChanges = make([]*types.ChangeValue, 0)
+	var newChanges = make([]*devicechangetypes.ChangeValue, 0)
 	//updates
 	for path, value := range updates {
-		changeValue, err := types.NewChangeValue(path, value, false)
+		changeValue, err := devicechangetypes.NewChangeValue(path, value, false)
 		if err != nil {
 			log.Warningf("Error creating value for %s %v", path, err)
 			continue
@@ -303,13 +303,43 @@ func (m *Manager) computeChange(updates types.TypedValueMap,
 	}
 	//deletes
 	for _, path := range deletes {
-		changeValue, _ := types.NewChangeValue(path, types.NewTypedValueEmpty(), true)
+		changeValue, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueEmpty(), true)
 		newChanges = append(newChanges, changeValue)
 	}
 	if description == "" {
 		description = fmt.Sprintf("Created at %s", time.Now().Format(time.RFC3339))
 	}
 	return change.NewChange(newChanges, description)
+}
+
+func (m *Manager) computeDeviceChange(ID devicepb.ID, deviceVersion string, updates devicechangetypes.TypedValueMap,
+	deletes []string, description string) (*devicechangetypes.Change, error) {
+	var newChanges = make([]*devicechangetypes.ChangeValue, 0)
+	//updates
+	for path, value := range updates {
+		changeValue, err := devicechangetypes.NewChangeValue(path, value, false)
+		if err != nil {
+			log.Warningf("Error creating value for %s %v", path, err)
+			continue
+		}
+		newChanges = append(newChanges, changeValue)
+	}
+	//deletes
+	for _, path := range deletes {
+		changeValue, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueEmpty(), true)
+		newChanges = append(newChanges, changeValue)
+	}
+	//if description == "" {
+	//	description = fmt.Sprintf("Created at %s", time.Now().Format(time.RFC3339))
+	//}
+	//TODO lost description of Change
+	changeElement := &devicechangetypes.Change{
+		DeviceID:      ID,
+		DeviceVersion: deviceVersion,
+		Values:        newChanges,
+	}
+
+	return changeElement, nil
 }
 
 func (m *Manager) storeChange(configChange *change.Change) (change.ID, error) {

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -30,7 +30,7 @@ import (
 // See also the Test_getWithPrefixNoOtherPathsNoTarget below where the Target
 // is in the Prefix
 func Test_getNoTarget(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	noTargetPath1 := gnmi.Path{Elem: make([]*gnmi.PathElem, 0)}
@@ -45,7 +45,7 @@ func Test_getNoTarget(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -62,7 +62,7 @@ func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 
 // Test_getNoPathElems tests for  Paths with no elements - should treat it like /
 func Test_getNoPathElems(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 
 	noPath1 := gnmi.Path{Target: "Device1"}
@@ -85,7 +85,7 @@ func Test_getNoPathElems(t *testing.T) {
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
 
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
@@ -111,7 +111,7 @@ func Test_getAllDevices(t *testing.T) {
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
 
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	request := gnmi.GetRequest{
@@ -132,7 +132,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 }
 
 func Test_get2PathsWithPrefix(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -173,7 +173,7 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -201,7 +201,7 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 }
 
 func Test_targetDoesNotExist(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -219,7 +219,7 @@ func Test_targetDoesNotExist(t *testing.T) {
 // Target does exist, but specified path does not
 // No error - just an empty value
 func Test_pathDoesNotExist(t *testing.T) {
-	server, _, mockStore := setUp(t)
+	server, _, mockStore, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -36,7 +36,7 @@ func TestMain(m *testing.M) {
 }
 
 // setUp should not depend on any global variables
-func setUp(t *testing.T) (*Server, *manager.Manager, *MockStore) {
+func setUp(t *testing.T) (*Server, *manager.Manager, *MockStore, *mockstore.MockNetworkChangesStore) {
 	var server = &Server{}
 
 	ctrl := gomock.NewController(t)
@@ -65,7 +65,7 @@ func setUp(t *testing.T) (*Server, *manager.Manager, *MockStore) {
 
 	log.Info("Finished setUp()")
 	//TODO return all mock stores here. it needs to be passed because otherwise we can't do expect calls
-	return server, mgr, mockDeviceStore
+	return server, mgr, mockDeviceStore, mockNetworkChangesStore
 }
 
 func tearDown(mgr *manager.Manager, wg *sync.WaitGroup) {

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -27,7 +27,7 @@ import (
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"google.golang.org/grpc/codes"
@@ -123,7 +123,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 			return nil, err
 		}
 		delete(targetRemovesTmp, target)
-		_, errDevice := manager.GetManager().DeviceStore.Get(devicepb.ID(target))
+		_, errDevice := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
 		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
 			disconnectedDevices = append(disconnectedDevices, target)
 		} else if errDevice != nil {
@@ -137,7 +137,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		if err != nil {
 			return nil, err
 		}
-		_, errDevice := manager.GetManager().DeviceStore.Get(devicepb.ID(target))
+		_, errDevice := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
 		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
 			disconnectedDevices = append(disconnectedDevices, target)
 		} else if errDevice != nil {
@@ -412,7 +412,7 @@ func (s *Server) executeSetConfig(targetUpdates mapTargetUpdates,
 
 func listenForDeviceResponse(changes mapNetworkChanges, target string, name store.ConfigName) error {
 	mgr := manager.GetManager()
-	respChan, ok := mgr.Dispatcher.GetResponseListener(devicepb.ID(target))
+	respChan, ok := mgr.Dispatcher.GetResponseListener(devicetopo.ID(target))
 	if !ok {
 		log.Infof("Device %s not properly registered, not waiting for southbound confirmation ", target)
 		return nil

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -172,13 +172,13 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	//TODO evaluate need of user
-	// TODO start watch and build update Result
+	//TODO evaluate need of user and add it back if need be.
+	//TODO start watch and build update Result
 	allDeviceChanges, errChanges := s.computeConfig(targetUpdates, targetRemoves, version, deviceType, netcfgchangename)
 	if errChanges != nil {
 		log.Error("Can't compute new network config", err)
 	}
-	newNetworkConfig, errNetConfig := networktypes.NewNetworkConfiguration(netcfgchangename, "User1", allDeviceChanges)
+	newNetworkConfig, errNetConfig := networktypes.NewNetworkConfiguration(netcfgchangename, allDeviceChanges)
 	if errNetConfig != nil {
 		log.Error("Can't compute new network config", err)
 	}
@@ -209,6 +209,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 
 	manager.GetManager().NetworkStore.Store =
 		append(manager.GetManager().NetworkStore.Store, *networkConfig)
+	//TODO computeConfig, NewNetworkConfiguration and the followign Create can be combined in a manger method
 	//Writing to the atomix backed store too
 	errNewStore := manager.GetManager().NetworkChangesStore.Create(newNetworkConfig)
 	if errNewStore != nil {

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -34,8 +34,9 @@ import (
 
 // Test_doSingleSet shows how a value of 1 path can be set on a target
 func Test_doSingleSet(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
@@ -122,8 +123,9 @@ func Test_doSingleSet(t *testing.T) {
 
 // Test_doSingleSet shows how a value of 1 list can be set on a target
 func Test_doSingleSetList(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
@@ -208,8 +210,9 @@ func Test_doSingleSetList(t *testing.T) {
 
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target
 func Test_do2SetsOnSameTarget(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -257,8 +260,9 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 // Test_do2SetsOnDiffTargets shows how paths on multiple targets can be Set at
 // same time
 func Test_do2SetsOnDiffTargets(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -306,8 +310,9 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 // Test_do2SetsOnOneTargetOneOnDiffTarget shows how multiple paths on multiple
 // targets can be Set at same time
 func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -365,8 +370,9 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 // Test_doDuplicateSetSingleTarget shows how duplicate combineation of paths on
 // a single target fails
 func Test_doDuplicateSetSingleTarget(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -425,8 +431,9 @@ func Test_doDuplicateSetSingleTarget(t *testing.T) {
 // Test_doDuplicateSet2Targets shows how if all paths on all targets are
 // duplicates it should fail
 func Test_doDuplicateSet2Targets(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -503,8 +510,9 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 // targets but non dups on other targets the dups can be quietly ignored
 // Note how the SetResponse does not include the dups
 func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any()).Times(2)
 	// Make 2 changes
 	pathElemsRefs2a, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	valueStr2a := gnmi.TypedValue_StringVal{StringVal: "6thValue2a"}
@@ -593,8 +601,9 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 }
 
 func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -652,8 +661,9 @@ func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
 
 // Test_doSingleDelete shows how a value of 1 path can be deleted on a target
 func Test_doSingleDelete(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
@@ -716,8 +726,9 @@ func Test_doSingleDelete(t *testing.T) {
 
 // Test_doUpdateDeleteSet shows how a request with a delete and an update can be applied on a target
 func Test_doUpdateDeleteSet(t *testing.T) {
-	server, _, mockStore := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)

--- a/pkg/types/change/network/network.go
+++ b/pkg/types/change/network/network.go
@@ -19,8 +19,8 @@ import (
 	"regexp"
 	"time"
 )
-
-func NewNetworkConfiguration(networkChangeID string, user string, changes []*device.Change) (*NetworkChange, error) {
+// NewNetworkConfiguration creates a new network configuration
+func NewNetworkConfiguration(networkChangeID string, changes []*device.Change) (*NetworkChange, error) {
 	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
 	match := r1.FindString(networkChangeID)
 	if networkChangeID == "" {

--- a/pkg/types/change/network/network.go
+++ b/pkg/types/change/network/network.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package network
 
 import (
@@ -19,6 +20,7 @@ import (
 	"regexp"
 	"time"
 )
+
 // NewNetworkConfiguration creates a new network configuration
 func NewNetworkConfiguration(networkChangeID string, changes []*device.Change) (*NetworkChange, error) {
 	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
@@ -29,7 +31,7 @@ func NewNetworkConfiguration(networkChangeID string, changes []*device.Change) (
 		return nil, fmt.Errorf("Error in name %s", networkChangeID)
 	}
 
-	return 	&NetworkChange{
+	return &NetworkChange{
 		ID:      ID(networkChangeID),
 		Created: time.Now(),
 		Updated: time.Now(),

--- a/pkg/types/change/network/network.go
+++ b/pkg/types/change/network/network.go
@@ -21,8 +21,8 @@ import (
 	"time"
 )
 
-// NewNetworkConfiguration creates a new network configuration
-func NewNetworkConfiguration(networkChangeID string, changes []*device.Change) (*NetworkChange, error) {
+// NewNetworkChange creates a new network configuration
+func NewNetworkChange(networkChangeID string, changes []*device.Change) (*NetworkChange, error) {
 	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
 	match := r1.FindString(networkChangeID)
 	if networkChangeID == "" {

--- a/pkg/types/change/network/network.go
+++ b/pkg/types/change/network/network.go
@@ -1,0 +1,38 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package network
+
+import (
+	"fmt"
+	"github.com/onosproject/onos-config/pkg/types/change/device"
+	"regexp"
+	"time"
+)
+
+func NewNetworkConfiguration(networkChangeID string, user string, changes []*device.Change) (*NetworkChange, error) {
+	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
+	match := r1.FindString(networkChangeID)
+	if networkChangeID == "" {
+		return nil, fmt.Errorf("Empty name not allowed")
+	} else if networkChangeID != match {
+		return nil, fmt.Errorf("Error in name %s", networkChangeID)
+	}
+
+	return 	&NetworkChange{
+		ID:      ID(networkChangeID),
+		Created: time.Now(),
+		Updated: time.Now(),
+		Changes: changes,
+	}, nil
+}


### PR DESCRIPTION
gNMI Set Request also writes in parallel to the new Network, Atomix backed, stores.

Errors are logged and ignored for now.
There is no watching mechanism implemented yet, so no correct result can be actually fed back to the user from the `.Create` operation. 
Augments calls being made in the tests on the mocks with expected result. 

 