### PR TITLE
Removed dependency on onos-config from model plugin to speed builds

### DIFF
--- a/build/plugins/Dockerfile
+++ b/build/plugins/Dockerfile
@@ -4,7 +4,6 @@ FROM onosproject/golang-build:$ONOS_BUILD_VERSION
 ENV GO111MODULE=on
 
 COPY vendor /go/src/github.com/onosproject/onos-config/vendor/
-COPY pkg /go/src/github.com/onosproject/onos-config/pkg
 COPY Makefile go.mod go.sum /go/src/github.com/onosproject/onos-config/
 COPY modelplugin /go/src/github.com/onosproject/onos-config/modelplugin/
 

--- a/modelplugin/Devicesim-1.0.0/modelmain.go
+++ b/modelplugin/Devicesim-1.0.0/modelmain.go
@@ -20,7 +20,6 @@ package main
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/modelplugin/Devicesim-1.0.0/devicesim_1_0_0"
-	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -65,8 +64,10 @@ func (m modelplugin) Schema() (map[string]*yang.Entry, error) {
 	return devicesim_1_0_0.UnzipSchema()
 }
 
-func (m modelplugin) GetStateMode() modelregistry.GetStateMode {
-	return modelregistry.GetStateOpState
+// GetStateMode returns an int - we do not use the enum because we do not want a
+// direct dependency on onos-config code (for build optimization)
+func (m modelplugin) GetStateMode() int {
+	return 1 // modelregistry.GetStateOpState
 }
 
 // ModelPlugin is the exported symbol that gives an entry point to this shared module

--- a/modelplugin/ModelGenerator.sh
+++ b/modelplugin/ModelGenerator.sh
@@ -83,7 +83,6 @@ package main
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/modelplugin/$TYPEVERSION/$TYPEVERSIONPKG"
-	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -128,9 +127,10 @@ func (m modelplugin) Schema() (map[string]*yang.Entry, error) {
 	return $TYPEVERSIONPKG.UnzipSchema()
 }
 
-// Defines how the device supports the Getting of Operational and State data
-func (m modelplugin) GetStateMode() modelregistry.GetStateMode {
-	return modelregistry.GetStateOpState
+// GetStateMode returns an int - we do not use the enum because we do not want a
+// direct dependency on onos-config code (for build optimization)
+func (m modelplugin) GetStateMode() int {
+	return 0 // modelregistry.GetStateNone
 }
 
 // ModelPlugin is the exported symbol that gives an entry point to this shared module

--- a/modelplugin/Stratum-1.0.0/modelmain.go
+++ b/modelplugin/Stratum-1.0.0/modelmain.go
@@ -20,7 +20,6 @@ package main
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/modelplugin/Stratum-1.0.0/stratum_1_0_0"
-	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -86,8 +85,10 @@ func (m modelplugin) Schema() (map[string]*yang.Entry, error) {
 	return stratum_1_0_0.UnzipSchema()
 }
 
-func (m modelplugin) GetStateMode() modelregistry.GetStateMode {
-	return modelregistry.GetStateExplicitRoPathsExpandWildcards
+// GetStateMode returns an int - we do not use the enum because we do not want a
+// direct dependency on onos-config code (for build optimization)
+func (m modelplugin) GetStateMode() int {
+	return 3 // modelregistry.GetStateExplicitRoPathsExpandWildcards
 }
 
 // ModelPlugin is the exported symbol that gives an entry point to this shared module

--- a/modelplugin/TestDevice-1.0.0/modelmain.go
+++ b/modelplugin/TestDevice-1.0.0/modelmain.go
@@ -20,7 +20,6 @@ package main
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
-	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -65,8 +64,10 @@ func (m modelplugin) Schema() (map[string]*yang.Entry, error) {
 	return testdevice_1_0_0.UnzipSchema()
 }
 
-func (m modelplugin) GetStateMode() modelregistry.GetStateMode {
-	return modelregistry.GetStateNone
+// GetStateMode returns an int - we do not use the enum because we do not want a
+// direct dependency on onos-config code (for build optimization)
+func (m modelplugin) GetStateMode() int {
+	return 0 // modelregistry.GetStateNone
 }
 
 // ModelPlugin is the exported symbol that gives an entry point to this shared module

--- a/modelplugin/TestDevice-2.0.0/modelmain.go
+++ b/modelplugin/TestDevice-2.0.0/modelmain.go
@@ -20,7 +20,6 @@ package main
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/modelplugin/TestDevice-2.0.0/testdevice_2_0_0"
-	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -65,8 +64,10 @@ func (m modelplugin) Schema() (map[string]*yang.Entry, error) {
 	return testdevice_2_0_0.UnzipSchema()
 }
 
-func (m modelplugin) GetStateMode() modelregistry.GetStateMode {
-	return modelregistry.GetStateNone
+// GetStateMode returns an int - we do not use the enum because we do not want a
+// direct dependency on onos-config code (for build optimization)
+func (m modelplugin) GetStateMode() int {
+	return 0 // modelregistry.GetStateNone
 }
 
 // ModelPlugin is the exported symbol that gives an entry point to this shared module

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -633,7 +633,7 @@ func (m MockModelPlugin) Schema() (map[string]*yang.Entry, error) {
 	panic("implement me")
 }
 
-func (m MockModelPlugin) GetStateMode() modelregistry.GetStateMode {
+func (m MockModelPlugin) GetStateMode() int {
 	panic("implement me")
 }
 

--- a/pkg/modelregistry/modelregistry.go
+++ b/pkg/modelregistry/modelregistry.go
@@ -149,7 +149,7 @@ type ModelPlugin interface {
 	UnmarshalConfigValues(jsonTree []byte) (*ygot.ValidatedGoStruct, error)
 	Validate(*ygot.ValidatedGoStruct, ...ygot.ValidationOption) error
 	Schema() (map[string]*yang.Entry, error)
-	GetStateMode() GetStateMode
+	GetStateMode() int
 }
 
 // RegisterModelPlugin adds an external model plugin to the model registry at startup

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -89,8 +89,8 @@ func (m modelPluginTest) Schema() (map[string]*yang.Entry, error) {
 }
 
 // GetStateMode uses the `generated.go` of the TestDevice1 plugin module
-func (m modelPluginTest) GetStateMode() GetStateMode {
-	return GetStateOpState // modelregistry.GetStateOpState
+func (m modelPluginTest) GetStateMode() int {
+	return 1 // modelregistry.GetStateOpState
 }
 
 func Test_CastModelPlugin(t *testing.T) {


### PR DESCRIPTION
the model-plugins docker is getting built everytime again (it didn't used to) - it's because I added a dependency on config by using the modelregistry.GetState enum in the plugin - taking this back out again here