### PR TITLE
Store device snapshots by device ID

### DIFF
--- a/pkg/controller/snapshot/device/controller.go
+++ b/pkg/controller/snapshot/device/controller.go
@@ -90,7 +90,7 @@ func (r *Reconciler) Reconcile(id types.ID) (bool, error) {
 func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot) (bool, error) {
 	// Get the previous snapshot if any
 	var prevIndex devicechangetype.Index
-	prevSnapshot, err := r.snapshots.Load(devicesnaptype.ID(deviceSnapshot.DeviceID))
+	prevSnapshot, err := r.snapshots.Load(deviceSnapshot.DeviceID)
 	if err != nil {
 		return false, err
 	} else if prevSnapshot != nil {
@@ -169,7 +169,7 @@ func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot
 // reconcileDelete reconciles a snapshot in the DELETE phase
 func (r *Reconciler) reconcileDelete(deviceSnapshot *devicesnaptype.DeviceSnapshot) (bool, error) {
 	// Load the current snapshot
-	snapshot, err := r.snapshots.Load(devicesnaptype.ID(deviceSnapshot.DeviceID))
+	snapshot, err := r.snapshots.Load(deviceSnapshot.DeviceID)
 	if err != nil {
 		return false, err
 	} else if snapshot == nil {

--- a/pkg/controller/snapshot/device/controller_test.go
+++ b/pkg/controller/snapshot/device/controller_test.go
@@ -99,7 +99,7 @@ func TestReconcileDeviceSnapshotIndex(t *testing.T) {
 	assert.Equal(t, snapshottype.State_COMPLETE, deviceSnapshot.Status.State)
 
 	// Verify the correct snapshot was taken
-	snapshot, err := snapshots.Load(devicesnap.ID(deviceSnapshot.DeviceID))
+	snapshot, err := snapshots.Load(deviceSnapshot.DeviceID)
 	assert.NoError(t, err)
 	assert.Equal(t, devicechange.Index(3), snapshot.ChangeIndex)
 	assert.Len(t, snapshot.Values, 1)
@@ -213,7 +213,7 @@ func TestReconcileDeviceSnapshotPhaseState(t *testing.T) {
 	assert.Equal(t, snapshottype.State_COMPLETE, deviceSnapshot.Status.State)
 
 	// Verify the correct snapshot was taken
-	snapshot, err := snapshots.Load(devicesnap.ID(deviceSnapshot.DeviceID))
+	snapshot, err := snapshots.Load(deviceSnapshot.DeviceID)
 	assert.NoError(t, err)
 	assert.Equal(t, devicechange.Index(3), snapshot.ChangeIndex)
 	assert.Len(t, snapshot.Values, 2)

--- a/pkg/test/mocks/store/device_snapshot_store_mock.go
+++ b/pkg/test/mocks/store/device_snapshot_store_mock.go
@@ -7,6 +7,7 @@ package store
 import (
 	gomock "github.com/golang/mock/gomock"
 	device "github.com/onosproject/onos-config/pkg/types/snapshot/device"
+	device0 "github.com/onosproject/onos-topo/pkg/northbound/device"
 	reflect "reflect"
 )
 
@@ -147,7 +148,7 @@ func (mr *MockDeviceSnapshotStoreMockRecorder) Store(snapshot interface{}) *gomo
 }
 
 // Load mocks base method
-func (m *MockDeviceSnapshotStore) Load(id device.ID) (*device.Snapshot, error) {
+func (m *MockDeviceSnapshotStore) Load(id device0.ID) (*device.Snapshot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Load", id)
 	ret0, _ := ret[0].(*device.Snapshot)
@@ -159,4 +160,18 @@ func (m *MockDeviceSnapshotStore) Load(id device.ID) (*device.Snapshot, error) {
 func (mr *MockDeviceSnapshotStoreMockRecorder) Load(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockDeviceSnapshotStore)(nil).Load), id)
+}
+
+// LoadAll mocks base method
+func (m *MockDeviceSnapshotStore) LoadAll(ch chan<- *device.Snapshot) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LoadAll", ch)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LoadAll indicates an expected call of LoadAll
+func (mr *MockDeviceSnapshotStoreMockRecorder) LoadAll(ch interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadAll", reflect.TypeOf((*MockDeviceSnapshotStore)(nil).LoadAll), ch)
 }


### PR DESCRIPTION
This PR changes the device snapshot store to store snapshots by device ID to ensure only a single snapshot is persisted per device.