### PR TITLE
Set SB plumbing, Get and Validate in parallel with Atomix

### DIFF
--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/types"
 	changetype "github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetype "github.com/onosproject/onos-config/pkg/types/change/device"
+	"github.com/onosproject/onos-config/pkg/utils/values"
 	deviceservice "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 )
@@ -123,7 +124,12 @@ func (r *Reconciler) reconcileChange(change *devicechangetype.DeviceChange) (boo
 // doChange pushes the given change to the device
 func (r *Reconciler) doChange(change *devicechangetype.DeviceChange) error {
 	log.Infof("doChange %v", change)
-	// TODO: Apply the change
+	// TODO: Apply the change here
+    setRequest, err := values.NativeNewChangeToGnmiChange(change.Change)
+    if err != nil {
+    	return err
+	}
+    log.Info("Reconciler doChange request ", setRequest)
 	return nil
 }
 
@@ -151,6 +157,11 @@ func (r *Reconciler) reconcileRollback(change *devicechangetype.DeviceChange) (b
 func (r *Reconciler) doRollback(change *devicechangetype.DeviceChange) error {
 	log.Infof("doRollback %v", change)
 	// TODO: Roll back the change
+	setRequest, err := values.NativeNewChangeToGnmiChange(change.Change)
+	if err != nil {
+		return err
+	}
+	log.Info("Reconciler doRollback request ", setRequest)
 	return nil
 }
 

--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -125,11 +125,11 @@ func (r *Reconciler) reconcileChange(change *devicechangetype.DeviceChange) (boo
 func (r *Reconciler) doChange(change *devicechangetype.DeviceChange) error {
 	log.Infof("doChange %v", change)
 	// TODO: Apply the change here
-    setRequest, err := values.NativeNewChangeToGnmiChange(change.Change)
-    if err != nil {
-    	return err
+	setRequest, err := values.NativeNewChangeToGnmiChange(change.Change)
+	if err != nil {
+		return err
 	}
-    log.Info("Reconciler doChange request ", setRequest)
+	log.Info("Reconciler doChange request ", setRequest)
 	return nil
 }
 

--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -64,8 +64,8 @@ func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, pa
 	return filteredValues, nil
 }
 
-// GetTargetConfig returns a set of change values given a target, a configuration name, a path and a layer.
-// The layer is the numbers of config changes we want to go back in time for. 0 is the latest
+// GetTargetNewConfig returns a set of change values given a target, a configuration name, a path and a layer.
+// The layer is the numbers of config changes we want to go back in time for. 0 is the latest (Atomix based)
 func (m *Manager) GetTargetNewConfig(target string, path string, layer int) ([]*types.PathValue, error) {
 	log.Infof("Getting config for %s at %s", target, path)
 	configValues, errExtract := device.ExtractFullConfig(devicetopo.ID(target), nil, m.DeviceChangesStore, layer)

--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -27,6 +27,7 @@ import (
 
 // GetTargetConfig returns a set of change values given a target, a configuration name, a path and a layer.
 // The layer is the numbers of config changes we want to go back in time for. 0 is the latest
+// Deprecated: GetTargetConfig works on legacy, non-atomix stores
 func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, path string, layer int) ([]*types.PathValue, error) {
 	log.Info("Getting config for ", target, path)
 	//TODO the key of the config store should be a tuple of (devicename, configname) use the param

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -364,17 +364,17 @@ func (m *Manager) ComputeNewDeviceChange(deviceName string, version string,
 	var newChanges = make([]*devicechangetypes.ChangeValue, 0)
 	//updates
 	for path, value := range updates {
-		changeValue, err := devicechangetypes.NewChangeValue(path, value, false)
+		updateValue, err := devicechangetypes.NewChangeValue(path, value, false)
 		if err != nil {
 			log.Warningf("Error creating value for %s %v", path, err)
 			continue
 		}
-		newChanges = append(newChanges, changeValue)
+		newChanges = append(newChanges, updateValue)
 	}
 	//deletes
 	for _, path := range deletes {
-		changeValue, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueEmpty(), true)
-		newChanges = append(newChanges, changeValue)
+		deleteValue, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueEmpty(), true)
+		newChanges = append(newChanges, deleteValue)
 	}
 	//description := fmt.Sprintf("Originally created as part of %s", description)
 	//if description == "" {

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -20,9 +20,9 @@ import (
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	devicestore "github.com/onosproject/onos-config/pkg/store/change/device"
-	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"strings"
 	"time"
@@ -77,8 +77,8 @@ func (m *Manager) ValidateNetworkConfig(deviceName string, version string,
 	return nil
 }
 
-// ValidateNetworkConfig validates the given updates and deletes, according to the path on the configuration
-// for the specified target
+// ValidateNewNetworkConfig validates the given updates and deletes, according to the path on the configuration
+// for the specified target (Atomix Based)
 func (m *Manager) ValidateNewNetworkConfig(deviceName string, version string,
 	deviceType string, updates devicechangetypes.TypedValueMap, deletes []string) error {
 
@@ -86,7 +86,7 @@ func (m *Manager) ValidateNewNetworkConfig(deviceName string, version string,
 	if err != nil {
 		return err
 	}
-    //TODO this results empty and will work only with exact match of these types (getStoredConfig was masking not exact matches)
+	//TODO this results empty and will work only with exact match of these types (getStoredConfig was masking not exact matches)
 	modelName := fmt.Sprintf("%s-%s", deviceType, version)
 	deviceModelYgotPlugin, ok := m.ModelRegistry.ModelPlugins[modelName]
 	if !ok {

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -37,8 +37,6 @@ import (
 func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetResponse, error) {
 	notifications := make([]*gnmi.Notification, 0)
 
-	log.Infof("Request %s", req)
-
 	prefix := req.GetPrefix()
 
 	disconnectedDevicesMap := make(map[device.ID]bool)
@@ -177,6 +175,8 @@ func getUpdate(prefix *gnmi.Path, path *gnmi.Path) (*gnmi.Update, error) {
 	if errNewMethod != nil {
 		log.Error("Error while extracting config", errNewMethod)
 	}
+
+	//TODO remove this print after the swap
 	log.Info("Old Config Values ", configValues)
 	log.Info("New Config Values from Atomix ", configValuesNew)
 

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -37,6 +37,8 @@ import (
 func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetResponse, error) {
 	notifications := make([]*gnmi.Notification, 0)
 
+	log.Infof("Request %s", req)
+
 	prefix := req.GetPrefix()
 
 	disconnectedDevicesMap := make(map[device.ID]bool)
@@ -169,6 +171,15 @@ func getUpdate(prefix *gnmi.Path, path *gnmi.Path) (*gnmi.Update, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	configValuesNew, errNewMethod := manager.GetManager().GetTargetNewConfig(target,
+		pathAsString, 0)
+	if errNewMethod != nil {
+		log.Error("Error while extracting config", errNewMethod)
+	}
+	log.Info("Old Config Values ", configValues)
+	log.Info("New Config Values from Atomix ", configValuesNew)
+
 	stateValues := manager.GetManager().GetTargetState(target, pathAsString)
 	//Merging the two results
 	configValues = append(configValues, stateValues...)

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -30,7 +30,7 @@ import (
 // See also the Test_getWithPrefixNoOtherPathsNoTarget below where the Target
 // is in the Prefix
 func Test_getNoTarget(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	noTargetPath1 := gnmi.Path{Elem: make([]*gnmi.PathElem, 0)}
@@ -45,7 +45,7 @@ func Test_getNoTarget(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -62,8 +62,14 @@ func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 
 // Test_getNoPathElems tests for  Paths with no elements - should treat it like /
 func Test_getNoPathElems(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	server, _, mockDeviceStore, _, _ := setUp(t)
+	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	//mockDeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
+	//	func(device device.ID, c chan<- *devicechange.DeviceChange) error {
+	//		fmt.Printf("Device %s\n", device)
+	//		close(c)
+	//		return nil
+	//	}).AnyTimes()
 
 	noPath1 := gnmi.Path{Target: "Device1"}
 	noPath2 := gnmi.Path{Target: "Device2"}
@@ -85,8 +91,15 @@ func Test_getNoPathElems(t *testing.T) {
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
 
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	//mockDeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
+	//	func(device device.ID, c chan<- *devicechange.DeviceChange) error {
+	//		fmt.Printf("Device %s\n", device)
+	//		close(c)
+	//		return nil
+	//	}).AnyTimes()
+
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
 
@@ -111,7 +124,7 @@ func Test_getAllDevices(t *testing.T) {
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
 
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	request := gnmi.GetRequest{
@@ -132,7 +145,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 }
 
 func Test_get2PathsWithPrefix(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -173,7 +186,7 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -201,7 +214,7 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 }
 
 func Test_targetDoesNotExist(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -219,7 +232,7 @@ func Test_targetDoesNotExist(t *testing.T) {
 // Target does exist, but specified path does not
 // No error - just an empty value
 func Test_pathDoesNotExist(t *testing.T) {
-	server, _, mockStore, _ := setUp(t)
+	server, _, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -30,8 +30,8 @@ import (
 // See also the Test_getWithPrefixNoOtherPathsNoTarget below where the Target
 // is in the Prefix
 func Test_getNoTarget(t *testing.T) {
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	noTargetPath1 := gnmi.Path{Elem: make([]*gnmi.PathElem, 0)}
 	noTargetPath2 := gnmi.Path{Elem: make([]*gnmi.PathElem, 0)}
@@ -45,8 +45,8 @@ func Test_getNoTarget(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -62,14 +62,8 @@ func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 
 // Test_getNoPathElems tests for  Paths with no elements - should treat it like /
 func Test_getNoPathElems(t *testing.T) {
-	server, _, mockDeviceStore, _, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	//mockDeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-	//	func(device device.ID, c chan<- *devicechange.DeviceChange) error {
-	//		fmt.Printf("Device %s\n", device)
-	//		close(c)
-	//		return nil
-	//	}).AnyTimes()
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 
 	noPath1 := gnmi.Path{Target: "Device1"}
 	noPath2 := gnmi.Path{Target: "Device2"}
@@ -91,15 +85,8 @@ func Test_getNoPathElems(t *testing.T) {
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
 
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
-	//mockDeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-	//	func(device device.ID, c chan<- *devicechange.DeviceChange) error {
-	//		fmt.Printf("Device %s\n", device)
-	//		close(c)
-	//		return nil
-	//	}).AnyTimes()
-
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
 
@@ -124,8 +111,8 @@ func Test_getAllDevices(t *testing.T) {
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
 
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	request := gnmi.GetRequest{
 		Prefix: &gnmi.Path{Target: "*"},
@@ -145,8 +132,8 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 }
 
 func Test_get2PathsWithPrefix(t *testing.T) {
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -186,8 +173,8 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -214,8 +201,8 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 }
 
 func Test_targetDoesNotExist(t *testing.T) {
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -232,8 +219,8 @@ func Test_targetDoesNotExist(t *testing.T) {
 // Target does exist, but specified path does not
 // No error - just an empty value
 func Test_pathDoesNotExist(t *testing.T) {
-	server, _, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -36,53 +36,63 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+type MockStores struct {
+	DeviceStore          *mockstore.MockDeviceStore
+	NetworkChangesStore  *mockstore.MockNetworkChangesStore
+	DeviceChangesStore   *mockstore.MockDeviceChangesStore
+	NetworkSnapshotStore *mockstore.MockNetworkSnapshotStore
+	DeviceSnapshotStore  *mockstore.MockDeviceSnapshotStore
+	LeadershipStore      *mockstore.MockLeadershipStore
+	MastershipStore      *mockstore.MockMastershipStore
+}
+
 // setUp should not depend on any global variables
-func setUp(t *testing.T) (*Server, *manager.Manager, *mockstore.MockDeviceStore,
-	*mockstore.MockNetworkChangesStore, *mockstore.MockDeviceChangesStore) {
+func setUp(t *testing.T) (*Server, *manager.Manager, *MockStores) {
 	var server = &Server{}
 
 	ctrl := gomock.NewController(t)
-	mockLeadershipStore := mockstore.NewMockLeadershipStore(ctrl)
-	mockMastershipStore := mockstore.NewMockMastershipStore(ctrl)
-	mockDeviceChangesStore := mockstore.NewMockDeviceChangesStore(ctrl)
-	mockNetworkChangesStore := mockstore.NewMockNetworkChangesStore(ctrl)
-	mockDeviceStore := mockstore.NewMockDeviceStore(ctrl)
-	mockNetworkSnapshotStore := mockstore.NewMockNetworkSnapshotStore(ctrl)
-	mockDeviceSnapshotStore := mockstore.NewMockDeviceSnapshotStore(ctrl)
+	mockStores := MockStores{
+		DeviceStore:          mockstore.NewMockDeviceStore(ctrl),
+		NetworkChangesStore:  mockstore.NewMockNetworkChangesStore(ctrl),
+		DeviceChangesStore:   mockstore.NewMockDeviceChangesStore(ctrl),
+		NetworkSnapshotStore: mockstore.NewMockNetworkSnapshotStore(ctrl),
+		DeviceSnapshotStore:  mockstore.NewMockDeviceSnapshotStore(ctrl),
+		LeadershipStore:      mockstore.NewMockLeadershipStore(ctrl),
+		MastershipStore:      mockstore.NewMockMastershipStore(ctrl),
+	}
 
 	mgr, err := manager.LoadManager(
 		"../../../configs/configStore-sample.json",
 		"../../../configs/changeStore-sample.json",
 		"../../../configs/networkStore-sample.json",
-		mockLeadershipStore,
-		mockMastershipStore,
-		mockDeviceChangesStore,
-		mockNetworkChangesStore,
-		mockNetworkSnapshotStore,
-		mockDeviceSnapshotStore)
+		mockStores.LeadershipStore,
+		mockStores.MastershipStore,
+		mockStores.DeviceChangesStore,
+		mockStores.NetworkChangesStore,
+		mockStores.NetworkSnapshotStore,
+		mockStores.DeviceSnapshotStore)
 
 	if err != nil {
 		log.Error("Expected manager to be loaded ", err)
 		os.Exit(-1)
 	}
-	mgr.DeviceStore = mockDeviceStore
-	mgr.DeviceChangesStore = mockDeviceChangesStore
-	mgr.NetworkChangesStore = mockNetworkChangesStore
+	mgr.DeviceStore = mockStores.DeviceStore
+	mgr.DeviceChangesStore = mockStores.DeviceChangesStore
+	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
 
 	log.Infof("Dispatcher pointer %p", &mgr.Dispatcher)
 	go listenToTopoLoading(mgr.TopoChannel)
 	go mgr.Dispatcher.Listen(mgr.ChangesChannel)
 
-	mockDeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
+	mockStores.DeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(device devicepb.ID, c chan<- *devicechange.DeviceChange) error {
-			//fmt.Printf("Device %s\n", device)
 			close(c)
 			return nil
 		}).AnyTimes()
 
 	log.Info("Finished setUp()")
-	//TODO return all mock stores here. it needs to be passed because otherwise we can't do expect calls
-	return server, mgr, mockDeviceStore, mockNetworkChangesStore, mockDeviceChangesStore
+
+	return server, mgr, &mockStores
 }
 
 func tearDown(mgr *manager.Manager, wg *sync.WaitGroup) {

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -56,8 +56,6 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	targetUpdates := make(mapTargetUpdates)
 	targetRemoves := make(mapTargetRemoves)
 
-	log.Infof("Request %s", req)
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	//Update
@@ -522,6 +520,11 @@ func validateChange(target string, version string, deviceType string, targetUpda
 		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
 			targetRemoves, target, err)
 		return err
+	}
+	errNewValidation := manager.GetManager().ValidateNewNetworkConfig(target, version, deviceType, targetUpdates, targetRemoves)
+	if errNewValidation != nil {
+		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
+			targetRemoves, target, errNewValidation)
 	}
 	return nil
 }

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -50,11 +50,14 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		version             string // May be specified as 101 in extension
 		deviceType          string // May be specified as 102 in extension
 		disconnectedDevices []string
+		deviceInfo          map[devicetopo.ID]manager.TypeVersionInfo
 	)
 
 	disconnectedDevices = make([]string, 0)
 	targetUpdates := make(mapTargetUpdates)
 	targetRemoves := make(mapTargetRemoves)
+
+	deviceInfo = make(map[devicetopo.ID]manager.TypeVersionInfo)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -86,20 +89,12 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		targetRemoves[target] = s.doDelete(u, targetRemoves)
 	}
 
-	for _, ext := range req.GetExtension() {
-		if ext.GetRegisteredExt().GetId() == GnmiExtensionNetwkChangeID {
-			netcfgchangename = string(ext.GetRegisteredExt().GetMsg())
-		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionVersion {
-			version = string(ext.GetRegisteredExt().GetMsg())
-		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionDeviceType {
-			deviceType = string(ext.GetRegisteredExt().GetMsg())
-		} else {
-			return nil, status.Error(codes.InvalidArgument, fmt.Errorf("unexpected extension %d = '%s' in Set()",
-				ext.GetRegisteredExt().GetId(), ext.GetRegisteredExt().GetMsg()).Error())
-		}
+	netcfgchangename, version, deviceType, extErr := extractExtensions(req)
+
+	if extErr != nil {
+		return nil, extErr
 	}
-	log.Infof("Set called with extensions; 100: %s, 101: %s, 102: %s",
-		netcfgchangename, version, deviceType)
+
 	errRo := s.checkForReadOnly(deviceType, version, targetUpdates, targetRemoves)
 	if errRo != nil {
 		return nil, status.Error(codes.InvalidArgument, errRo.Error())
@@ -115,33 +110,47 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		targetRemovesTmp[k] = v
 	}
 
+	mgr := manager.GetManager()
+
 	//TODO this can be parallelized with a pattern manager.go ValidateStores()
 	//Checking for wrong configuration against the device models for updates
 	for target, updates := range targetUpdates {
-		err := validateChange(target, version, deviceType, updates, targetRemoves[target])
+		storedDevice, errDevice := mgr.DeviceStore.Get(devicetopo.ID(target))
+		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
+			disconnectedDevices = append(disconnectedDevices, target)
+		} else if errDevice != nil {
+			//handling gRPC errors
+			return nil, errDevice
+		}
+		typeVersionInfo, errTypeVersion := manager.ExtractTypeAndVersion(devicetopo.ID(target),
+			storedDevice, version, deviceType)
+		if errTypeVersion != nil {
+			return nil, errTypeVersion
+		}
+		deviceInfo[devicetopo.ID(target)] = typeVersionInfo
+		err := validateChange(target, version, deviceType, deviceInfo, updates, targetRemoves[target])
 		if err != nil {
 			return nil, err
 		}
 		delete(targetRemovesTmp, target)
-		_, errDevice := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
-		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
-			disconnectedDevices = append(disconnectedDevices, target)
-		} else if errDevice != nil {
-			//handling gRPC errors
-			return nil, err
-		}
 	}
 	//Checking for wrong configuration against the device models for deletes
 	for target, removes := range targetRemovesTmp {
-		err := validateChange(target, version, deviceType, make(devicechangetypes.TypedValueMap), removes)
-		if err != nil {
-			return nil, err
-		}
-		_, errDevice := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
+		storedDevice, errDevice := mgr.DeviceStore.Get(devicetopo.ID(target))
 		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
 			disconnectedDevices = append(disconnectedDevices, target)
 		} else if errDevice != nil {
 			//handling gRPC errors
+			return nil, errDevice
+		}
+		typeVersionInfo, errTypeVersion := manager.ExtractTypeAndVersion(devicetopo.ID(target),
+			storedDevice, version, deviceType)
+		if errTypeVersion != nil {
+			return nil, errTypeVersion
+		}
+		deviceInfo[devicetopo.ID(target)] = typeVersionInfo
+		err := validateChange(target, version, deviceType, deviceInfo, make(devicechangetypes.TypedValueMap), removes)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -158,7 +167,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	// Look for use of this name already
-	for _, nwCfg := range manager.GetManager().NetworkStore.Store {
+	for _, nwCfg := range mgr.NetworkStore.Store {
 		if nwCfg.Name == netcfgchangename {
 			return nil, status.Error(codes.InvalidArgument, fmt.Errorf(
 				"name %s is already used for a Network Configuration", netcfgchangename).Error())
@@ -171,7 +180,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	//Creating and setting the config on the new atomix Store
-	manager.GetManager().SetNewNetworkConfig(targetUpdates, targetRemoves, version, deviceType, netcfgchangename)
+	mgr.SetNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 
 	extensions := []*gnmi_ext.Extension{
 		{
@@ -197,8 +206,9 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		extensions = append(extensions, disconnectedExt)
 	}
 
-	manager.GetManager().NetworkStore.Store =
-		append(manager.GetManager().NetworkStore.Store, *networkConfig)
+	//TODO remove, old way of set.
+	mgr.NetworkStore.Store =
+		append(mgr.NetworkStore.Store, *networkConfig)
 	setResponse := &gnmi.SetResponse{
 		Response:  updateResults,
 		Timestamp: time.Now().Unix(),
@@ -206,6 +216,27 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 	//TODO Can't do it for one device only, needs to be done for all targets.
 	return setResponse, nil
+}
+
+func extractExtensions(req *gnmi.SetRequest) (string, string, string, error) {
+	var netcfgchangename string
+	var version string
+	var deviceType string
+	for _, ext := range req.GetExtension() {
+		if ext.GetRegisteredExt().GetId() == GnmiExtensionNetwkChangeID {
+			netcfgchangename = string(ext.GetRegisteredExt().GetMsg())
+		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionVersion {
+			version = string(ext.GetRegisteredExt().GetMsg())
+		} else if ext.GetRegisteredExt().GetId() == GnmiExtensionDeviceType {
+			deviceType = string(ext.GetRegisteredExt().GetMsg())
+		} else {
+			return "", "", "", status.Error(codes.InvalidArgument, fmt.Errorf("unexpected extension %d = '%s' in Set()",
+				ext.GetRegisteredExt().GetId(), ext.GetRegisteredExt().GetMsg()).Error())
+		}
+		log.Infof("Set called with extensions; 100: %s, 101: %s, 102: %s",
+			netcfgchangename, version, deviceType)
+	}
+	return netcfgchangename, version, deviceType, nil
 }
 
 // This deals with either a path and a value (simple case) or a path with
@@ -278,8 +309,10 @@ func (s *Server) doDelete(u *gnmi.Path, targetRemoves mapTargetRemoves) []string
 
 }
 
+// Deprecated: checkForReadOnly works on legacy, non-atomix stores
 func (s *Server) checkForReadOnly(deviceType string, version string, targetUpdates mapTargetUpdates,
 	targetRemoves mapTargetRemoves) error {
+	//TODO update with ne stores
 	configs := manager.GetManager().ConfigStore.Store
 
 	// Iterate through all the updates - many may use the same target - here we
@@ -338,6 +371,7 @@ func (s *Server) checkForReadOnly(deviceType string, version string, targetUpdat
 	return nil
 }
 
+// Deprecated: executeSetConfig works on legacy, non-atomix stores
 func (s *Server) executeSetConfig(targetUpdates mapTargetUpdates,
 	targetRemoves mapTargetRemoves, version string, deviceType string,
 	description string) ([]*gnmi.UpdateResult, mapNetworkChanges, error) {
@@ -410,6 +444,7 @@ func (s *Server) executeSetConfig(targetUpdates mapTargetUpdates,
 	return updateResults, networkChanges, nil
 }
 
+// Deprecated: listenForDeviceResponse works on legacy, non-atomix stores
 func listenForDeviceResponse(changes mapNetworkChanges, target string, name store.ConfigName) error {
 	mgr := manager.GetManager()
 	respChan, ok := mgr.Dispatcher.GetResponseListener(devicetopo.ID(target))
@@ -459,6 +494,7 @@ func listenForDeviceResponse(changes mapNetworkChanges, target string, name stor
 	}
 }
 
+// Deprecated: doRollback works on legacy, non-atomix stores
 func doRollback(changes mapNetworkChanges, mgr *manager.Manager, target string,
 	name store.ConfigName, errResp error) error {
 	rolledbackIDs := make([]string, 0)
@@ -494,6 +530,7 @@ func buildUpdateResult(pathStr string, target string, op gnmi.UpdateResult_Opera
 
 }
 
+// Deprecated: doRollback works on legacy, non-atomix stores
 func setChange(target string, version string, devicetype string, targetUpdates devicechangetypes.TypedValueMap,
 	targetRemoves []string, description string) (change.ID, *store.ConfigName, bool, error) {
 	changeID, configName, err := manager.GetManager().SetNetworkConfig(
@@ -509,8 +546,8 @@ func setChange(target string, version string, devicetype string, targetUpdates d
 	return changeID, configName, false, nil
 }
 
-func validateChange(target string, version string, deviceType string, targetUpdates devicechangetypes.TypedValueMap,
-	targetRemoves []string) error {
+func validateChange(target string, version string, deviceType string, deviceTypeAndVersion map[devicetopo.ID]manager.TypeVersionInfo,
+	targetUpdates devicechangetypes.TypedValueMap, targetRemoves []string) error {
 	if len(targetUpdates) == 0 && len(targetRemoves) == 0 {
 		return fmt.Errorf("no updates found in change on %s - invalid", target)
 	}
@@ -521,7 +558,9 @@ func validateChange(target string, version string, deviceType string, targetUpda
 			targetRemoves, target, err)
 		return err
 	}
-	errNewValidation := manager.GetManager().ValidateNewNetworkConfig(target, version, deviceType, targetUpdates, targetRemoves)
+	deviceInfo := deviceTypeAndVersion[devicetopo.ID(target)]
+	errNewValidation := manager.GetManager().ValidateNewNetworkConfig(target, deviceInfo.Version, deviceInfo.DeviceType,
+		targetUpdates, targetRemoves)
 	if errNewValidation != nil {
 		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
 			targetRemoves, target, errNewValidation)

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -56,6 +56,8 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	targetUpdates := make(mapTargetUpdates)
 	targetRemoves := make(mapTargetRemoves)
 
+	log.Infof("Request %s", req)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	//Update

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -125,7 +125,13 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		typeVersionInfo, errTypeVersion := manager.ExtractTypeAndVersion(devicetopo.ID(target),
 			storedDevice, version, deviceType)
 		if errTypeVersion != nil {
-			return nil, errTypeVersion
+			//TODO return instead of log
+			log.Error(errTypeVersion)
+			typeVersionInfo = manager.TypeVersionInfo{
+				DeviceType: "",
+				Version:    "",
+			}
+			//return nil, errTypeVersion
 		}
 		deviceInfo[devicetopo.ID(target)] = typeVersionInfo
 		err := validateChange(target, version, deviceType, deviceInfo, updates, targetRemoves[target])
@@ -146,7 +152,13 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		typeVersionInfo, errTypeVersion := manager.ExtractTypeAndVersion(devicetopo.ID(target),
 			storedDevice, version, deviceType)
 		if errTypeVersion != nil {
-			return nil, errTypeVersion
+			//TODO return instead of log
+			log.Error(errTypeVersion)
+			typeVersionInfo = manager.TypeVersionInfo{
+				DeviceType: "",
+				Version:    "",
+			}
+			//return nil, errTypeVersion
 		}
 		deviceInfo[devicetopo.ID(target)] = typeVersionInfo
 		err := validateChange(target, version, deviceType, deviceInfo, make(devicechangetypes.TypedValueMap), removes)

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -34,9 +34,9 @@ import (
 
 // Test_doSingleSet shows how a value of 1 path can be set on a target
 func Test_doSingleSet(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
@@ -123,9 +123,9 @@ func Test_doSingleSet(t *testing.T) {
 
 // Test_doSingleSet shows how a value of 1 list can be set on a target
 func Test_doSingleSetList(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
@@ -210,9 +210,9 @@ func Test_doSingleSetList(t *testing.T) {
 
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target
 func Test_do2SetsOnSameTarget(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -260,9 +260,9 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 // Test_do2SetsOnDiffTargets shows how paths on multiple targets can be Set at
 // same time
 func Test_do2SetsOnDiffTargets(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -310,9 +310,9 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 // Test_do2SetsOnOneTargetOneOnDiffTarget shows how multiple paths on multiple
 // targets can be Set at same time
 func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -370,9 +370,9 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 // Test_doDuplicateSetSingleTarget shows how duplicate combineation of paths on
 // a single target fails
 func Test_doDuplicateSetSingleTarget(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -431,9 +431,9 @@ func Test_doDuplicateSetSingleTarget(t *testing.T) {
 // Test_doDuplicateSet2Targets shows how if all paths on all targets are
 // duplicates it should fail
 func Test_doDuplicateSet2Targets(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -510,9 +510,9 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 // targets but non dups on other targets the dups can be quietly ignored
 // Note how the SetResponse does not include the dups
 func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any()).Times(2)
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any()).Times(2)
 	// Make 2 changes
 	pathElemsRefs2a, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	valueStr2a := gnmi.TypedValue_StringVal{StringVal: "6thValue2a"}
@@ -601,9 +601,9 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 }
 
 func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
@@ -661,9 +661,9 @@ func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
 
 // Test_doSingleDelete shows how a value of 1 path can be deleted on a target
 func Test_doSingleDelete(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
@@ -726,9 +726,9 @@ func Test_doSingleDelete(t *testing.T) {
 
 // Test_doUpdateDeleteSet shows how a request with a delete and an update can be applied on a target
 func Test_doUpdateDeleteSet(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, _, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -34,7 +34,7 @@ import (
 
 // Test_doSingleSet shows how a value of 1 path can be set on a target
 func Test_doSingleSet(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
@@ -123,7 +123,7 @@ func Test_doSingleSet(t *testing.T) {
 
 // Test_doSingleSet shows how a value of 1 list can be set on a target
 func Test_doSingleSetList(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
@@ -210,7 +210,7 @@ func Test_doSingleSetList(t *testing.T) {
 
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target
 func Test_do2SetsOnSameTarget(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
@@ -260,7 +260,7 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 // Test_do2SetsOnDiffTargets shows how paths on multiple targets can be Set at
 // same time
 func Test_do2SetsOnDiffTargets(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
@@ -310,7 +310,7 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 // Test_do2SetsOnOneTargetOneOnDiffTarget shows how multiple paths on multiple
 // targets can be Set at same time
 func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
@@ -370,7 +370,7 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 // Test_doDuplicateSetSingleTarget shows how duplicate combineation of paths on
 // a single target fails
 func Test_doDuplicateSetSingleTarget(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
@@ -431,7 +431,7 @@ func Test_doDuplicateSetSingleTarget(t *testing.T) {
 // Test_doDuplicateSet2Targets shows how if all paths on all targets are
 // duplicates it should fail
 func Test_doDuplicateSet2Targets(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
@@ -510,7 +510,7 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 // targets but non dups on other targets the dups can be quietly ignored
 // Note how the SetResponse does not include the dups
 func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any()).Times(2)
 	// Make 2 changes
@@ -601,7 +601,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 }
 
 func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)
@@ -661,7 +661,7 @@ func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
 
 // Test_doSingleDelete shows how a value of 1 path can be deleted on a target
 func Test_doSingleDelete(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
@@ -726,7 +726,7 @@ func Test_doSingleDelete(t *testing.T) {
 
 // Test_doUpdateDeleteSet shows how a request with a delete and an update can be applied on a target
 func Test_doUpdateDeleteSet(t *testing.T) {
-	server, _, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, _, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 	var deletePaths = make([]*gnmi.Path, 0)

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -82,8 +82,8 @@ func (x gNMISubscribeServerPollFake) Recv() (*gnmi.SubscribeRequest, error) {
 
 // Test_SubscribeLeafOnce tests subscribing with mode ONCE and then immediately receiving the subscription for a specific leaf.
 func Test_SubscribeLeafOnce(t *testing.T) {
-	server, mgr, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -122,9 +122,9 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with updates for that path
 func Test_SubscribeLeafStream(t *testing.T) {
-	server, mgr, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -185,8 +185,8 @@ func Test_SubscribeLeafStream(t *testing.T) {
 }
 
 func Test_WrongDevice(t *testing.T) {
-	_, mgr, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	_, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -234,8 +234,8 @@ func Test_WrongDevice(t *testing.T) {
 }
 
 func Test_WrongPath(t *testing.T) {
-	_, mgr, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	_, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -275,8 +275,8 @@ func Test_WrongPath(t *testing.T) {
 }
 
 func Test_ErrorDoubleSubscription(t *testing.T) {
-	server, mgr, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
 
@@ -314,8 +314,8 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 }
 
 func Test_Poll(t *testing.T) {
-	server, mgr, mockStore, _, _ := setUp(t)
-	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	server, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -375,9 +375,9 @@ func Test_Poll(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with delete paths
 func Test_SubscribeLeafStreamDelete(t *testing.T) {
-	server, mgr, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, mgr, mockStores := setUp(t)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -438,7 +438,7 @@ func Test_SubscribeLeafStreamDelete(t *testing.T) {
 // Test_SubscribeLeafStreamWithDeviceLoaded tests subscribing with mode STREAM for an existing device
 // and then issuing a set request with updates for that path
 func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
-	server, mgr, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
+	server, mgr, mockStores := setUp(t)
 
 	targetStr := "Device1"
 	target := device.ID(targetStr)
@@ -446,9 +446,9 @@ func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
 		ID: target,
 	}
 
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(presentDevice, nil)
-	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(presentDevice, nil)
-	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(presentDevice, nil)
+	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(presentDevice, nil)
+	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	configChan, respChan, err := mgr.Dispatcher.RegisterDevice(target)
 

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -82,7 +82,7 @@ func (x gNMISubscribeServerPollFake) Recv() (*gnmi.SubscribeRequest, error) {
 
 // Test_SubscribeLeafOnce tests subscribing with mode ONCE and then immediately receiving the subscription for a specific leaf.
 func Test_SubscribeLeafOnce(t *testing.T) {
-	server, mgr, mockStore, _ := setUp(t)
+	server, mgr, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	var wg sync.WaitGroup
@@ -122,7 +122,7 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with updates for that path
 func Test_SubscribeLeafStream(t *testing.T) {
-	server, mgr, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, mgr, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
@@ -185,7 +185,7 @@ func Test_SubscribeLeafStream(t *testing.T) {
 }
 
 func Test_WrongDevice(t *testing.T) {
-	_, mgr, mockStore, _ := setUp(t)
+	_, mgr, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
@@ -234,7 +234,7 @@ func Test_WrongDevice(t *testing.T) {
 }
 
 func Test_WrongPath(t *testing.T) {
-	_, mgr, mockStore, _ := setUp(t)
+	_, mgr, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
@@ -275,7 +275,7 @@ func Test_WrongPath(t *testing.T) {
 }
 
 func Test_ErrorDoubleSubscription(t *testing.T) {
-	server, mgr, mockStore, _ := setUp(t)
+	server, mgr, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -314,7 +314,7 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 }
 
 func Test_Poll(t *testing.T) {
-	server, mgr, mockStore, _ := setUp(t)
+	server, mgr, mockStore, _, _ := setUp(t)
 	mockStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 
 	var wg sync.WaitGroup
@@ -375,7 +375,7 @@ func Test_Poll(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with delete paths
 func Test_SubscribeLeafStreamDelete(t *testing.T) {
-	server, mgr, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, mgr, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 	mockDeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any())
 
@@ -438,7 +438,7 @@ func Test_SubscribeLeafStreamDelete(t *testing.T) {
 // Test_SubscribeLeafStreamWithDeviceLoaded tests subscribing with mode STREAM for an existing device
 // and then issuing a set request with updates for that path
 func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
-	server, mgr, mockDeviceStore, mockNetworkChangesStore := setUp(t)
+	server, mgr, mockDeviceStore, mockNetworkChangesStore, _ := setUp(t)
 
 	targetStr := "Device1"
 	target := device.ID(targetStr)

--- a/pkg/store/change/device/utils.go
+++ b/pkg/store/change/device/utils.go
@@ -1,0 +1,100 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package device
+
+import (
+	"github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
+	log "k8s.io/klog"
+	"sort"
+	"strings"
+)
+
+// ExtractFullConfig retrieves the full consolidated config for a Configuration
+// This gets the change up to and including the latest
+// Use "nBack" to specify a number of changes back to go
+// If there are not as many changes in the history as nBack nothing is returned
+func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.DeviceChange, changeStore Store,
+	nBack int) ([]*device.PathValue, error) {
+
+	// Have to use a slice to have a consistent output order
+	consolidatedConfig := make([]*device.PathValue, 0)
+
+	changeChan := make(chan *device.DeviceChange)
+
+	err := changeStore.List(deviceID, changeChan)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if newChange != nil {
+		consolidatedConfig = getPathValue(newChange, consolidatedConfig)
+	}
+
+	count := 0
+	for storeChange := range changeChan {
+		if nBack != 0 && count == nBack {
+			break
+		}
+		count++
+		log.Infof("Change %s", storeChange)
+		consolidatedConfig = getPathValue(storeChange, consolidatedConfig)
+	}
+
+	sort.Slice(consolidatedConfig, func(i, j int) bool {
+		return consolidatedConfig[i].Path < consolidatedConfig[j].Path
+	})
+
+	return consolidatedConfig, nil
+}
+
+func getPathValue(storeChange *device.DeviceChange, consolidatedConfig []*device.PathValue) []*device.PathValue {
+	for _, changeValue := range storeChange.Change.Values {
+		if changeValue.Removed {
+			// Delete everything at that path and all below it
+			// Have to search through consolidated config
+			// Make a list of indices to remove
+			indices := make([]int, 0)
+			for idx, cce := range consolidatedConfig {
+				if strings.Contains(cce.Path, changeValue.Path) {
+					indices = append(indices, idx)
+				}
+			}
+			// Remove in reverse
+			for i := len(indices) - 1; i >= 0; i-- {
+				consolidatedConfig = append(consolidatedConfig[:indices[i]], consolidatedConfig[indices[i]+1:]...)
+			}
+
+		} else {
+			var alreadyExists bool
+			for idx, cv := range consolidatedConfig {
+				if changeValue.Path == cv.Path {
+					consolidatedConfig[idx].Value = changeValue.GetValue()
+					alreadyExists = true
+					break
+				}
+			}
+			if !alreadyExists {
+				copyCv := device.PathValue{
+					Path:  changeValue.GetPath(),
+					Value: changeValue.GetValue(),
+				}
+				consolidatedConfig = append(consolidatedConfig, &copyCv)
+			}
+		}
+	}
+	return consolidatedConfig
+}

--- a/pkg/store/change/device/utils.go
+++ b/pkg/store/change/device/utils.go
@@ -17,7 +17,6 @@ package device
 import (
 	"github.com/onosproject/onos-config/pkg/types/change/device"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
-	log "k8s.io/klog"
 	"sort"
 	"strings"
 )
@@ -26,7 +25,7 @@ import (
 // This gets the change up to and including the latest
 // Use "nBack" to specify a number of changes back to go
 // If there are not as many changes in the history as nBack nothing is returned
-func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.DeviceChange, changeStore Store,
+func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.Change, changeStore Store,
 	nBack int) ([]*device.PathValue, error) {
 
 	// Have to use a slice to have a consistent output order
@@ -50,8 +49,7 @@ func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.DeviceChange, c
 			break
 		}
 		count++
-		log.Infof("Change %s", storeChange)
-		consolidatedConfig = getPathValue(storeChange, consolidatedConfig)
+		consolidatedConfig = getPathValue(storeChange.Change, consolidatedConfig)
 	}
 
 	sort.Slice(consolidatedConfig, func(i, j int) bool {
@@ -61,8 +59,8 @@ func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.DeviceChange, c
 	return consolidatedConfig, nil
 }
 
-func getPathValue(storeChange *device.DeviceChange, consolidatedConfig []*device.PathValue) []*device.PathValue {
-	for _, changeValue := range storeChange.Change.Values {
+func getPathValue(storeChange *device.Change, consolidatedConfig []*device.PathValue) []*device.PathValue {
+	for _, changeValue := range storeChange.Values {
 		if changeValue.Removed {
 			// Delete everything at that path and all below it
 			// Have to search through consolidated config

--- a/pkg/utils/values/gnmiChange_test.go
+++ b/pkg/utils/values/gnmiChange_test.go
@@ -23,14 +23,13 @@ import (
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"gotest.tools/assert"
-	"os"
 	"testing"
 )
 
 const (
-	Test1Cont1ACont2ALeaf2C      = "/cont1a/cont2a/leaf2c"
-	Test1Cont1AList2ATxout2      = "/cont1a/list2a[name=txout2]"
-	ValueLeaf2CDef      = "def"
+	Test1Cont1ACont2ALeaf2C = "/cont1a/cont2a/leaf2c"
+	Test1Cont1AList2ATxout2 = "/cont1a/list2a[name=txout2]"
+	ValueLeaf2CDef          = "def"
 )
 
 // Test_NativeChangeToGnmiChange tests conversion from an ONOS change to a GNMI change


### PR DESCRIPTION
This patch provides in parallel operations based on the new atomic store for set in SB, Get and Validate changes:
- in the change/device/controller.go we are now converting the change to a gNMI setRequest.
- Get in the SB works against the atomix based stores
- Validate validates the changes based on the atomic stored elements.
- store-api_test.go are only partially ported.