### PR TITLE
Harmonizing aliases for devicetopo, devicechangetypes and networkchangetypes

### DIFF
--- a/pkg/cli/changes.go
+++ b/pkg/cli/changes.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/spf13/cobra"
 	"io"
 	"strings"
@@ -100,6 +100,6 @@ func wrapPath(path string, lineLen int, tabs int) string {
 	return strings.Join(wrapped, sep)
 }
 
-func valueToSstring(cv types.TypedValue) string {
+func valueToSstring(cv devicechangetypes.TypedValue) string {
 	return cv.ValueToString()
 }

--- a/pkg/cli/configs_test.go
+++ b/pkg/cli/configs_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/admin"
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	"io"
 	"strings"
@@ -62,11 +62,11 @@ func generateChangeData(count int) {
 	changes = make([]admin.Change, count)
 	now := time.Now()
 	for chIdx := range changes {
-		changeValues := make([]*types.ChangeValue, count)
+		changeValues := make([]*devicechangetypes.ChangeValue, count)
 		for cvIdx := range changeValues {
-			cv := types.ChangeValue{
+			cv := devicechangetypes.ChangeValue{
 				Path:  fmt.Sprintf("/root/leaf-%d", cvIdx),
-				Value: types.NewTypedValueString("Test"),
+				Value: devicechangetypes.NewTypedValueString("Test"),
 			}
 			changeValues[cvIdx] = &cv
 		}

--- a/pkg/cli/devicechanges.go
+++ b/pkg/cli/devicechanges.go
@@ -17,7 +17,7 @@ package cli
 import (
 	"context"
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/spf13/cobra"
 	"io"
 	"text/template"
@@ -39,7 +39,7 @@ func getWatchDeviceChangesCommand() *cobra.Command {
 }
 
 func runWatchDeviceChangesCommand(cmd *cobra.Command, args []string) error {
-	id := types.ID(args[0]) // Argument is mandatory
+	id := devicechangetypes.ID(args[0]) // Argument is mandatory
 	noHeaders, _ := cmd.Flags().GetBool("no-headers")
 
 	clientConnection, clientConnectionError := getConnection()

--- a/pkg/cli/devicetree.go
+++ b/pkg/cli/devicetree.go
@@ -21,7 +21,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/spf13/cobra"
 	"io"
 	"text/template"
@@ -137,7 +137,7 @@ func runDeviceTreeCommand(cmd *cobra.Command, args []string) error {
 			ID:          change.ID(idBytes),
 			Description: in.Desc,
 			Created:     *in.Time,
-			Config:      make([]*types.ChangeValue, 0),
+			Config:      make([]*devicechangetypes.ChangeValue, 0),
 		}
 		changeObj.Config = append(changeObj.Config, in.ChangeValues...)
 		changes[in.Id] = &changeObj

--- a/pkg/cli/devicetree_test.go
+++ b/pkg/cli/devicetree_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/northbound/admin"
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	"io"
 	"regexp"
@@ -57,9 +57,9 @@ func diagChangesRecv() (*admin.Change, error) {
 			Time: &now,
 			Id:   "2Lo0ZC0wqhuwbnSF9px6kDvEEWI=",
 			Desc: "Change1",
-			ChangeValues: []*types.ChangeValue{
+			ChangeValues: []*devicechangetypes.ChangeValue{
 				{Path: "/a/b/c",
-					Value: types.NewTypedValueString("VALUE"),
+					Value: devicechangetypes.NewTypedValueString("VALUE"),
 				},
 			},
 		}

--- a/pkg/cli/networkchanges.go
+++ b/pkg/cli/networkchanges.go
@@ -17,7 +17,7 @@ package cli
 import (
 	"context"
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
-	types "github.com/onosproject/onos-config/pkg/types/change/network"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	"github.com/spf13/cobra"
 	"io"
 	"text/template"
@@ -52,9 +52,9 @@ func getWatchNetworkChangesCommand() *cobra.Command {
 }
 
 func runWatchNetworkChangesCommand(cmd *cobra.Command, args []string) error {
-	var id types.ID
+	var id networkchangetypes.ID
 	if len(args) > 0 {
-		id = types.ID(args[0])
+		id = networkchangetypes.ID(args[0])
 	}
 	verbose, _ := cmd.Flags().GetBool("verbose")
 	noHeaders, _ := cmd.Flags().GetBool("no-headers")

--- a/pkg/cli/opstate_test.go
+++ b/pkg/cli/opstate_test.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/northbound/diags"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	"io"
 	"regexp"
@@ -33,9 +33,9 @@ func generateOpstate(count int) {
 	for opstateIndex := range opstateInfo {
 		valueString := fmt.Sprintf("value%d", opstateIndex)
 		pathString := fmt.Sprintf("/root/system/path%d", opstateIndex)
-		value := types.PathValue{
+		value := devicechangetypes.PathValue{
 			Path:  pathString,
-			Value: types.NewTypedValueString(valueString),
+			Value: devicechangetypes.NewTypedValueString(valueString),
 		}
 		opstateInfo[opstateIndex] = diags.OpStateResponse{
 			Type:      0,

--- a/pkg/cli/snapshot.go
+++ b/pkg/cli/snapshot.go
@@ -17,7 +17,7 @@ package cli
 import (
 	"context"
 	"github.com/onosproject/onos-config/pkg/northbound/admin"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/spf13/cobra"
 	"io"
 )
@@ -58,7 +58,7 @@ func runSnapshotCommand(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		snapshot, err := client.GetSnapshot(context.Background(), &admin.GetSnapshotRequest{
-			DeviceID: device.ID(args[0]),
+			DeviceID: devicetopo.ID(args[0]),
 		})
 		if err != nil {
 			return err

--- a/pkg/controller/change/device/controller_test.go
+++ b/pkg/controller/change/device/controller_test.go
@@ -21,8 +21,8 @@ import (
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-config/pkg/types/change"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"io"
@@ -30,14 +30,14 @@ import (
 )
 
 const (
-	device1  = device.ID("device-1")
-	device2  = device.ID("device-2")
-	dcDevice = device.ID("disconnected")
+	device1  = devicetopo.ID("device-1")
+	device2  = devicetopo.ID("device-2")
+	dcDevice = devicetopo.ID("disconnected")
 )
 
 const (
-	change1 = devicechange.ID("device-1:device-1")
-	change2 = devicechange.ID("device-2:device-2")
+	change1 = devicechangetypes.ID("device-1:device-1")
+	change2 = devicechangetypes.ID("device-2:device-2")
 )
 
 func TestReconcilerChangeSuccess(t *testing.T) {
@@ -181,50 +181,50 @@ func TestReconcilerRollbackSuccess(t *testing.T) {
 func newStores(t *testing.T) (devicestore.Store, devicechanges.Store) {
 	ctrl := gomock.NewController(t)
 
-	devices := map[device.ID]*device.Device{
+	devices := map[devicetopo.ID]*devicetopo.Device{
 		device1: {
 			ID: device1,
-			Protocols: []*device.ProtocolState{
+			Protocols: []*devicetopo.ProtocolState{
 				{
-					Protocol:          device.Protocol_GNMI,
-					ConnectivityState: device.ConnectivityState_REACHABLE,
-					ChannelState:      device.ChannelState_CONNECTED,
+					Protocol:          devicetopo.Protocol_GNMI,
+					ConnectivityState: devicetopo.ConnectivityState_REACHABLE,
+					ChannelState:      devicetopo.ChannelState_CONNECTED,
 				},
 			},
 		},
 		device2: {
 			ID: device2,
-			Protocols: []*device.ProtocolState{
+			Protocols: []*devicetopo.ProtocolState{
 				{
-					Protocol:          device.Protocol_GNMI,
-					ConnectivityState: device.ConnectivityState_REACHABLE,
-					ChannelState:      device.ChannelState_CONNECTED,
+					Protocol:          devicetopo.Protocol_GNMI,
+					ConnectivityState: devicetopo.ConnectivityState_REACHABLE,
+					ChannelState:      devicetopo.ChannelState_CONNECTED,
 				},
 			},
 		},
 		dcDevice: {
 			ID: dcDevice,
-			Protocols: []*device.ProtocolState{
+			Protocols: []*devicetopo.ProtocolState{
 				{
-					Protocol:          device.Protocol_GNMI,
-					ConnectivityState: device.ConnectivityState_UNREACHABLE,
-					ChannelState:      device.ChannelState_DISCONNECTED,
+					Protocol:          devicetopo.Protocol_GNMI,
+					ConnectivityState: devicetopo.ConnectivityState_UNREACHABLE,
+					ChannelState:      devicetopo.ChannelState_DISCONNECTED,
 				},
 			},
 		},
 	}
 
 	stream := NewMockDeviceService_ListClient(ctrl)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: devices[device1]}, nil)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: devices[device2]}, nil)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: devices[dcDevice]}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: devices[device1]}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: devices[device2]}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: devices[dcDevice]}, nil)
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 
 	client := NewMockDeviceServiceClient(ctrl)
 	client.EXPECT().List(gomock.Any(), gomock.Any()).Return(stream, nil).AnyTimes()
 	client.EXPECT().Get(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, in *device.GetRequest, opts ...grpc.CallOption) (*device.GetResponse, error) {
-			return &device.GetResponse{
+		DoAndReturn(func(ctx context.Context, in *devicetopo.GetRequest, opts ...grpc.CallOption) (*devicetopo.GetResponse, error) {
+			return &devicetopo.GetResponse{
 				Device: devices[in.ID],
 			}, nil
 		}).AnyTimes()
@@ -236,20 +236,20 @@ func newStores(t *testing.T) (devicestore.Store, devicechanges.Store) {
 	return deviceStore, deviceChanges
 }
 
-func newChange(device device.ID) *devicechange.DeviceChange {
-	return &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+func newChange(device devicetopo.ID) *devicechangetypes.DeviceChange {
+	return &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    types.ID(device),
 			Index: 1,
 		},
-		Change: &devicechange.Change{
+		Change: &devicechangetypes.Change{
 			DeviceID: device,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "foo",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},

--- a/pkg/controller/change/device/partitioner.go
+++ b/pkg/controller/change/device/partitioner.go
@@ -17,7 +17,7 @@ package device
 import (
 	"github.com/onosproject/onos-config/pkg/controller"
 	"github.com/onosproject/onos-config/pkg/types"
-	changetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 )
 
 // Partitioner is a WorkPartitioner for devices
@@ -26,7 +26,7 @@ type Partitioner struct {
 
 // Partition returns the device as a partition key
 func (p *Partitioner) Partition(id types.ID) (controller.PartitionKey, error) {
-	return controller.PartitionKey(changetypes.ID(id).GetDeviceID()), nil
+	return controller.PartitionKey(devicechangetypes.ID(id).GetDeviceID()), nil
 }
 
 var _ controller.WorkPartitioner = &Partitioner{}

--- a/pkg/controller/change/device/partitioner_test.go
+++ b/pkg/controller/change/device/partitioner_test.go
@@ -17,15 +17,15 @@ package device
 import (
 	"github.com/onosproject/onos-config/pkg/controller"
 	"github.com/onosproject/onos-config/pkg/types"
-	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestDevicePartitioner(t *testing.T) {
 	partitioner := &Partitioner{}
-	key, err := partitioner.Partition(types.ID(networkchange.ID("change-1").GetDeviceChangeID(device.ID("device-1"))))
+	key, err := partitioner.Partition(types.ID(networkchangetypes.ID("change-1").GetDeviceChangeID(devicetopo.ID("device-1"))))
 	assert.NoError(t, err)
 	assert.Equal(t, controller.PartitionKey("device-1"), key)
 }

--- a/pkg/controller/change/device/watcher.go
+++ b/pkg/controller/change/device/watcher.go
@@ -19,8 +19,8 @@ import (
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/types"
-	devicechangetype "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"sync"
 )
 
@@ -31,7 +31,7 @@ type Watcher struct {
 	DeviceStore devicestore.Store
 	ChangeStore devicechangestore.Store
 	ch          chan<- types.ID
-	channels    map[device.ID]chan *devicechangetype.DeviceChange
+	channels    map[devicetopo.ID]chan *devicechangetypes.DeviceChange
 	mu          sync.Mutex
 	wg          sync.WaitGroup
 }
@@ -45,10 +45,10 @@ func (w *Watcher) Start(ch chan<- types.ID) error {
 	}
 
 	w.ch = ch
-	w.channels = make(map[device.ID]chan *devicechangetype.DeviceChange)
+	w.channels = make(map[devicetopo.ID]chan *devicechangetypes.DeviceChange)
 	w.mu.Unlock()
 
-	deviceCh := make(chan *device.ListResponse)
+	deviceCh := make(chan *devicetopo.ListResponse)
 	if err := w.DeviceStore.Watch(deviceCh); err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (w *Watcher) Start(ch chan<- types.ID) error {
 }
 
 // watchDevice watches changes for the given device
-func (w *Watcher) watchDevice(device device.ID, ch chan<- types.ID) {
+func (w *Watcher) watchDevice(device devicetopo.ID, ch chan<- types.ID) {
 	w.mu.Lock()
 	deviceCh := w.channels[device]
 	if deviceCh != nil {
@@ -70,7 +70,7 @@ func (w *Watcher) watchDevice(device device.ID, ch chan<- types.ID) {
 		return
 	}
 
-	deviceCh = make(chan *devicechangetype.DeviceChange, queueSize)
+	deviceCh = make(chan *devicechangetypes.DeviceChange, queueSize)
 	w.channels[device] = deviceCh
 	w.mu.Unlock()
 

--- a/pkg/controller/change/network/controller_test.go
+++ b/pkg/controller/change/network/controller_test.go
@@ -21,23 +21,23 @@ import (
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-config/pkg/types/change"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 )
 
 const (
-	device1 = device.ID("device-1")
-	device2 = device.ID("device-2")
-	device3 = device.ID("device-3")
-	device4 = device.ID("device-4")
+	device1 = devicetopo.ID("device-1")
+	device2 = devicetopo.ID("device-2")
+	device3 = devicetopo.ID("device-3")
+	device4 = devicetopo.ID("device-4")
 )
 
 const (
-	change1 = networkchange.ID("change-1")
+	change1 = networkchangetypes.ID("change-1")
 )
 
 // TestReconcilerChangeRollback tests applying and then rolling back a change
@@ -326,10 +326,10 @@ func newStores(t *testing.T) (devicestore.Store, networkchanges.Store, devicecha
 	ctrl := gomock.NewController(t)
 
 	stream := NewMockDeviceService_ListClient(ctrl)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: &device.Device{ID: device1}}, nil)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: &device.Device{ID: device2}}, nil)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: &device.Device{ID: device3}}, nil)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: &device.Device{ID: device4}}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: &devicetopo.Device{ID: device1}}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: &devicetopo.Device{ID: device2}}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: &devicetopo.Device{ID: device3}}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: &devicetopo.Device{ID: device4}}, nil)
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 
 	client := NewMockDeviceServiceClient(ctrl)
@@ -344,23 +344,23 @@ func newStores(t *testing.T) (devicestore.Store, networkchanges.Store, devicecha
 	return devices, networkChanges, deviceChanges
 }
 
-func newChange(id networkchange.ID, devices ...device.ID) *networkchange.NetworkChange {
-	changes := make([]*devicechange.Change, len(devices))
+func newChange(id networkchangetypes.ID, devices ...devicetopo.ID) *networkchangetypes.NetworkChange {
+	changes := make([]*devicechangetypes.Change, len(devices))
 	for i, device := range devices {
-		changes[i] = &devicechange.Change{
+		changes[i] = &devicechangetypes.Change{
 			DeviceID: device,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "foo",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},
 		}
 	}
-	return &networkchange.NetworkChange{
+	return &networkchangetypes.NetworkChange{
 		ID:      id,
 		Changes: changes,
 	}

--- a/pkg/controller/change/network/watcher_test.go
+++ b/pkg/controller/change/network/watcher_test.go
@@ -21,9 +21,9 @@ import (
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-config/pkg/types/change"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
@@ -43,37 +43,37 @@ func TestNetworkWatcher(t *testing.T) {
 	err = watcher.Start(ch)
 	assert.NoError(t, err)
 
-	change1 := &networkchange.NetworkChange{
+	change1 := &networkchangetypes.NetworkChange{
 		ID: "change-1",
-		Changes: []*devicechange.Change{
+		Changes: []*devicechangetypes.Change{
 			{
 
-				DeviceID: device.ID("device-1"),
-				Values: []*devicechange.ChangeValue{
+				DeviceID: devicetopo.ID("device-1"),
+				Values: []*devicechangetypes.ChangeValue{
 					{
 						Path: "foo",
-						Value: &devicechange.TypedValue{
+						Value: &devicechangetypes.TypedValue{
 							Bytes: []byte("Hello world!"),
-							Type:  devicechange.ValueType_STRING,
+							Type:  devicechangetypes.ValueType_STRING,
 						},
 					},
 					{
 						Path: "bar",
-						Value: &devicechange.TypedValue{
+						Value: &devicechangetypes.TypedValue{
 							Bytes: []byte("Hello world again!"),
-							Type:  devicechange.ValueType_STRING,
+							Type:  devicechangetypes.ValueType_STRING,
 						},
 					},
 				},
 			},
 			{
-				DeviceID: device.ID("device-2"),
-				Values: []*devicechange.ChangeValue{
+				DeviceID: devicetopo.ID("device-2"),
+				Values: []*devicechangetypes.ChangeValue{
 					{
 						Path: "baz",
-						Value: &devicechange.TypedValue{
+						Value: &devicechangetypes.TypedValue{
 							Bytes: []byte("Goodbye world!"),
-							Type:  devicechange.ValueType_STRING,
+							Type:  devicechangetypes.ValueType_STRING,
 						},
 					},
 				},
@@ -86,17 +86,17 @@ func TestNetworkWatcher(t *testing.T) {
 
 	select {
 	case id := <-ch:
-		assert.Equal(t, change1.ID, networkchange.ID(id))
+		assert.Equal(t, change1.ID, networkchangetypes.ID(id))
 	case <-time.After(5 * time.Second):
 		t.FailNow()
 	}
 
-	change2 := &networkchange.NetworkChange{
+	change2 := &networkchangetypes.NetworkChange{
 		ID: "change-2",
-		Changes: []*devicechange.Change{
+		Changes: []*devicechangetypes.Change{
 			{
-				DeviceID: device.ID("device-1"),
-				Values: []*devicechange.ChangeValue{
+				DeviceID: devicetopo.ID("device-1"),
+				Values: []*devicechangetypes.ChangeValue{
 					{
 						Path:    "foo",
 						Removed: true,
@@ -132,8 +132,8 @@ func TestDeviceWatcher(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	stream := NewMockDeviceService_ListClient(ctrl)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: &device.Device{ID: device.ID("device-1")}}, nil)
-	stream.EXPECT().Recv().Return(&device.ListResponse{Device: &device.Device{ID: device.ID("device-2")}}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: &devicetopo.Device{ID: devicetopo.ID("device-1")}}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: &devicetopo.Device{ID: devicetopo.ID("device-2")}}, nil)
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 
 	client := NewMockDeviceServiceClient(ctrl)
@@ -155,26 +155,26 @@ func TestDeviceWatcher(t *testing.T) {
 	err = watcher.Start(ch)
 	assert.NoError(t, err)
 
-	change1 := &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+	change1 := &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    "network-change-1",
 			Index: 2,
 		},
-		Change: &devicechange.Change{
-			DeviceID: device.ID("device-1"),
-			Values: []*devicechange.ChangeValue{
+		Change: &devicechangetypes.Change{
+			DeviceID: devicetopo.ID("device-1"),
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "foo",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 				{
 					Path: "bar",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world again!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},
@@ -191,19 +191,19 @@ func TestDeviceWatcher(t *testing.T) {
 		t.FailNow()
 	}
 
-	change2 := &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+	change2 := &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    "network-change-2",
 			Index: 2,
 		},
-		Change: &devicechange.Change{
-			DeviceID: device.ID("device-2"),
-			Values: []*devicechange.ChangeValue{
+		Change: &devicechangetypes.Change{
+			DeviceID: devicetopo.ID("device-2"),
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "baz",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Goodbye world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},

--- a/pkg/controller/filter.go
+++ b/pkg/controller/filter.go
@@ -17,7 +17,7 @@ package controller
 import (
 	mastershipstore "github.com/onosproject/onos-config/pkg/store/mastership"
 	"github.com/onosproject/onos-config/pkg/types"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"regexp"
 )
 
@@ -55,7 +55,7 @@ var _ Filter = &MastershipFilter{}
 // DeviceResolver resolves a device from a type ID
 type DeviceResolver interface {
 	// Resolve resolves a device
-	Resolve(id types.ID) (device.ID, error)
+	Resolve(id types.ID) (devicetopo.ID, error)
 }
 
 // RegexpDeviceResolver is a DeviceResolver that reads a device ID from a regexp
@@ -64,8 +64,8 @@ type RegexpDeviceResolver struct {
 }
 
 // Resolve resolves a device ID from the configured regexp
-func (r *RegexpDeviceResolver) Resolve(id types.ID) (device.ID, error) {
-	return device.ID(r.Regexp.FindString(string(id))), nil
+func (r *RegexpDeviceResolver) Resolve(id types.ID) (devicetopo.ID, error) {
+	return devicetopo.ID(r.Regexp.FindString(string(id))), nil
 }
 
 var _ DeviceResolver = &RegexpDeviceResolver{}

--- a/pkg/controller/filter_test.go
+++ b/pkg/controller/filter_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/mastership"
 	"github.com/onosproject/onos-config/pkg/types"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -27,8 +27,8 @@ import (
 type testDeviceResolver struct {
 }
 
-func (r testDeviceResolver) Resolve(id types.ID) (device.ID, error) {
-	return device.ID(id), nil
+func (r testDeviceResolver) Resolve(id types.ID) (devicetopo.ID, error) {
+	return devicetopo.ID(id), nil
 }
 
 func TestMastershipFilter(t *testing.T) {
@@ -51,8 +51,8 @@ func TestMastershipFilter(t *testing.T) {
 		Resolver: testDeviceResolver{},
 	}
 
-	device1 := device.ID("device1")
-	device2 := device.ID("device2")
+	device1 := devicetopo.ID("device1")
+	device2 := devicetopo.ID("device2")
 
 	master, err := store1.IsMaster(device1)
 	assert.NoError(t, err)

--- a/pkg/controller/snapshot/device/controller.go
+++ b/pkg/controller/snapshot/device/controller.go
@@ -21,10 +21,10 @@ import (
 	snapstore "github.com/onosproject/onos-config/pkg/store/snapshot/device"
 	"github.com/onosproject/onos-config/pkg/types"
 	changetype "github.com/onosproject/onos-config/pkg/types/change"
-	devicechangetype "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	snaptype "github.com/onosproject/onos-config/pkg/types/snapshot"
 	devicesnaptype "github.com/onosproject/onos-config/pkg/types/snapshot/device"
-	deviceservice "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"strings"
 )
@@ -55,7 +55,7 @@ type Resolver struct {
 }
 
 // Resolve resolves a device ID from a device snapshot ID
-func (r *Resolver) Resolve(id types.ID) (deviceservice.ID, error) {
+func (r *Resolver) Resolve(id types.ID) (devicetopo.ID, error) {
 	return devicesnaptype.ID(id).GetDeviceID(), nil
 }
 
@@ -91,7 +91,7 @@ func (r *Reconciler) Reconcile(id types.ID) (bool, error) {
 // reconcileMark reconciles a snapshot in the MARK phase
 func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot) (bool, error) {
 	// Get the previous snapshot if any
-	var prevIndex devicechangetype.Index
+	var prevIndex devicechangetypes.Index
 	prevSnapshot, err := r.snapshots.Load(deviceSnapshot.DeviceID)
 	if err != nil {
 		return false, err
@@ -100,7 +100,7 @@ func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot
 	}
 
 	// Create a map to track the current state of the device
-	state := make(map[string]*devicechangetype.PathValue)
+	state := make(map[string]*devicechangetypes.PathValue)
 
 	// Initialize the state map from the previous snapshot if available
 	if prevSnapshot != nil {
@@ -110,7 +110,7 @@ func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot
 	}
 
 	// List the changes for the device
-	changes := make(chan *devicechangetype.DeviceChange)
+	changes := make(chan *devicechangetypes.DeviceChange)
 	if err := r.changes.List(deviceSnapshot.DeviceID, changes); err != nil {
 		return false, err
 	}
@@ -141,7 +141,7 @@ func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot
 						}
 					}
 				} else {
-					state[value.Path] = &devicechangetype.PathValue{
+					state[value.Path] = &devicechangetypes.PathValue{
 						Path:  value.GetPath(),
 						Value: value.GetValue(),
 					}
@@ -153,7 +153,7 @@ func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot
 
 	// If the snapshot index is greater than the previous snapshot index, store the snapshot
 	if snapshotIndex > prevIndex {
-		values := make([]*devicechangetype.PathValue, 0, len(state))
+		values := make([]*devicechangetypes.PathValue, 0, len(state))
 		for _, value := range state {
 			values = append(values, value)
 		}
@@ -196,7 +196,7 @@ func (r *Reconciler) reconcileDelete(deviceSnapshot *devicesnaptype.DeviceSnapsh
 	}
 
 	// List the changes for the device
-	changes := make(chan *devicechangetype.DeviceChange)
+	changes := make(chan *devicechangetypes.DeviceChange)
 	if err := r.changes.List(deviceSnapshot.DeviceID, changes); err != nil {
 		return false, err
 	}

--- a/pkg/controller/snapshot/device/controller_test.go
+++ b/pkg/controller/snapshot/device/controller_test.go
@@ -308,7 +308,7 @@ func newRemove(index networkchangetypes.Index, device devicetopo.ID, path string
 func newChange(index networkchangetypes.Index, created time.Time, phase changetype.Phase, state changetype.State, change *devicechangetypes.Change) *devicechangetypes.DeviceChange {
 	return &devicechangetypes.DeviceChange{
 		NetworkChange: devicechangetypes.NetworkChangeRef{
-			ID:    types.ID(fmt.Sprintf("networkchangetypes-change-%d", index)),
+			ID:    types.ID(fmt.Sprintf("network-change-%d", index)),
 			Index: types.Index(index),
 		},
 		Change: change,

--- a/pkg/controller/snapshot/device/controller_test.go
+++ b/pkg/controller/snapshot/device/controller_test.go
@@ -20,18 +20,18 @@ import (
 	devicesnapstore "github.com/onosproject/onos-config/pkg/store/snapshot/device"
 	"github.com/onosproject/onos-config/pkg/types"
 	changetype "github.com/onosproject/onos-config/pkg/types/change"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-config/pkg/types/change/network"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	snapshottype "github.com/onosproject/onos-config/pkg/types/snapshot"
 	devicesnap "github.com/onosproject/onos-config/pkg/types/snapshot/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 )
 
 const (
-	device1 = device.ID("device-1")
+	device1 = devicetopo.ID("device-1")
 )
 
 func TestReconcileDeviceSnapshotIndex(t *testing.T) {
@@ -101,7 +101,7 @@ func TestReconcileDeviceSnapshotIndex(t *testing.T) {
 	// Verify the correct snapshot was taken
 	snapshot, err := snapshots.Load(deviceSnapshot.DeviceID)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.Index(3), snapshot.ChangeIndex)
+	assert.Equal(t, devicechangetypes.Index(3), snapshot.ChangeIndex)
 	assert.Len(t, snapshot.Values, 2)
 	assert.Equal(t, "/bar/msg", snapshot.Values[0].Path)
 	assert.Equal(t, "Hello world 3", snapshot.Values[0].GetValue().ValueToString())
@@ -218,7 +218,7 @@ func TestReconcileDeviceSnapshotPhaseState(t *testing.T) {
 	// Verify the correct snapshot was taken
 	snapshot, err := snapshots.Load(deviceSnapshot.DeviceID)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.Index(3), snapshot.ChangeIndex)
+	assert.Equal(t, devicechangetypes.Index(3), snapshot.ChangeIndex)
 	assert.Len(t, snapshot.Values, 4)
 
 	// Verify changes have not been deleted
@@ -277,26 +277,26 @@ func newStores(t *testing.T) (devicechangestore.Store, devicesnapstore.Store) {
 	return changes, snapshots
 }
 
-func newSet(index network.Index, device device.ID, path string, created time.Time, phase changetype.Phase, state changetype.State) *devicechange.DeviceChange {
-	return newChange(index, created, phase, state, &devicechange.Change{
+func newSet(index networkchangetypes.Index, device devicetopo.ID, path string, created time.Time, phase changetype.Phase, state changetype.State) *devicechangetypes.DeviceChange {
+	return newChange(index, created, phase, state, &devicechangetypes.Change{
 		DeviceID: device,
-		Values: []*devicechange.ChangeValue{
+		Values: []*devicechangetypes.ChangeValue{
 			{
 				Path:  fmt.Sprintf("/%s/msg", path),
-				Value: devicechange.NewTypedValueString(fmt.Sprintf("Hello world %d", len(path))),
+				Value: devicechangetypes.NewTypedValueString(fmt.Sprintf("Hello world %d", len(path))),
 			},
 			{
 				Path:  fmt.Sprintf("/%s/meaning", path),
-				Value: devicechange.NewTypedValueInt64(39 + len(path)),
+				Value: devicechangetypes.NewTypedValueInt64(39 + len(path)),
 			},
 		},
 	})
 }
 
-func newRemove(index network.Index, device device.ID, path string, created time.Time, phase changetype.Phase, state changetype.State) *devicechange.DeviceChange {
-	return newChange(index, created, phase, state, &devicechange.Change{
+func newRemove(index networkchangetypes.Index, device devicetopo.ID, path string, created time.Time, phase changetype.Phase, state changetype.State) *devicechangetypes.DeviceChange {
+	return newChange(index, created, phase, state, &devicechangetypes.Change{
 		DeviceID: device,
-		Values: []*devicechange.ChangeValue{
+		Values: []*devicechangetypes.ChangeValue{
 			{
 				Path:    fmt.Sprintf("/%s", path),
 				Removed: true,
@@ -305,10 +305,10 @@ func newRemove(index network.Index, device device.ID, path string, created time.
 	})
 }
 
-func newChange(index network.Index, created time.Time, phase changetype.Phase, state changetype.State, change *devicechange.Change) *devicechange.DeviceChange {
-	return &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
-			ID:    types.ID(fmt.Sprintf("network-change-%d", index)),
+func newChange(index networkchangetypes.Index, created time.Time, phase changetype.Phase, state changetype.State, change *devicechangetypes.Change) *devicechangetypes.DeviceChange {
+	return &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
+			ID:    types.ID(fmt.Sprintf("networkchangetypes-change-%d", index)),
 			Index: types.Index(index),
 		},
 		Change: change,

--- a/pkg/controller/snapshot/device/watcher_test.go
+++ b/pkg/controller/snapshot/device/watcher_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-config/pkg/types/snapshot"
 	devicesnaptype "github.com/onosproject/onos-config/pkg/types/snapshot/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -39,7 +39,7 @@ func TestDeviceSnapshotWatcher(t *testing.T) {
 	assert.NoError(t, err)
 
 	change1 := &devicesnaptype.DeviceSnapshot{
-		DeviceID: device.ID("device-1"),
+		DeviceID: devicetopo.ID("device-1"),
 		NetworkSnapshot: devicesnaptype.NetworkSnapshotRef{
 			ID:    "snapshot-1",
 			Index: 1,
@@ -57,7 +57,7 @@ func TestDeviceSnapshotWatcher(t *testing.T) {
 	}
 
 	change2 := &devicesnaptype.DeviceSnapshot{
-		DeviceID: device.ID("device-2"),
+		DeviceID: devicetopo.ID("device-2"),
 		NetworkSnapshot: devicesnaptype.NetworkSnapshotRef{
 			ID:    "snapshot-1",
 			Index: 1,

--- a/pkg/controller/snapshot/network/controller.go
+++ b/pkg/controller/snapshot/network/controller.go
@@ -26,7 +26,7 @@ import (
 	snaptypes "github.com/onosproject/onos-config/pkg/types/snapshot"
 	devicesnaptypes "github.com/onosproject/onos-config/pkg/types/snapshot/device"
 	networksnaptypes "github.com/onosproject/onos-config/pkg/types/snapshot/network"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"time"
 )
@@ -137,8 +137,8 @@ func (r *Reconciler) reconcileRunningMark(snapshot *networksnaptypes.NetworkSnap
 // createDeviceSnapshots marks NetworkChanges for deletion and creates device snapshots
 func (r *Reconciler) createDeviceSnapshots(snapshot *networksnaptypes.NetworkSnapshot) (bool, error) {
 	// Iterate through network changes
-	deviceChanges := make(map[device.ID]networkchangetypes.Index)
-	deviceMaxChanges := make(map[device.ID]networkchangetypes.Index)
+	deviceChanges := make(map[devicetopo.ID]networkchangetypes.Index)
+	deviceMaxChanges := make(map[devicetopo.ID]networkchangetypes.Index)
 
 	// List network changes
 	changes := make(chan *networkchangetypes.NetworkChange)

--- a/pkg/controller/snapshot/network/controller_test.go
+++ b/pkg/controller/snapshot/network/controller_test.go
@@ -20,20 +20,20 @@ import (
 	networksnapstore "github.com/onosproject/onos-config/pkg/store/snapshot/network"
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-config/pkg/types/change"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	"github.com/onosproject/onos-config/pkg/types/snapshot"
 	devicesnaptype "github.com/onosproject/onos-config/pkg/types/snapshot/device"
 	networksnap "github.com/onosproject/onos-config/pkg/types/snapshot/network"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 const (
-	device1 = device.ID("device-1")
-	device2 = device.ID("device-2")
-	device3 = device.ID("device-3")
+	device1 = devicetopo.ID("device-1")
+	device2 = devicetopo.ID("device-2")
+	device3 = devicetopo.ID("device-3")
 )
 
 func TestReconcileNetworkSnapshotPhaseState(t *testing.T) {
@@ -305,30 +305,30 @@ func newStores(t *testing.T) (networkchangestore.Store, networksnapstore.Store, 
 	return networkChanges, networkSnapshots, deviceSnapshots
 }
 
-func newNetworkChange(id networkchange.ID, phase change.Phase, state change.State, devices ...device.ID) *networkchange.NetworkChange {
-	changes := make([]*devicechange.Change, len(devices))
+func newNetworkChange(id networkchangetypes.ID, phase change.Phase, state change.State, devices ...devicetopo.ID) *networkchangetypes.NetworkChange {
+	changes := make([]*devicechangetypes.Change, len(devices))
 	for i, device := range devices {
-		changes[i] = &devicechange.Change{
+		changes[i] = &devicechangetypes.Change{
 			DeviceID: device,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "foo",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},
 		}
 	}
 
-	refs := make([]*networkchange.DeviceChangeRef, len(devices))
+	refs := make([]*networkchangetypes.DeviceChangeRef, len(devices))
 	for i, device := range devices {
-		refs[i] = &networkchange.DeviceChangeRef{
+		refs[i] = &networkchangetypes.DeviceChangeRef{
 			DeviceChangeID: id.GetDeviceChangeID(device),
 		}
 	}
-	return &networkchange.NetworkChange{
+	return &networkchangetypes.NetworkChange{
 		ID:      id,
 		Changes: changes,
 		Refs:    refs,

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -25,25 +25,25 @@ package dispatcher
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/events"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 )
 
 // Dispatcher manages SB and NB configuration event listeners
 type Dispatcher struct {
-	deviceListeners        map[device.ID]chan events.ConfigEvent
+	deviceListeners        map[devicetopo.ID]chan events.ConfigEvent
 	nbiListeners           map[string]chan events.ConfigEvent
 	nbiOpStateListeners    map[string]chan events.OperationalStateEvent
-	deviceResponseListener map[device.ID]chan events.DeviceResponse
+	deviceResponseListener map[devicetopo.ID]chan events.DeviceResponse
 }
 
 // NewDispatcher creates and initializes a new event dispatcher
 func NewDispatcher() *Dispatcher {
 	return &Dispatcher{
-		deviceListeners:        make(map[device.ID]chan events.ConfigEvent),
+		deviceListeners:        make(map[devicetopo.ID]chan events.ConfigEvent),
 		nbiListeners:           make(map[string]chan events.ConfigEvent),
 		nbiOpStateListeners:    make(map[string]chan events.OperationalStateEvent),
-		deviceResponseListener: make(map[device.ID]chan events.DeviceResponse),
+		deviceResponseListener: make(map[devicetopo.ID]chan events.DeviceResponse),
 	}
 }
 
@@ -57,7 +57,7 @@ func (d *Dispatcher) Listen(changeChannel <-chan events.ConfigEvent) {
 
 	for configEvent := range changeChannel {
 		log.Info("Listener: Event ", configEvent)
-		deviceChan, ok := d.deviceListeners[device.ID(configEvent.Subject())]
+		deviceChan, ok := d.deviceListeners[devicetopo.ID(configEvent.Subject())]
 		if !ok {
 			log.Warning("Device not connected - config event discarded ", configEvent)
 		} else {
@@ -92,7 +92,7 @@ func (d *Dispatcher) ListenOperationalState(operationalStateChannel <-chan event
 
 // RegisterDevice is a way for device synchronizers to register for
 // channel of config events
-func (d *Dispatcher) RegisterDevice(id device.ID) (chan events.ConfigEvent, chan events.DeviceResponse, error) {
+func (d *Dispatcher) RegisterDevice(id devicetopo.ID) (chan events.ConfigEvent, chan events.DeviceResponse, error) {
 	if d.deviceListeners[id] != nil {
 		return nil, nil, fmt.Errorf("Device %s is already registered", id)
 	}
@@ -128,7 +128,7 @@ func (d *Dispatcher) RegisterOpState(subscriber string) (chan events.Operational
 }
 
 // UnregisterDevice closes the device config channel and removes it from the deviceListeners
-func (d *Dispatcher) UnregisterDevice(id device.ID) error {
+func (d *Dispatcher) UnregisterDevice(id devicetopo.ID) error {
 	channel, ok := d.deviceListeners[id]
 	if !ok {
 		return fmt.Errorf("Subscriber %s had not been registered", id)
@@ -186,13 +186,13 @@ func (d *Dispatcher) GetListeners() []string {
 }
 
 // HasListener returns true if the named listeners has been registered
-func (d *Dispatcher) HasListener(name device.ID) bool {
+func (d *Dispatcher) HasListener(name devicetopo.ID) bool {
 	_, ok := d.deviceListeners[name]
 	return ok
 }
 
 // GetResponseListener returns the response listener if the named listeners has been registered
-func (d *Dispatcher) GetResponseListener(name device.ID) (chan events.DeviceResponse, bool) {
+func (d *Dispatcher) GetResponseListener(name devicetopo.ID) (chan events.DeviceResponse, bool) {
 	c, ok := d.deviceResponseListener[name]
 	return c, ok
 }

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -18,8 +18,8 @@ import (
 	"encoding/base64"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"gotest.tools/assert"
 	is "gotest.tools/assert/cmp"
 	log "k8s.io/klog"
@@ -33,7 +33,7 @@ var (
 	device1Channel, device2Channel, device3Channel chan events.ConfigEvent
 	respChannel1, respChannel2, respChannel3       chan events.DeviceResponse
 	optStateChannel                                chan events.OperationalStateEvent
-	device1, device2, device3                      device.Device
+	device1, device2, device3                      devicetopo.Device
 	err                                            error
 )
 
@@ -67,9 +67,9 @@ func tearDown(t *testing.T, d *Dispatcher) {
 func TestMain(m *testing.M) {
 	log.SetOutput(os.Stdout)
 
-	device1 = device.Device{ID: "localhost-1", Address: "localhost:10161"}
-	device2 = device.Device{ID: "localhost-2", Address: "localhost:10162"}
-	device3 = device.Device{ID: "localhost-3", Address: "localhost:10163"}
+	device1 = devicetopo.Device{ID: "localhost-1", Address: "localhost:10161"}
+	device2 = devicetopo.Device{ID: "localhost-2", Address: "localhost:10162"}
+	device3 = devicetopo.Device{ID: "localhost-3", Address: "localhost:10163"}
 
 	configStoreTest, err = store.LoadConfigStore(configStoreDefaultFileName)
 	if err != nil {
@@ -105,7 +105,7 @@ func Test_getListeners(t *testing.T) {
 
 func Test_register(t *testing.T) {
 	d := setUp()
-	device4Channel, respChannel4, err := d.RegisterDevice(device.ID("device4"))
+	device4Channel, respChannel4, err := d.RegisterDevice("device4")
 	assert.NilError(t, err, "Unexpected error when registering device %s", err)
 
 	opStateChannel2, err := d.RegisterOpState("opStateTest2")
@@ -117,30 +117,30 @@ func Test_register(t *testing.T) {
 	var respChannelIf interface{} = respChannel4
 	chanTypeResp, ok := respChannelIf.(chan events.DeviceResponse)
 	assert.Assert(t, ok, "Unexpected channel type when registering device %v", chanTypeResp)
-	_ = d.UnregisterDevice(device.ID("device4"))
+	_ = d.UnregisterDevice("device4")
 
 	var opChannelIf interface{} = opStateChannel2
 	chanTypeOp, ok := opChannelIf.(chan events.OperationalStateEvent)
 	assert.Assert(t, ok, "Unexpected channel type when registering device %v", chanTypeOp)
-	_ = d.UnregisterDevice(device.ID("opStateTest2"))
+	_ = d.UnregisterDevice("opStateTest2")
 
 	tearDown(t, d)
 }
 
 func Test_unregister(t *testing.T) {
 	d := setUp()
-	err1 := d.UnregisterDevice(device.ID("device5"))
+	err1 := d.UnregisterDevice("device5")
 
-	assert.Assert(t, err1 != nil, "Unexpected lack of error when unregistering non existent device")
+	assert.Assert(t, err1 != nil, "Unexpected lack of error when unregistering non existent devicetopo")
 	assert.Assert(t, is.Contains(err1.Error(), "had not been registered"),
 		"Unexpected error text when unregistering non existent device %s", err1)
 
-	_, _, _ = d.RegisterDevice(device.ID("device6"))
-	_, _, _ = d.RegisterDevice(device.ID("device7"))
+	_, _, _ = d.RegisterDevice("device6")
+	_, _, _ = d.RegisterDevice("device7")
 
-	err2 := d.UnregisterDevice(device.ID("device6"))
+	err2 := d.UnregisterDevice("device6")
 	assert.NilError(t, err2, "Unexpected error when unregistering device6 %s", err2)
-	_ = d.UnregisterDevice(device.ID("device7"))
+	_ = d.UnregisterDevice("device7")
 
 	tearDown(t, d)
 }
@@ -207,7 +207,7 @@ func Test_listen_operational(t *testing.T) {
 	go d.ListenOperationalState(opStateCh)
 	// Send down some changes
 	event := events.NewOperationalStateEvent("foobar", "testpath",
-		types.NewTypedValueString("testValue"), events.EventItemUpdated)
+		devicechangetypes.NewTypedValueString("testValue"), events.EventItemUpdated)
 	opStateCh <- event
 
 	// Wait for the changes to get distributed
@@ -237,11 +237,11 @@ func Test_listen_none(t *testing.T) {
 func Test_register_dup(t *testing.T) {
 	d := NewDispatcher()
 	_, _ = d.RegisterNbi("nbi")
-	_, _, _ = d.RegisterDevice(device.ID("dev1"))
+	_, _, _ = d.RegisterDevice("dev1")
 	i := len(d.GetListeners())
 	_, _ = d.RegisterNbi("nbi")
 	assert.Equal(t, i, len(d.GetListeners()), "Duplicate NBI listener added")
-	_, _, _ = d.RegisterDevice(device.ID("dev1"))
+	_, _, _ = d.RegisterDevice("dev1")
 	assert.Equal(t, i, len(d.GetListeners()), "Duplicate device listener added")
 }
 

--- a/pkg/dispatcher/dispatcher_test.go
+++ b/pkg/dispatcher/dispatcher_test.go
@@ -131,7 +131,7 @@ func Test_unregister(t *testing.T) {
 	d := setUp()
 	err1 := d.UnregisterDevice("device5")
 
-	assert.Assert(t, err1 != nil, "Unexpected lack of error when unregistering non existent devicetopo")
+	assert.Assert(t, err1 != nil, "Unexpected lack of error when unregistering non existent device")
 	assert.Assert(t, is.Contains(err1.Error(), "had not been registered"),
 		"Unexpected error text when unregistering non existent device %s", err1)
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -17,7 +17,7 @@ package events
 import (
 	"encoding/base64"
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"strings"
 	"testing"
 	"time"
@@ -68,7 +68,7 @@ func Test_configEventConstruction(t *testing.T) {
 
 func Test_operationalStateEventConstruction(t *testing.T) {
 
-	event := NewOperationalStateEvent(eventSubject, path1, types.NewTypedValueString(value1), EventItemAdded)
+	event := NewOperationalStateEvent(eventSubject, path1, devicechangetypes.NewTypedValueString(value1), EventItemAdded)
 
 	assert.Equal(t, event.EventType(), EventTypeOperationalState)
 	assert.Equal(t, event.Subject(), eventSubject)

--- a/pkg/events/operationalevent.go
+++ b/pkg/events/operationalevent.go
@@ -15,7 +15,7 @@
 package events
 
 import (
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"time"
 )
 
@@ -24,12 +24,12 @@ type OperationalStateEvent interface {
 	Event
 	ItemAction() EventAction
 	Path() string
-	Value() *types.TypedValue
+	Value() *devicechangetypes.TypedValue
 }
 
 type operationalStateEventObj struct {
 	path       string
-	value      *types.TypedValue
+	value      *devicechangetypes.TypedValue
 	itemAction EventAction
 }
 
@@ -53,7 +53,7 @@ func (e operationalStateEventImpl) Path() string {
 	return ""
 }
 
-func (e operationalStateEventImpl) Value() *types.TypedValue {
+func (e operationalStateEventImpl) Value() *devicechangetypes.TypedValue {
 	oe, ok := e.object.(operationalStateEventObj)
 	if ok {
 		return oe.value
@@ -62,7 +62,7 @@ func (e operationalStateEventImpl) Value() *types.TypedValue {
 }
 
 // NewOperationalStateEvent creates a new operational state event object
-func NewOperationalStateEvent(subject string, path string, value *types.TypedValue,
+func NewOperationalStateEvent(subject string, path string, value *devicechangetypes.TypedValue,
 	eventAction EventAction) OperationalStateEvent {
 	opStateEvent := operationalStateEventImpl{
 		eventImpl: eventImpl{

--- a/pkg/manager/devicehandler.go
+++ b/pkg/manager/devicehandler.go
@@ -16,27 +16,27 @@ package manager
 
 import (
 	"github.com/onosproject/onos-config/pkg/store/device"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 )
 
 // DeviceConnected signals the corresponding topology service that the device connected.
-func (m *Manager) DeviceConnected(id devicepb.ID) (*devicepb.Device, error) {
+func (m *Manager) DeviceConnected(id devicetopo.ID) (*devicetopo.Device, error) {
 	log.Infof("Device %s connected", id)
-	return updateDevice(m.DeviceStore, id, devicepb.ConnectivityState_REACHABLE, devicepb.ChannelState_CONNECTED,
-		devicepb.ServiceState_AVAILABLE)
+	return updateDevice(m.DeviceStore, id, devicetopo.ConnectivityState_REACHABLE, devicetopo.ChannelState_CONNECTED,
+		devicetopo.ServiceState_AVAILABLE)
 }
 
 // DeviceDisconnected signal the corresponding topology service that the device disconnected.
-func (m *Manager) DeviceDisconnected(id devicepb.ID, err error) (*devicepb.Device, error) {
+func (m *Manager) DeviceDisconnected(id devicetopo.ID, err error) (*devicetopo.Device, error) {
 	log.Infof("Device %s disconnected or had error in connection %s", id, err)
 	//TODO check different possible availabilities based on error
-	return updateDevice(m.DeviceStore, id, devicepb.ConnectivityState_UNREACHABLE, devicepb.ChannelState_DISCONNECTED,
-		devicepb.ServiceState_UNAVAILABLE)
+	return updateDevice(m.DeviceStore, id, devicetopo.ConnectivityState_UNREACHABLE, devicetopo.ChannelState_DISCONNECTED,
+		devicetopo.ServiceState_UNAVAILABLE)
 }
 
-func updateDevice(deviceStore device.Store, id devicepb.ID, connectivity devicepb.ConnectivityState, channel devicepb.ChannelState,
-	service devicepb.ServiceState) (*devicepb.Device, error) {
+func updateDevice(deviceStore device.Store, id devicetopo.ID, connectivity devicetopo.ConnectivityState, channel devicetopo.ChannelState,
+	service devicetopo.ServiceState) (*devicetopo.Device, error) {
 	topoDevice, err := deviceStore.Get(id)
 	if err != nil {
 		return nil, err
@@ -45,9 +45,9 @@ func updateDevice(deviceStore device.Store, id devicepb.ID, connectivity devicep
 	if protocolState != nil {
 		topoDevice.Protocols = remove(topoDevice.Protocols, index)
 	} else {
-		protocolState = new(devicepb.ProtocolState)
+		protocolState = new(devicetopo.ProtocolState)
 	}
-	protocolState.Protocol = devicepb.Protocol_GNMI
+	protocolState.Protocol = devicetopo.Protocol_GNMI
 	protocolState.ConnectivityState = connectivity
 	protocolState.ChannelState = channel
 	protocolState.ServiceState = service
@@ -61,16 +61,16 @@ func updateDevice(deviceStore device.Store, id devicepb.ID, connectivity devicep
 	return updatedDevice, nil
 }
 
-func containsGnmi(protocols []*devicepb.ProtocolState) (*devicepb.ProtocolState, int) {
+func containsGnmi(protocols []*devicetopo.ProtocolState) (*devicetopo.ProtocolState, int) {
 	for i, p := range protocols {
-		if p.Protocol == devicepb.Protocol_GNMI {
+		if p.Protocol == devicetopo.Protocol_GNMI {
 			return p, i
 		}
 	}
 	return nil, -1
 }
 
-func remove(s []*devicepb.ProtocolState, i int) []*devicepb.ProtocolState {
+func remove(s []*devicetopo.ProtocolState, i int) []*devicetopo.ProtocolState {
 	s[i] = s[len(s)-1]
 	return s[:len(s)-1]
 }

--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change/device"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
@@ -28,7 +28,7 @@ import (
 // GetTargetConfig returns a set of change values given a target, a configuration name, a path and a layer.
 // The layer is the numbers of config changes we want to go back in time for. 0 is the latest
 // Deprecated: GetTargetConfig works on legacy, non-atomix stores
-func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, path string, layer int) ([]*types.PathValue, error) {
+func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, path string, layer int) ([]*devicechangetypes.PathValue, error) {
 	log.Info("Getting config for ", target, path)
 	//TODO the key of the config store should be a tuple of (devicename, configname) use the param
 	var config store.Configuration
@@ -40,13 +40,13 @@ func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, pa
 			}
 		}
 		if config.Name == "" {
-			return make([]*types.PathValue, 0),
+			return make([]*devicechangetypes.PathValue, 0),
 				fmt.Errorf("no Configuration found for %s", target)
 		}
 	} else if configname != "" {
 		config = m.ConfigStore.Store[configname]
 		if config.Name == "" {
-			return make([]*types.PathValue, 0),
+			return make([]*devicechangetypes.PathValue, 0),
 				fmt.Errorf("no Configuration found for %s", configname)
 		}
 	}
@@ -54,7 +54,7 @@ func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, pa
 	if len(configValues) == 0 {
 		return configValues, nil
 	}
-	filteredValues := make([]*types.PathValue, 0)
+	filteredValues := make([]*devicechangetypes.PathValue, 0)
 	pathRegexp := utils.MatchWildcardRegexp(path)
 	for _, cv := range configValues {
 		if pathRegexp.MatchString(cv.Path) {
@@ -67,7 +67,7 @@ func (m *Manager) GetTargetConfig(target string, configname store.ConfigName, pa
 
 // GetTargetNewConfig returns a set of change values given a target, a configuration name, a path and a layer.
 // The layer is the numbers of config changes we want to go back in time for. 0 is the latest (Atomix based)
-func (m *Manager) GetTargetNewConfig(target string, path string, layer int) ([]*types.PathValue, error) {
+func (m *Manager) GetTargetNewConfig(target string, path string, layer int) ([]*devicechangetypes.PathValue, error) {
 	log.Infof("Getting config for %s at %s", target, path)
 	configValues, errExtract := device.ExtractFullConfig(devicetopo.ID(target), nil, m.DeviceChangesStore, layer)
 	if errExtract != nil {
@@ -76,7 +76,7 @@ func (m *Manager) GetTargetNewConfig(target string, path string, layer int) ([]*
 	if len(configValues) == 0 {
 		return configValues, nil
 	}
-	filteredValues := make([]*types.PathValue, 0)
+	filteredValues := make([]*devicechangetypes.PathValue, 0)
 	pathRegexp := utils.MatchWildcardRegexp(path)
 	for _, cv := range configValues {
 		if pathRegexp.MatchString(cv.Path) {

--- a/pkg/manager/getstate.go
+++ b/pkg/manager/getstate.go
@@ -15,21 +15,21 @@
 package manager
 
 import (
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 )
 
 // GetTargetState returns a set of state values given a target and a path.
-func (m *Manager) GetTargetState(target string, path string) []*types.PathValue {
+func (m *Manager) GetTargetState(target string, path string) []*devicechangetypes.PathValue {
 	log.Info("Getting State for ", target, path)
-	configValues := make([]*types.PathValue, 0)
+	configValues := make([]*devicechangetypes.PathValue, 0)
 	//First check the cache, if it's not empty for this path we read that and return,
 	pathRegexp := utils.MatchWildcardRegexp(path)
-	for pathCache, value := range m.OperationalStateCache[device.ID(target)] {
+	for pathCache, value := range m.OperationalStateCache[devicetopo.ID(target)] {
 		if pathRegexp.MatchString(pathCache) {
-			configValues = append(configValues, &types.PathValue{
+			configValues = append(configValues, &devicechangetypes.PathValue{
 				Path:  pathCache,
 				Value: value,
 			})

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -30,7 +30,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/store/change/network"
-	devicelocal "github.com/onosproject/onos-config/pkg/store/device"
+	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/store/leadership"
 	"github.com/onosproject/onos-config/pkg/store/mastership"
 	devicesnap "github.com/onosproject/onos-config/pkg/store/snapshot/device"
@@ -52,7 +52,7 @@ type Manager struct {
 	LeadershipStore           leadership.Store
 	MastershipStore           mastership.Store
 	DeviceChangesStore        device.Store
-	DeviceStore               devicelocal.Store
+	DeviceStore               devicestore.Store
 	NetworkStore              *store.NetworkStore
 	NetworkChangesStore       network.Store
 	NetworkSnapshotStore      networksnap.Store
@@ -78,7 +78,7 @@ type TypeVersionInfo struct {
 
 // NewManager initializes the network config manager subsystem.
 func NewManager(configStore *store.ConfigurationStore, leadershipStore leadership.Store, mastershipStore mastership.Store,
-	deviceChangesStore device.Store, changeStore *store.ChangeStore, deviceStore devicelocal.Store, networkStore *store.NetworkStore,
+	deviceChangesStore device.Store, changeStore *store.ChangeStore, deviceStore devicestore.Store, networkStore *store.NetworkStore,
 	networkChangesStore network.Store, networkSnapshotStore networksnap.Store, deviceSnapshotStore devicesnap.Store,
 	topoCh chan *devicetopo.ListResponse) (*Manager, error) {
 	log.Info("Creating Manager")
@@ -163,7 +163,7 @@ func LoadManager(configStoreFile string, changeStoreFile string, networkStoreFil
 	}
 	log.Info("Change store loaded from ", changeStoreFile)
 
-	deviceStore, err := devicelocal.NewTopoStore(opts...)
+	deviceStore, err := devicestore.NewTopoStore(opts...)
 	if err != nil {
 		log.Error("Cannot load device store ", err)
 		return nil, err

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -30,13 +30,13 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change"
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/store/change/network"
-	devicetopo "github.com/onosproject/onos-config/pkg/store/device"
+	devicelocal "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/store/leadership"
 	"github.com/onosproject/onos-config/pkg/store/mastership"
 	devicesnap "github.com/onosproject/onos-config/pkg/store/snapshot/device"
 	networksnap "github.com/onosproject/onos-config/pkg/store/snapshot/network"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	log "k8s.io/klog"
 	"strings"
@@ -52,7 +52,7 @@ type Manager struct {
 	LeadershipStore           leadership.Store
 	MastershipStore           mastership.Store
 	DeviceChangesStore        device.Store
-	DeviceStore               devicetopo.Store
+	DeviceStore               devicelocal.Store
 	NetworkStore              *store.NetworkStore
 	NetworkChangesStore       network.Store
 	NetworkSnapshotStore      networksnap.Store
@@ -62,12 +62,12 @@ type Manager struct {
 	networkSnapshotController *controller.Controller
 	deviceSnapshotController  *controller.Controller
 	ModelRegistry             *modelregistry.ModelRegistry
-	TopoChannel               chan *devicepb.ListResponse
+	TopoChannel               chan *devicetopo.ListResponse
 	ChangesChannel            chan events.ConfigEvent
 	OperationalStateChannel   chan events.OperationalStateEvent
 	SouthboundErrorChan       chan events.DeviceResponse
 	Dispatcher                *dispatcher.Dispatcher
-	OperationalStateCache     map[devicepb.ID]devicechangetypes.TypedValueMap
+	OperationalStateCache     map[devicetopo.ID]devicechangetypes.TypedValueMap
 }
 
 //TypeVersionInfo contains the info about the device type and version
@@ -78,9 +78,9 @@ type TypeVersionInfo struct {
 
 // NewManager initializes the network config manager subsystem.
 func NewManager(configStore *store.ConfigurationStore, leadershipStore leadership.Store, mastershipStore mastership.Store,
-	deviceChangesStore device.Store, changeStore *store.ChangeStore, deviceStore devicetopo.Store, networkStore *store.NetworkStore,
+	deviceChangesStore device.Store, changeStore *store.ChangeStore, deviceStore devicelocal.Store, networkStore *store.NetworkStore,
 	networkChangesStore network.Store, networkSnapshotStore networksnap.Store, deviceSnapshotStore devicesnap.Store,
-	topoCh chan *devicepb.ListResponse) (*Manager, error) {
+	topoCh chan *devicetopo.ListResponse) (*Manager, error) {
 	log.Info("Creating Manager")
 	modelReg := &modelregistry.ModelRegistry{
 		ModelPlugins:        make(map[string]modelregistry.ModelPlugin),
@@ -111,7 +111,7 @@ func NewManager(configStore *store.ConfigurationStore, leadershipStore leadershi
 		OperationalStateChannel:   make(chan events.OperationalStateEvent, 10),
 		SouthboundErrorChan:       make(chan events.DeviceResponse, 10),
 		Dispatcher:                dispatcher.NewDispatcher(),
-		OperationalStateCache:     make(map[devicepb.ID]devicechangetypes.TypedValueMap),
+		OperationalStateCache:     make(map[devicetopo.ID]devicechangetypes.TypedValueMap),
 	}
 
 	changeIds := make([]string, 0)
@@ -147,7 +147,7 @@ func NewManager(configStore *store.ConfigurationStore, leadershipStore leadershi
 func LoadManager(configStoreFile string, changeStoreFile string, networkStoreFile string, leadershipStore leadership.Store,
 	mastershipStore mastership.Store, deviceChangesStore device.Store, networkChangesStore network.Store,
 	networkSnapshotStore networksnap.Store, deviceSnapshotStore devicesnap.Store, opts ...grpc.DialOption) (*Manager, error) {
-	topoChannel := make(chan *devicepb.ListResponse, 10)
+	topoChannel := make(chan *devicetopo.ListResponse, 10)
 
 	configStore, err := store.LoadConfigStore(configStoreFile)
 	if err != nil {
@@ -163,7 +163,7 @@ func LoadManager(configStoreFile string, changeStoreFile string, networkStoreFil
 	}
 	log.Info("Change store loaded from ", changeStoreFile)
 
-	deviceStore, err := devicetopo.NewTopoStore(opts...)
+	deviceStore, err := devicelocal.NewTopoStore(opts...)
 	if err != nil {
 		log.Error("Cannot load device store ", err)
 		return nil, err
@@ -306,7 +306,7 @@ func GetManager() *Manager {
 func listenOnResponseChannel(respChan chan events.DeviceResponse, m *Manager) {
 	log.Info("Listening for Errors in Manager")
 	for event := range respChan {
-		subject := devicepb.ID(event.Subject())
+		subject := devicetopo.ID(event.Subject())
 		switch event.EventType() {
 		case events.EventTypeDeviceConnected:
 			_, err := m.DeviceConnected(subject)
@@ -382,7 +382,7 @@ func (m *Manager) ComputeNewDeviceChange(deviceName string, version string,
 	//}
 	//TODO lost description of Change
 	changeElement := &devicechangetypes.Change{
-		DeviceID:      devicepb.ID(deviceName),
+		DeviceID:      devicetopo.ID(deviceName),
 		DeviceVersion: version,
 		Values:        newChanges,
 	}
@@ -401,7 +401,7 @@ func (m *Manager) storeChange(configChange *change.Change) (change.ID, error) {
 }
 
 //ExtractTypeAndVersion gets a deviceType and a Version based on the available store, topo and extension info
-func ExtractTypeAndVersion(target devicepb.ID, storedDevice *devicepb.Device, versionExt string, deviceTypeExt string) (TypeVersionInfo, error) {
+func ExtractTypeAndVersion(target devicetopo.ID, storedDevice *devicetopo.Device, versionExt string, deviceTypeExt string) (TypeVersionInfo, error) {
 	var (
 		deviceType string
 		version    string

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -29,7 +29,7 @@ import (
 
 // RollbackTargetConfig rollbacks the last change for a given configuration on the target. Only the last one is
 // restored to the previous state. Going back n changes in time requires n sequential calls of this method.
-// A change is created so that it can be passed down to the real devicetopo
+// A change is created so that it can be passed down to the real device
 // Deprecated: RollbackTargetConfig works on legacy, non-atomix stores
 func (m *Manager) RollbackTargetConfig(configname store.ConfigName) (change.ID, error) {
 	targetID := m.ConfigStore.Store[store.ConfigName(configname)].Device

--- a/pkg/modelregistry/jsonvalues/convertJsonRo_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonRo_test.go
@@ -19,7 +19,7 @@ import (
 	ds1 "github.com/onosproject/onos-config/modelplugin/Devicesim-1.0.0/devicesim_1_0_0"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -84,80 +84,80 @@ func Test_correctJsonPathValues(t *testing.T) {
 	// here in the intermediate jsonToValues format
 	const systemNtpAuthMismatchNoNs = "/system/ntp/state/auth-mismatch"
 	const systemNtpAuthMismatchValue = 123456.00000
-	val01 := types.PathValue{Path: systemNtpAuthMismatchNoNs,
-		Value: types.NewTypedValueFloat(systemNtpAuthMismatchValue)}
+	val01 := devicechangetypes.PathValue{Path: systemNtpAuthMismatchNoNs,
+		Value: devicechangetypes.NewTypedValueFloat(systemNtpAuthMismatchValue)}
 
 	const systemNtpEnableAuth = "/system/ntp/state/enable-ntp-auth"
 	const systemNtpEnableAuthValue = true
-	val02 := types.PathValue{Path: systemNtpEnableAuth,
-		Value: types.NewTypedValueBool(systemNtpEnableAuthValue)}
+	val02 := devicechangetypes.PathValue{Path: systemNtpEnableAuth,
+		Value: devicechangetypes.NewTypedValueBool(systemNtpEnableAuthValue)}
 
 	const systemNtpSourceAddr = "/system/ntp/state/ntp-source-address"
 	const systemNtpSourceAddrValue = "192.168.0.17"
-	val03 := types.PathValue{Path: systemNtpSourceAddr,
-		Value: types.NewTypedValueString(systemNtpSourceAddrValue)}
+	val03 := devicechangetypes.PathValue{Path: systemNtpSourceAddr,
+		Value: devicechangetypes.NewTypedValueString(systemNtpSourceAddrValue)}
 
 	const iface1Mtu = "/interfaces/interface[1]/state/mtu"
 	const iface1MtuValue = 960.0
-	val04 := types.PathValue{Path: iface1Mtu,
-		Value: types.NewTypedValueFloat(iface1MtuValue)}
+	val04 := devicechangetypes.PathValue{Path: iface1Mtu,
+		Value: devicechangetypes.NewTypedValueFloat(iface1MtuValue)}
 	const iface1Name = "/interfaces/interface[1]/name"
 	const iface1NameValue = "eth1"
-	val05 := types.PathValue{Path: iface1Name,
-		Value: types.NewTypedValueString(iface1NameValue)}
+	val05 := devicechangetypes.PathValue{Path: iface1Name,
+		Value: devicechangetypes.NewTypedValueString(iface1NameValue)}
 	const iface1Desc = "/interfaces/interface[1]/state/description"
 	const iface1DescValue = "new if desc"
-	val06 := types.PathValue{Path: iface1Desc,
-		Value: types.NewTypedValueString(iface1DescValue)}
+	val06 := devicechangetypes.PathValue{Path: iface1Desc,
+		Value: devicechangetypes.NewTypedValueString(iface1DescValue)}
 
 	const iface1Sub15IfaceIdx = "/interfaces/interface[1]/subinterfaces/subinterface[15]/state/ifindex"
 	const iface1Sub15IfaceIdxValue = 10.0
-	val07 := types.PathValue{Path: iface1Sub15IfaceIdx,
-		Value: types.NewTypedValueFloat(iface1Sub15IfaceIdxValue)}
+	val07 := devicechangetypes.PathValue{Path: iface1Sub15IfaceIdx,
+		Value: devicechangetypes.NewTypedValueFloat(iface1Sub15IfaceIdxValue)}
 	const iface1Sub15Idx = "/interfaces/interface[1]/subinterfaces/subinterface[15]/index"
 	const iface1Sub15IdxValue = "120"
-	val08 := types.PathValue{Path: iface1Sub15Idx,
-		Value: types.NewTypedValueString(iface1Sub15IdxValue)}
+	val08 := devicechangetypes.PathValue{Path: iface1Sub15Idx,
+		Value: devicechangetypes.NewTypedValueString(iface1Sub15IdxValue)}
 	const iface1Sub15AdSt = "/interfaces/interface[1]/subinterfaces/subinterface[15]/state/admin-status"
 	const iface1Sub15AdStValue = "UP"
-	val09 := types.PathValue{Path: iface1Sub15AdSt,
-		Value: types.NewTypedValueString(iface1Sub15AdStValue)}
+	val09 := devicechangetypes.PathValue{Path: iface1Sub15AdSt,
+		Value: devicechangetypes.NewTypedValueString(iface1Sub15AdStValue)}
 
 	const sysAaaGr10Svr199Ca = "/system/aaa/server-groups/server-group[10]/servers/server[199]/state/connection-aborts"
 	const sysAaaGr10Svr199CaValue = 12.00
-	val10 := types.PathValue{Path: sysAaaGr10Svr199Ca,
-		Value: types.NewTypedValueFloat(sysAaaGr10Svr199CaValue)}
+	val10 := devicechangetypes.PathValue{Path: sysAaaGr10Svr199Ca,
+		Value: devicechangetypes.NewTypedValueFloat(sysAaaGr10Svr199CaValue)}
 	const sysAaaGr10Name = "/system/aaa/server-groups/server-group[10]/name"
 	const sysAaaGr10NameValue = "g1"
-	val11 := types.PathValue{Path: sysAaaGr10Name,
-		Value: types.NewTypedValueString(sysAaaGr10NameValue)}
+	val11 := devicechangetypes.PathValue{Path: sysAaaGr10Name,
+		Value: devicechangetypes.NewTypedValueString(sysAaaGr10NameValue)}
 	const sysAaaGr10Svr199Addr = "/system/aaa/server-groups/server-group[10]/servers/server[199]/address"
 	const sysAaaGr10Svr199AddrValue = "192.168.0.7"
-	val12 := types.PathValue{Path: sysAaaGr10Svr199Addr,
-		Value: types.NewTypedValueString(sysAaaGr10Svr199AddrValue)}
+	val12 := devicechangetypes.PathValue{Path: sysAaaGr10Svr199Addr,
+		Value: devicechangetypes.NewTypedValueString(sysAaaGr10Svr199AddrValue)}
 
 	const sysAaaGr12Svr199Ca = "/system/aaa/server-groups/server-group[12]/servers/server[199]/state/connection-aborts"
 	const sysAaaGr12Svr199CaValue = 4.0
-	val13 := types.PathValue{Path: sysAaaGr12Svr199Ca,
-		Value: types.NewTypedValueFloat(sysAaaGr12Svr199CaValue)}
+	val13 := devicechangetypes.PathValue{Path: sysAaaGr12Svr199Ca,
+		Value: devicechangetypes.NewTypedValueFloat(sysAaaGr12Svr199CaValue)}
 	const sysAaaGr12Name = "/system/aaa/server-groups/server-group[12]/name"
 	const sysAaaGr12NameValue = "g2"
-	val14 := types.PathValue{Path: sysAaaGr12Name,
-		Value: types.NewTypedValueString(sysAaaGr12NameValue)}
+	val14 := devicechangetypes.PathValue{Path: sysAaaGr12Name,
+		Value: devicechangetypes.NewTypedValueString(sysAaaGr12NameValue)}
 	const sysAaaGr12Svr199Addr = "/system/aaa/server-groups/server-group[12]/servers/server[199]/address"
 	const sysAaaGr12Svr199AddrValue = "192.168.0.4"
-	val15 := types.PathValue{Path: sysAaaGr12Svr199Addr,
-		Value: types.NewTypedValueString(sysAaaGr12Svr199AddrValue)}
+	val15 := devicechangetypes.PathValue{Path: sysAaaGr12Svr199Addr,
+		Value: devicechangetypes.NewTypedValueString(sysAaaGr12Svr199AddrValue)}
 
 	const sysAaaGr12Svr200Ca = "/system/aaa/server-groups/server-group[12]/servers/server[200]/state/connection-aborts"
 	const sysAaaGr12Svr200CaValue = 5.0
-	val16 := types.PathValue{Path: sysAaaGr12Svr200Ca,
-		Value: types.NewTypedValueFloat(sysAaaGr12Svr200CaValue)}
+	val16 := devicechangetypes.PathValue{Path: sysAaaGr12Svr200Ca,
+		Value: devicechangetypes.NewTypedValueFloat(sysAaaGr12Svr200CaValue)}
 	const sysAaaGr12Svr200Addr = "/system/aaa/server-groups/server-group[12]/servers/server[200]/address"
 	const sysAaaGr12Svr200AddrValue = "192.168.0.5"
-	val17 := types.PathValue{Path: sysAaaGr12Svr200Addr,
-		Value: types.NewTypedValueString(sysAaaGr12Svr200AddrValue)}
-	jsonPathValues := []*types.PathValue{&val01, &val02, &val03, &val04,
+	val17 := devicechangetypes.PathValue{Path: sysAaaGr12Svr200Addr,
+		Value: devicechangetypes.NewTypedValueString(sysAaaGr12Svr200AddrValue)}
+	jsonPathValues := []*devicechangetypes.PathValue{&val01, &val02, &val03, &val04,
 		&val05, &val06, &val07, &val08, &val09, &val10, &val11, &val12, &val13,
 		&val14, &val15, &val16, &val17}
 
@@ -179,45 +179,45 @@ func Test_correctJsonPathValues(t *testing.T) {
 		const sysAaaGrG2Srv5Ca = "/system/aaa/server-groups/server-group[name=g2]/servers/server[address=192.168.0.5]/state/connection-aborts"
 		switch correctedPathValue.Path {
 		case systemNtpAuthMismatchNoNs:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(systemNtpAuthMismatchValue))
+			assert.Equal(t, (*devicechangetypes.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(systemNtpAuthMismatchValue))
 		case systemNtpEnableAuth:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_BOOL)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_BOOL)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedBool)(correctedPathValue.GetValue()).Bool(), true)
+			assert.Equal(t, (*devicechangetypes.TypedBool)(correctedPathValue.GetValue()).Bool(), true)
 		case systemNtpSourceAddr:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 			assert.Equal(t, correctedPathValue.GetValue().ValueToString(), systemNtpSourceAddrValue)
 		case ifEth1Mtu:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(iface1MtuValue))
+			assert.Equal(t, (*devicechangetypes.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(iface1MtuValue))
 		case ifEth1Desc:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 			assert.Equal(t, correctedPathValue.GetValue().ValueToString(), iface1DescValue)
 		case ifEth1Sub120IfIdx:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(iface1Sub15IfaceIdxValue))
+			assert.Equal(t, (*devicechangetypes.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(iface1Sub15IfaceIdxValue))
 		case ifEth1Sub120AdSt:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 			assert.Equal(t, correctedPathValue.GetValue().ValueToString(), iface1Sub15AdStValue)
 		case sysAaaGrG1Srv7Ca:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(sysAaaGr10Svr199CaValue))
+			assert.Equal(t, (*devicechangetypes.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(sysAaaGr10Svr199CaValue))
 		case sysAaaGrG2Srv4Ca:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(sysAaaGr12Svr199CaValue))
+			assert.Equal(t, (*devicechangetypes.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(sysAaaGr12Svr199CaValue))
 		case sysAaaGrG2Srv5Ca:
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
-			assert.Equal(t, (*types.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(sysAaaGr12Svr200CaValue))
+			assert.Equal(t, (*devicechangetypes.TypedUint64)(correctedPathValue.GetValue()).Uint(), uint(sysAaaGr12Svr200CaValue))
 		default:
 			t.Fatal("Unexpected path", correctedPathValue.Path)
 		}
@@ -275,14 +275,14 @@ func Test_correctJsonPathValues2(t *testing.T) {
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=1]/state/address",
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=1]/state/aux-id",
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=1]/state/port":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		case
 			"/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=0]/state/priority",
 			"/system/openflow/controllers/controller[name=main]/connections/connection[aux-id=1]/state/priority",
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=0]/state/priority",
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=1]/state/priority":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		default:
 			t.Fatal("Unexpected path", correctedPathValue.Path)

--- a/pkg/modelregistry/jsonvalues/convertJsonRw_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonRw_test.go
@@ -19,7 +19,7 @@ import (
 	td1 "github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/goyang/pkg/yang"
 	"gotest.tools/assert"
 	"io/ioutil"
@@ -60,18 +60,18 @@ func Test_correctJsonPathRwValuesSubInterfaces(t *testing.T) {
 			"/interfaces/interface[name=eth1]/config/description",
 			"/interfaces/interface[name=eth1]/subinterfaces/subinterface[index=120]/config/description",
 			"/interfaces/interface[name=eth1]/subinterfaces/subinterface[index=121]/config/description":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		case
 			"/interfaces/interface[name=eth1]/subinterfaces/subinterface[index=120]/config/enabled",
 			"/interfaces/interface[name=eth1]/subinterfaces/subinterface[index=121]/config/enabled":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_BOOL, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_BOOL, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		case
 			"/interfaces/interface[name=eth1]/config/mtu",
 			"/interfaces/interface[name=eth1]/hold-time/config/down",
 			"/interfaces/interface[name=eth1]/hold-time/config/up":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		default:
 			t.Fatal("Unexpected path", correctedPathValue.Path)
@@ -112,7 +112,7 @@ func Test_correctJsonPathRwValuesSystemLogging(t *testing.T) {
 			"/system/logging/remote-servers/remote-server[host=h1]/selectors/selector[facility=1,severity=2]/config/facility",
 			"/system/logging/console/selectors/selector[facility=3,severity=4]/config/facility",
 			"/system/logging/console/selectors/selector[facility=3,severity=4]/config/severity":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		default:
 			t.Fatal("Unexpected path", correctedPathValue.Path)
@@ -148,12 +148,12 @@ func Test_correctJsonPathRwValues2(t *testing.T) {
 		switch correctedPathValue.Path {
 		case
 			"/cont1a/cont2a/leaf2a":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 			assert.Equal(t, correctedPathValue.GetValue().ValueToString(), "12")
 		case
 			"/cont1a/cont2a/leaf2b":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_FLOAT, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_FLOAT, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 			assert.Equal(t, correctedPathValue.GetValue().ValueToString(), "1.210000")
 		default:

--- a/pkg/modelregistry/jsonvalues/convertJsonTdRo_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonTdRo_test.go
@@ -19,7 +19,7 @@ import (
 	td1 "github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -95,11 +95,11 @@ func Test_correctJsonPathValuesTd(t *testing.T) {
 			"/cont1a/cont2a/leaf2c",
 			"/cont1b-state/list2b[index=100]/leaf3c",
 			"/cont1b-state/list2b[index=101]/leaf3c":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_STRING, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_STRING, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		case
 			"/cont1b-state/leaf2d":
-			assert.Equal(t, correctedPathValue.GetValue().GetType(), types.ValueType_UINT, correctedPathValue.Path)
+			assert.Equal(t, correctedPathValue.GetValue().GetType(), devicechangetypes.ValueType_UINT, correctedPathValue.Path)
 			assert.Equal(t, len(correctedPathValue.GetValue().GetTypeOpts()), 0)
 		default:
 			t.Fatal("Unexpected path", correctedPathValue.Path)

--- a/pkg/modelregistry/jsonvalues/convertjson.go
+++ b/pkg/modelregistry/jsonvalues/convertjson.go
@@ -17,7 +17,7 @@ package jsonvalues
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"regexp"
 	"sort"
 	"strings"
@@ -34,10 +34,10 @@ type indexEntry struct {
 // CorrectJSONPaths takes configuration values extracted from a json, of which we are not sure about the type and,
 // through the model plugin assigns them the correct type according to the YANG model provided, returning an
 // updated set of configuration values.
-func CorrectJSONPaths(jsonBase string, jsonPathValues []*types.PathValue,
-	paths modelregistry.PathMap, stripNamespaces bool) ([]*types.PathValue, error) {
+func CorrectJSONPaths(jsonBase string, jsonPathValues []*devicechangetypes.PathValue,
+	paths modelregistry.PathMap, stripNamespaces bool) ([]*devicechangetypes.PathValue, error) {
 
-	correctedPathValues := make([]*types.PathValue, 0)
+	correctedPathValues := make([]*devicechangetypes.PathValue, 0)
 	rOnIndex := regexp.MustCompile(matchOnIndex)
 	rOnNamespace := regexp.MustCompile(matchNamespace)
 	indexMap := make(map[string][]string)
@@ -101,7 +101,7 @@ func CorrectJSONPaths(jsonBase string, jsonPathValues []*types.PathValue,
 					return nil, err
 				}
 				jsonPathValue.Value = newTypeValue
-				err = types.IsPathValid(jsonPathValue.Path)
+				err = devicechangetypes.IsPathValid(jsonPathValue.Path)
 				if err != nil {
 					return nil, fmt.Errorf("invalid value %s", err)
 				}
@@ -113,11 +113,11 @@ func CorrectJSONPaths(jsonBase string, jsonPathValues []*types.PathValue,
 				if err != nil {
 					return nil, err
 				}
-				cv := types.PathValue{
+				cv := devicechangetypes.PathValue{
 					Path:  jsonPathStr,
 					Value: newTypeValue,
 				}
-				err = types.IsPathValid(cv.Path)
+				err = devicechangetypes.IsPathValid(cv.Path)
 				if err != nil {
 					return nil, fmt.Errorf("invalid value %s", err)
 				}
@@ -127,8 +127,8 @@ func CorrectJSONPaths(jsonBase string, jsonPathValues []*types.PathValue,
 				hasPrefixMultipleIdx(modelPathOnlySecondIndex, jsonPathIdx) {
 				indexName := jsonPathIdx[strings.LastIndex(jsonPathIdx, "[")+1:]
 				index := jsonPathValue.GetValue().ValueToString()
-				if jsonPathValue.GetValue().GetType() == types.ValueType_FLOAT {
-					index = fmt.Sprintf("%.0f", (*types.TypedFloat)(jsonPathValue.GetValue()).Float32())
+				if jsonPathValue.GetValue().GetType() == devicechangetypes.ValueType_FLOAT {
+					index = fmt.Sprintf("%.0f", (*devicechangetypes.TypedFloat)(jsonPathValue.GetValue()).Float32())
 				}
 				jsonRoPath := jsonPathStr[:strings.LastIndex(jsonPathStr, "/")]
 				idx, ok := indexMap[jsonRoPath]
@@ -184,7 +184,7 @@ func extractIndices(indexStr string) []string {
 }
 
 func assignModelType(paths modelregistry.PathMap, modelPath string,
-	jsonPathValue *types.PathValue) (*types.TypedValue, error) {
+	jsonPathValue *devicechangetypes.PathValue) (*devicechangetypes.TypedValue, error) {
 
 	modelType, err := paths.TypeForPath(modelPath)
 	if err != nil {
@@ -199,32 +199,32 @@ func assignModelType(paths modelregistry.PathMap, modelPath string,
 	return newTypeValue, nil
 }
 
-func pathType(jsonPathValue *types.PathValue, spType types.ValueType) (*types.TypedValue, error) {
-	var newTypeValue *types.TypedValue
+func pathType(jsonPathValue *devicechangetypes.PathValue, spType devicechangetypes.ValueType) (*devicechangetypes.TypedValue, error) {
+	var newTypeValue *devicechangetypes.TypedValue
 	var err error
 	switch jsonPathValue.Value.Type {
-	case types.ValueType_FLOAT:
+	case devicechangetypes.ValueType_FLOAT:
 		// Could be int, uint, or float from json - convert to numeric
-		floatVal := (*types.TypedFloat)(jsonPathValue.Value).Float32()
+		floatVal := (*devicechangetypes.TypedFloat)(jsonPathValue.Value).Float32()
 
 		switch spType {
-		case types.ValueType_FLOAT:
+		case devicechangetypes.ValueType_FLOAT:
 			newTypeValue = jsonPathValue.GetValue()
-		case types.ValueType_INT:
-			newTypeValue = types.NewTypedValueInt64(int(floatVal))
-		case types.ValueType_UINT:
-			newTypeValue = types.NewTypedValueUint64(uint(floatVal))
-			//case types.ValueTypeDECIMAL:
+		case devicechangetypes.ValueType_INT:
+			newTypeValue = devicechangetypes.NewTypedValueInt64(int(floatVal))
+		case devicechangetypes.ValueType_UINT:
+			newTypeValue = devicechangetypes.NewTypedValueUint64(uint(floatVal))
+			//case devicechangetypes.ValueTypeDECIMAL:
 			// TODO add a conversion from float to D64 will also need number of decimal places from Read Only SubPath
-			//	newTypeValue = types.NewTypedValueDecimal64()
-		case types.ValueType_STRING:
-			newTypeValue = types.NewTypedValueString(fmt.Sprintf("%.0f", float64(floatVal)))
+			//	newTypeValue = devicechangetypes.NewTypedValueDecimal64()
+		case devicechangetypes.ValueType_STRING:
+			newTypeValue = devicechangetypes.NewTypedValueString(fmt.Sprintf("%.0f", float64(floatVal)))
 		default:
 			newTypeValue = jsonPathValue.GetValue()
 		}
 
 	default:
-		newTypeValue, err = types.NewTypedValue(jsonPathValue.GetValue().GetBytes(), spType, []int32{})
+		newTypeValue, err = devicechangetypes.NewTypedValue(jsonPathValue.GetValue().GetBytes(), spType, []int32{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/modelregistry/modelregistry.go
+++ b/pkg/modelregistry/modelregistry.go
@@ -16,7 +16,7 @@ package modelregistry
 
 import (
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
@@ -31,7 +31,7 @@ import (
 // PathMap is an interface that is implemented by ReadOnly- and ReadWrite- PathMaps
 type PathMap interface {
 	JustPaths() []string
-	TypeForPath(path string) (types.ValueType, error)
+	TypeForPath(path string) (devicechangetypes.ValueType, error)
 }
 
 // GetStateMode defines the Getstate handling
@@ -55,7 +55,7 @@ const (
 
 // ReadOnlyAttrib is the known metadata about a Read Only leaf
 type ReadOnlyAttrib struct {
-	Datatype    types.ValueType
+	Datatype    devicechangetypes.ValueType
 	Description string
 	Units       string
 }
@@ -82,7 +82,7 @@ func (ro ReadOnlyPathMap) JustPaths() []string {
 }
 
 // TypeForPath finds the type from the model for a particular path
-func (ro ReadOnlyPathMap) TypeForPath(path string) (types.ValueType, error) {
+func (ro ReadOnlyPathMap) TypeForPath(path string) (devicechangetypes.ValueType, error) {
 	for k, subPaths := range ro {
 		for k1, sp := range subPaths {
 			if k1 == "/" {
@@ -96,12 +96,12 @@ func (ro ReadOnlyPathMap) TypeForPath(path string) (types.ValueType, error) {
 			}
 		}
 	}
-	return types.ValueType_EMPTY, fmt.Errorf("path %s not found in RO paths of model", path)
+	return devicechangetypes.ValueType_EMPTY, fmt.Errorf("path %s not found in RO paths of model", path)
 }
 
 // ReadWritePathElem holds data about a leaf or container
 type ReadWritePathElem struct {
-	ValueType   types.ValueType
+	ValueType   devicechangetypes.ValueType
 	Units       string
 	Description string
 	Mandatory   bool
@@ -126,13 +126,13 @@ func (rw ReadWritePathMap) JustPaths() []string {
 }
 
 // TypeForPath finds the type from the model for a particular path
-func (rw ReadWritePathMap) TypeForPath(path string) (types.ValueType, error) {
+func (rw ReadWritePathMap) TypeForPath(path string) (devicechangetypes.ValueType, error) {
 	for k, elem := range rw {
 		if k == path {
 			return elem.ValueType, nil
 		}
 	}
-	return types.ValueType_EMPTY, fmt.Errorf("path %s not found in RW paths of model", path)
+	return devicechangetypes.ValueType_EMPTY, fmt.Errorf("path %s not found in RW paths of model", path)
 }
 
 // ModelRegistry is the object for the saving information about device models
@@ -396,42 +396,42 @@ func PathsRW(rwPathMap ReadWritePathMap) []string {
 	return keys
 }
 
-func toValueType(entry *yang.YangType, isLeafList bool) (types.ValueType, error) {
-	//TODO evaluate better types and error return
+func toValueType(entry *yang.YangType, isLeafList bool) (devicechangetypes.ValueType, error) {
+	//TODO evaluate better devicechangetypes and error return
 	switch entry.Name {
 	case "int8", "int16", "int32", "int64":
 		if isLeafList {
-			return types.ValueType_LEAFLIST_INT, nil
+			return devicechangetypes.ValueType_LEAFLIST_INT, nil
 		}
-		return types.ValueType_INT, nil
+		return devicechangetypes.ValueType_INT, nil
 	case "uint8", "uint16", "uint32", "uint64", "counter64":
 		if isLeafList {
-			return types.ValueType_LEAFLIST_UINT, nil
+			return devicechangetypes.ValueType_LEAFLIST_UINT, nil
 		}
-		return types.ValueType_UINT, nil
+		return devicechangetypes.ValueType_UINT, nil
 	case "decimal64":
 		if isLeafList {
-			return types.ValueType_LEAFLIST_DECIMAL, nil
+			return devicechangetypes.ValueType_LEAFLIST_DECIMAL, nil
 		}
-		return types.ValueType_DECIMAL, nil
+		return devicechangetypes.ValueType_DECIMAL, nil
 	case "string", "enumeration", "leafref", "identityref", "union", "instance-identifier":
 		if isLeafList {
-			return types.ValueType_LEAFLIST_STRING, nil
+			return devicechangetypes.ValueType_LEAFLIST_STRING, nil
 		}
-		return types.ValueType_STRING, nil
+		return devicechangetypes.ValueType_STRING, nil
 	case "boolean":
 		if isLeafList {
-			return types.ValueType_LEAFLIST_BOOL, nil
+			return devicechangetypes.ValueType_LEAFLIST_BOOL, nil
 		}
-		return types.ValueType_BOOL, nil
+		return devicechangetypes.ValueType_BOOL, nil
 	case "bits", "binary":
 		if isLeafList {
-			return types.ValueType_LEAFLIST_BYTES, nil
+			return devicechangetypes.ValueType_LEAFLIST_BYTES, nil
 		}
-		return types.ValueType_BYTES, nil
+		return devicechangetypes.ValueType_BYTES, nil
 	case "empty":
-		return types.ValueType_EMPTY, nil
+		return devicechangetypes.ValueType_EMPTY, nil
 	default:
-		return types.ValueType_STRING, nil
+		return devicechangetypes.ValueType_STRING, nil
 	}
 }

--- a/pkg/modelregistry/modelregistryDeviceSim1_test.go
+++ b/pkg/modelregistry/modelregistryDeviceSim1_test.go
@@ -16,7 +16,7 @@ package modelregistry
 
 import (
 	ds1 "github.com/onosproject/onos-config/modelplugin/Devicesim-1.0.0/devicesim_1_0_0"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/goyang/pkg/yang"
 	"gotest.tools/assert"
 	"testing"
@@ -206,6 +206,6 @@ func Test_SchemaDeviceSim(t *testing.T) {
 
 	logSvrSelFacName, logSvrSelFacNameOk := readWritePathsDeviceSim1["/system/logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/config/facility"]
 	assert.Assert(t, logSvrSelFacNameOk, "expected to get /system/logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/config/facility")
-	assert.Equal(t, logSvrSelFacName.ValueType, types.ValueType_STRING, "expected /system/logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/config/facility to be STRING")
+	assert.Equal(t, logSvrSelFacName.ValueType, devicechangetypes.ValueType_STRING, "expected /system/logging/remote-servers/remote-server[host=*]/selectors/selector[facility severity=*]/config/facility to be STRING")
 
 }

--- a/pkg/modelregistry/modelregistryTestDevice1_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice1_test.go
@@ -16,7 +16,7 @@ package modelregistry
 
 import (
 	td1 "github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/goyang/pkg/yang"
 	"gotest.tools/assert"
 	"testing"
@@ -49,7 +49,7 @@ func Test_SchemaTestDevice1(t *testing.T) {
 	assert.Equal(t, len(leaf2c), 1, "expected /cont1a/cont2a/leaf2c to have only 1 subpath")
 	leaf2cVt, leaf2cVtOk := leaf2c["/"]
 	assert.Assert(t, leaf2cVtOk, "expected /cont1a/cont2a/leaf2c to have subpath /")
-	assert.Equal(t, leaf2cVt.Datatype, types.ValueType_STRING)
+	assert.Equal(t, leaf2cVt.Datatype, devicechangetypes.ValueType_STRING)
 	assert.Equal(t, leaf2cVt.Description, "") // TODO: When YGOT is updated to extract description then update this
 	assert.Equal(t, leaf2cVt.Units, "")
 
@@ -59,15 +59,15 @@ func Test_SchemaTestDevice1(t *testing.T) {
 
 	cont1bVt, cont1bVtOk := cont1b["/leaf2d"]
 	assert.Assert(t, cont1bVtOk, "expected /cont1b-state to have subpath /leaf2d")
-	assert.Equal(t, cont1bVt.Datatype, types.ValueType_UINT)
+	assert.Equal(t, cont1bVt.Datatype, devicechangetypes.ValueType_UINT)
 
 	l2bIdxVt, l2bIdxVtOk := cont1b["/list2b[index=*]/index"]
 	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
-	assert.Equal(t, l2bIdxVt.Datatype, types.ValueType_UINT)
+	assert.Equal(t, l2bIdxVt.Datatype, devicechangetypes.ValueType_UINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1b["/list2b[index=*]/leaf3c"]
 	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
-	assert.Equal(t, l2bLeaf3cVt.Datatype, types.ValueType_STRING)
+	assert.Equal(t, l2bLeaf3cVt.Datatype, devicechangetypes.ValueType_STRING)
 
 	////////////////////////////////////////////////////
 	/// Read write paths
@@ -97,23 +97,23 @@ func Test_SchemaTestDevice1(t *testing.T) {
 
 	list2aName, list2aNameOk := readWritePathsTestDevice1["/cont1a/list2a[name=*]/name"]
 	assert.Assert(t, list2aNameOk, "expected to get /cont1a/list2a[name=*]/name")
-	assert.Equal(t, list2aName.ValueType, types.ValueType_STRING, "expected /cont1a/list2a[name=*]/name to be STRING")
+	assert.Equal(t, list2aName.ValueType, devicechangetypes.ValueType_STRING, "expected /cont1a/list2a[name=*]/name to be STRING")
 	assert.Equal(t, len(list2aName.Length), 1, "expected 1 length terms")
 	assert.Equal(t, list2aName.Length[0], "4..8", "expected length 0 to be 4..8")
 
 	list2aTxp, list2aTxpOk := readWritePathsTestDevice1["/cont1a/list2a[name=*]/tx-power"]
 	assert.Assert(t, list2aTxpOk, "expected to get /cont1a/list2a[name=*]/tx-power")
-	assert.Equal(t, list2aTxp.ValueType, types.ValueType_UINT, "expected /cont1a/list2a[name=*]/tx-power to be UINT")
+	assert.Equal(t, list2aTxp.ValueType, devicechangetypes.ValueType_UINT, "expected /cont1a/list2a[name=*]/tx-power to be UINT")
 	assert.Equal(t, len(list2aTxp.Range), 1, "expected 1 range terms")
 	assert.Equal(t, list2aTxp.Range[0], "1..20", "expected range 0 to be 1..20")
 
 	leaf1a, leaf1aOk := readWritePathsTestDevice1["/cont1a/leaf1a"]
 	assert.Assert(t, leaf1aOk, "expected to get /cont1a/leaf1a")
-	assert.Equal(t, leaf1a.ValueType, types.ValueType_STRING, "expected /cont1a/leaf1a to be STRING")
+	assert.Equal(t, leaf1a.ValueType, devicechangetypes.ValueType_STRING, "expected /cont1a/leaf1a to be STRING")
 
 	leaf2a, leaf2aOk := readWritePathsTestDevice1["/cont1a/cont2a/leaf2a"]
 	assert.Assert(t, leaf2aOk, "expected to get /cont1a/cont2a/leaf2a")
-	assert.Equal(t, leaf2a.ValueType, types.ValueType_UINT, "expected /cont1a/cont2a/leaf2a to be UINT")
+	assert.Equal(t, leaf2a.ValueType, devicechangetypes.ValueType_UINT, "expected /cont1a/cont2a/leaf2a to be UINT")
 	assert.Equal(t, leaf2a.Default, "2", "expected default 2")
 	assert.Equal(t, leaf2a.Description, "", "expected description to be blank - boo for YGOT - hopefully should get description sometime")
 	assert.Equal(t, leaf2a.Units, "", "expected units to be blank - boo for YGOT - hopefully should get units sometime")
@@ -123,29 +123,29 @@ func Test_SchemaTestDevice1(t *testing.T) {
 
 	leaf2b, leaf2bOk := readWritePathsTestDevice1["/cont1a/cont2a/leaf2b"]
 	assert.Assert(t, leaf2bOk, "expected to get /cont1a/cont2a/leaf2b")
-	assert.Equal(t, leaf2b.ValueType, types.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2b to be DECIMAL")
+	assert.Equal(t, leaf2b.ValueType, devicechangetypes.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2b to be DECIMAL")
 	assert.Equal(t, len(leaf2b.Range), 1, "expected 1 range term")
 	assert.Equal(t, leaf2b.Range[0], "0.001..2.000", "expected range 0 to be 0.001..2.000")
 
 	leaf2d, leaf2dOk := readWritePathsTestDevice1["/cont1a/cont2a/leaf2d"]
 	assert.Assert(t, leaf2dOk, "expected to get /cont1a/cont2a/leaf2d")
-	assert.Equal(t, leaf2d.ValueType, types.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2d to be DECIMAL")
+	assert.Equal(t, leaf2d.ValueType, devicechangetypes.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2d to be DECIMAL")
 
 	leaf2e, leaf2eOk := readWritePathsTestDevice1["/cont1a/cont2a/leaf2e"]
 	assert.Assert(t, leaf2eOk, "expected to get /cont1a/cont2a/leaf2e")
-	assert.Equal(t, leaf2e.ValueType, types.ValueType_LEAFLIST_INT, "expected /cont1a/cont2a/leaf2d to be Leaf List INT")
+	assert.Equal(t, leaf2e.ValueType, devicechangetypes.ValueType_LEAFLIST_INT, "expected /cont1a/cont2a/leaf2d to be Leaf List INT")
 	assert.Equal(t, len(leaf2e.Range), 1, "expected 1 range term")
 	assert.Equal(t, leaf2e.Range[0], "-100..200", "expected range 0 to be -100..200")
 
 	leaf2f, leaf2fOk := readWritePathsTestDevice1["/cont1a/cont2a/leaf2f"]
 	assert.Assert(t, leaf2fOk, "expected to get /cont1a/cont2a/leaf2f")
-	assert.Equal(t, leaf2f.ValueType, types.ValueType_BYTES, "expected /cont1a/cont2a/leaf2f to be BYTES")
+	assert.Equal(t, leaf2f.ValueType, devicechangetypes.ValueType_BYTES, "expected /cont1a/cont2a/leaf2f to be BYTES")
 
 	leaf2g, leaf2gOk := readWritePathsTestDevice1["/cont1a/cont2a/leaf2g"]
 	assert.Assert(t, leaf2gOk, "expected to get /cont1a/cont2a/leaf2g")
-	assert.Equal(t, leaf2g.ValueType, types.ValueType_BOOL, "expected /cont1a/cont2a/leaf2g to be BOOL")
+	assert.Equal(t, leaf2g.ValueType, devicechangetypes.ValueType_BOOL, "expected /cont1a/cont2a/leaf2g to be BOOL")
 
 	leafTopLevel, leafTopLevelOk := readWritePathsTestDevice1["/leafAtTopLevel"]
 	assert.Assert(t, leafTopLevelOk, "expected to get /leafAtTopLevel")
-	assert.Equal(t, leafTopLevel.ValueType, types.ValueType_STRING, "expected /leafAtTopLevel to be STRING")
+	assert.Equal(t, leafTopLevel.ValueType, devicechangetypes.ValueType_STRING, "expected /leafAtTopLevel to be STRING")
 }

--- a/pkg/modelregistry/modelregistryTestDevice2_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice2_test.go
@@ -16,7 +16,7 @@ package modelregistry
 
 import (
 	td2 "github.com/onosproject/onos-config/modelplugin/TestDevice-2.0.0/testdevice_2_0_0"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/goyang/pkg/yang"
 	"gotest.tools/assert"
 	"testing"
@@ -46,7 +46,7 @@ func Test_SchemaTestDevice2(t *testing.T) {
 	assert.Equal(t, len(leaf2c), 1, "expected /cont1a/cont2a/leaf2c to have only 1 subpath")
 	leaf2cVt, leaf2cVtOk := leaf2c["/"]
 	assert.Assert(t, leaf2cVtOk, "expected /cont1a/cont2a/leaf2c to have subpath /")
-	assert.Equal(t, leaf2cVt.Datatype, types.ValueType_STRING)
+	assert.Equal(t, leaf2cVt.Datatype, devicechangetypes.ValueType_STRING)
 
 	cont1b, cont1bOk := readOnlyPathsTestDevice2["/cont1b-state"]
 	assert.Assert(t, cont1bOk, "expected to get /cont1b-state")
@@ -54,15 +54,15 @@ func Test_SchemaTestDevice2(t *testing.T) {
 
 	cont1bVt, cont1bVtOk := cont1b["/leaf2d"]
 	assert.Assert(t, cont1bVtOk, "expected /cont1b-state to have subpath /leaf2d")
-	assert.Equal(t, cont1bVt.Datatype, types.ValueType_UINT)
+	assert.Equal(t, cont1bVt.Datatype, devicechangetypes.ValueType_UINT)
 
 	l2bIdxVt, l2bIdxVtOk := cont1b["/list2b[index=*]/index"]
 	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
-	assert.Equal(t, l2bIdxVt.Datatype, types.ValueType_UINT)
+	assert.Equal(t, l2bIdxVt.Datatype, devicechangetypes.ValueType_UINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1b["/list2b[index=*]/leaf3c"]
 	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
-	assert.Equal(t, l2bLeaf3cVt.Datatype, types.ValueType_STRING)
+	assert.Equal(t, l2bLeaf3cVt.Datatype, devicechangetypes.ValueType_STRING)
 
 	////////////////////////////////////////////////////
 	/// Read write paths
@@ -93,46 +93,46 @@ func Test_SchemaTestDevice2(t *testing.T) {
 
 	list2aName, list2aNameOk := readWritePathsTestDevice2["/cont1a/list2a[name=*]/name"]
 	assert.Assert(t, list2aNameOk, "expected to get /cont1a/list2a[name=*]/name")
-	assert.Equal(t, list2aName.ValueType, types.ValueType_STRING, "expected /cont1a/list2a[name=*]/name to be STRING")
+	assert.Equal(t, list2aName.ValueType, devicechangetypes.ValueType_STRING, "expected /cont1a/list2a[name=*]/name to be STRING")
 
 	list2aTxp, list2aTxpOk := readWritePathsTestDevice2["/cont1a/list2a[name=*]/tx-power"]
 	assert.Assert(t, list2aTxpOk, "expected to get /cont1a/list2a[name=*]/tx-power")
-	assert.Equal(t, list2aTxp.ValueType, types.ValueType_UINT, "expected /cont1a/list2a[name=*]/tx-power to be UINT")
+	assert.Equal(t, list2aTxp.ValueType, devicechangetypes.ValueType_UINT, "expected /cont1a/list2a[name=*]/tx-power to be UINT")
 
 	list2aRxp, list2aRxpOk := readWritePathsTestDevice2["/cont1a/list2a[name=*]/rx-power"]
 	assert.Assert(t, list2aRxpOk, "expected to get /cont1a/list2a[name=*]/rx-power")
-	assert.Equal(t, list2aRxp.ValueType, types.ValueType_UINT, "expected /cont1a/list2a[name=*]/rx-power to be UINT")
+	assert.Equal(t, list2aRxp.ValueType, devicechangetypes.ValueType_UINT, "expected /cont1a/list2a[name=*]/rx-power to be UINT")
 
 	leaf1a, leaf1aOk := readWritePathsTestDevice2["/cont1a/leaf1a"]
 	assert.Assert(t, leaf1aOk, "expected to get /cont1a/leaf1a")
-	assert.Equal(t, leaf1a.ValueType, types.ValueType_STRING, "expected /cont1a/leaf1a to be STRING")
+	assert.Equal(t, leaf1a.ValueType, devicechangetypes.ValueType_STRING, "expected /cont1a/leaf1a to be STRING")
 
 	leaf2a, leaf2aOk := readWritePathsTestDevice2["/cont1a/cont2a/leaf2a"]
 	assert.Assert(t, leaf2aOk, "expected to get /cont1a/cont2a/leaf2a")
-	assert.Equal(t, leaf2a.ValueType, types.ValueType_UINT, "expected /cont1a/cont2a/leaf2a to be UINT")
+	assert.Equal(t, leaf2a.ValueType, devicechangetypes.ValueType_UINT, "expected /cont1a/cont2a/leaf2a to be UINT")
 
 	leaf2b, leaf2bOk := readWritePathsTestDevice2["/cont1a/cont2a/leaf2b"]
 	assert.Assert(t, leaf2bOk, "expected to get /cont1a/cont2a/leaf2b")
-	assert.Equal(t, leaf2b.ValueType, types.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2b to be DECIMAL")
+	assert.Equal(t, leaf2b.ValueType, devicechangetypes.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2b to be DECIMAL")
 
 	leaf2d, leaf2dOk := readWritePathsTestDevice2["/cont1a/cont2a/leaf2d"]
 	assert.Assert(t, leaf2dOk, "expected to get /cont1a/cont2a/leaf2d")
-	assert.Equal(t, leaf2d.ValueType, types.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2d to be DECIMAL")
+	assert.Equal(t, leaf2d.ValueType, devicechangetypes.ValueType_DECIMAL, "expected /cont1a/cont2a/leaf2d to be DECIMAL")
 
 	leaf2e, leaf2eOk := readWritePathsTestDevice2["/cont1a/cont2a/leaf2e"]
 	assert.Assert(t, leaf2eOk, "expected to get /cont1a/cont2a/leaf2e")
-	assert.Equal(t, leaf2e.ValueType, types.ValueType_LEAFLIST_INT, "expected /cont1a/cont2a/leaf2d to be Leaf List INT")
+	assert.Equal(t, leaf2e.ValueType, devicechangetypes.ValueType_LEAFLIST_INT, "expected /cont1a/cont2a/leaf2d to be Leaf List INT")
 
 	leaf2f, leaf2fOk := readWritePathsTestDevice2["/cont1a/cont2a/leaf2f"]
 	assert.Assert(t, leaf2fOk, "expected to get /cont1a/cont2a/leaf2f")
-	assert.Equal(t, leaf2f.ValueType, types.ValueType_BYTES, "expected /cont1a/cont2a/leaf2f to be BYTES")
+	assert.Equal(t, leaf2f.ValueType, devicechangetypes.ValueType_BYTES, "expected /cont1a/cont2a/leaf2f to be BYTES")
 
 	leaf2g, leaf2gOk := readWritePathsTestDevice2["/cont1a/cont2a/leaf2g"]
 	assert.Assert(t, leaf2gOk, "expected to get /cont1a/cont2a/leaf2g")
-	assert.Equal(t, leaf2g.ValueType, types.ValueType_BOOL, "expected /cont1a/cont2a/leaf2g to be BOOL")
+	assert.Equal(t, leaf2g.ValueType, devicechangetypes.ValueType_BOOL, "expected /cont1a/cont2a/leaf2g to be BOOL")
 
 	leafTopLevel, leafTopLevelOk := readWritePathsTestDevice2["/leafAtTopLevel"]
 	assert.Assert(t, leafTopLevelOk, "expected to get /leafAtTopLevel")
-	assert.Equal(t, leafTopLevel.ValueType, types.ValueType_STRING, "expected /leafAtTopLevel to be STRING")
+	assert.Equal(t, leafTopLevel.ValueType, devicechangetypes.ValueType_STRING, "expected /leafAtTopLevel to be STRING")
 
 }

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -17,7 +17,7 @@ package modelregistry
 import (
 	"fmt"
 	ds1 "github.com/onosproject/onos-config/modelplugin/Devicesim-1.0.0/devicesim_1_0_0"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -116,15 +116,15 @@ func Test_JustPaths(t *testing.T) {
 func Test_TypeForPath(t *testing.T) {
 	modelType1, err := readOnlyPaths.TypeForPath("/system/clock/state/timezone-name")
 	assert.NilError(t, err, "Unexpected error on TypeForPath RO")
-	assert.Equal(t, modelType1, types.ValueType_STRING)
+	assert.Equal(t, modelType1, devicechangetypes.ValueType_STRING)
 
 	modelType2, err := readWritePaths.TypeForPath("/system/clock/config/timezone-name")
 	assert.NilError(t, err, "Unexpected error on TypeForPath RW")
-	assert.Equal(t, modelType2, types.ValueType_STRING)
+	assert.Equal(t, modelType2, devicechangetypes.ValueType_STRING)
 
 	modelType3, err := readWritePaths.TypeForPath("/system/clock/config/timezone-name1")
 	assert.ErrorContains(t, err, "not found in RW paths of model")
-	assert.Equal(t, modelType3, types.ValueType_EMPTY)
+	assert.Equal(t, modelType3, devicechangetypes.ValueType_EMPTY)
 }
 
 func Test_Schema(t *testing.T) {

--- a/pkg/northbound/diags/diags.go
+++ b/pkg/northbound/diags/diags.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onosproject/onos-config/pkg/northbound/admin"
 	"github.com/onosproject/onos-config/pkg/store"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
 	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	"github.com/onosproject/onos-config/pkg/utils"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
@@ -145,7 +144,7 @@ func (s Server) GetOpState(r *OpStateRequest, stream OpStateDiags_GetOpStateServ
 	}
 
 	for path, value := range deviceCache {
-		pathValue := &types.PathValue{
+		pathValue := &devicechangetypes.PathValue{
 			Path:  path,
 			Value: value,
 		}
@@ -175,7 +174,7 @@ func (s Server) GetOpState(r *OpStateRequest, stream OpStateDiags_GetOpStateServ
 				log.Infof("Event received NBI Diags OpState subscribe channel %s for %s",
 					streamID, r.DeviceId)
 
-				pathValue := &types.PathValue{
+				pathValue := &devicechangetypes.PathValue{
 					Path:  opStateEvent.Path(),
 					Value: opStateEvent.Value(),
 				}

--- a/pkg/northbound/diags/diags_test.go
+++ b/pkg/northbound/diags/diags_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/northbound"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"google.golang.org/grpc"
 	"gotest.tools/assert"
 	"io"
@@ -125,7 +125,7 @@ func Test_GetOpState_DeviceSubscribe(t *testing.T) {
 
 		switch pv.GetPath() {
 		case "/cont1a/cont2a/leaf2c":
-			assert.Equal(t, pv.GetValue().GetType(), types.ValueType_STRING)
+			assert.Equal(t, pv.GetValue().GetType(), devicechangetypes.ValueType_STRING)
 			switch pv.GetValue().ValueToString() {
 			case "test1":
 				//From the initial response
@@ -139,7 +139,7 @@ func Test_GetOpState_DeviceSubscribe(t *testing.T) {
 				t.Fatal("Unexpected value for", pv.Path, pv.GetValue().ValueToString())
 			}
 		case "/cont1b-state/leaf2d":
-			assert.Equal(t, pv.GetValue().GetType(), types.ValueType_UINT)
+			assert.Equal(t, pv.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 			assert.Equal(t, pv.GetValue().ValueToString(), "12345")
 		default:
 			t.Fatal("Unexpected path in opstate cache for Device2", pv.Path)

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -26,9 +26,9 @@ import (
 	"time"
 
 	"github.com/onosproject/onos-config/pkg/manager"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 )
@@ -39,7 +39,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 
 	prefix := req.GetPrefix()
 
-	disconnectedDevicesMap := make(map[device.ID]bool)
+	disconnectedDevicesMap := make(map[devicetopo.ID]bool)
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -54,13 +54,13 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 			target = prefix.GetTarget()
 		}
 		//if target is already disconnected we don't do a get again.
-		_, ok := disconnectedDevicesMap[device.ID(target)]
+		_, ok := disconnectedDevicesMap[devicetopo.ID(target)]
 		if !ok {
-			_, errGet := manager.GetManager().DeviceStore.Get(device.ID(target))
+			_, errGet := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
 
 			if errGet != nil && status.Convert(errGet).Code() == codes.NotFound {
 				log.Infof("Device is not connected %s, %s", target, errGet)
-				disconnectedDevicesMap[device.ID(path.GetTarget())] = true
+				disconnectedDevicesMap[devicetopo.ID(path.GetTarget())] = true
 			} else if errGet != nil {
 				//handling gRPC errors
 				return nil, errGet
@@ -82,12 +82,12 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		}
 		target := prefix.GetTarget()
 		//if target is already disconnected we don't do a get again.
-		_, ok := disconnectedDevicesMap[device.ID(target)]
+		_, ok := disconnectedDevicesMap[devicetopo.ID(target)]
 		if !ok {
-			_, errGet := manager.GetManager().DeviceStore.Get(device.ID(target))
+			_, errGet := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
 			if errGet != nil && status.Convert(errGet).Code() == codes.NotFound {
 				log.Infof("Device is not connected %s, %s", target, errGet)
-				disconnectedDevicesMap[device.ID(target)] = true
+				disconnectedDevicesMap[devicetopo.ID(target)] = true
 			} else if errGet != nil {
 				//handling gRPC errors
 				return nil, errGet
@@ -187,7 +187,7 @@ func getUpdate(prefix *gnmi.Path, path *gnmi.Path) (*gnmi.Update, error) {
 	return buildUpdate(prefix, path, configValues)
 }
 
-func buildUpdate(prefix *gnmi.Path, path *gnmi.Path, configValues []*types.PathValue) (*gnmi.Update, error) {
+func buildUpdate(prefix *gnmi.Path, path *gnmi.Path, configValues []*devicechangetypes.PathValue) (*gnmi.Update, error) {
 	var value *gnmi.TypedValue
 	var err error
 	if len(configValues) == 0 {

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -19,8 +19,8 @@ import (
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/manager"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"os"
 	"sync"
@@ -85,7 +85,7 @@ func setUp(t *testing.T) (*Server, *manager.Manager, *MockStores) {
 	go mgr.Dispatcher.Listen(mgr.ChangesChannel)
 
 	mockStores.DeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(device devicepb.ID, c chan<- *devicechange.DeviceChange) error {
+		func(device devicetopo.ID, c chan<- *devicechangetypes.DeviceChange) error {
 			close(c)
 			return nil
 		}).AnyTimes()
@@ -105,7 +105,7 @@ func tearDown(mgr *manager.Manager, wg *sync.WaitGroup) {
 
 }
 
-func listenToTopoLoading(deviceChan <-chan *devicepb.ListResponse) {
+func listenToTopoLoading(deviceChan <-chan *devicetopo.ListResponse) {
 	for deviceConfigEvent := range deviceChan {
 		log.Info("Ignoring event for testing ", deviceConfigEvent)
 	}

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-config/pkg/manager"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -118,7 +118,7 @@ func Test_doSingleSet(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, len(newChange.Config), 1)
 	assert.Equal(t, newChange.Config[0].Path, "/cont1a/cont2a/leaf2a")
-	assert.Equal(t, (*types.TypedUint64)(newChange.Config[0].GetValue()).Uint(), uint(16))
+	assert.Equal(t, (*devicechangetypes.TypedUint64)(newChange.Config[0].GetValue()).Uint(), uint(16))
 }
 
 // Test_doSingleSet shows how a value of 1 list can be set on a target
@@ -205,7 +205,7 @@ func Test_doSingleSetList(t *testing.T) {
 	assert.Assert(t, ok)
 	assert.Equal(t, len(newChange.Config), 1)
 	assert.Equal(t, newChange.Config[0].Path, "/cont1a/list2a[name=a/b]/tx-power")
-	assert.Equal(t, (*types.TypedUint64)(newChange.Config[0].GetValue()).Uint(), uint(16))
+	assert.Equal(t, (*devicechangetypes.TypedUint64)(newChange.Config[0].GetValue()).Uint(), uint(16))
 }
 
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -145,7 +145,7 @@ func listenOnChannel(stream gnmi.GNMI_SubscribeServer, mgr *manager.Manager, has
 
 func collector(stream gnmi.GNMI_SubscribeServer, request *gnmi.SubscriptionList, resChan chan result, mode gnmi.SubscriptionList_Mode) {
 	for _, sub := range request.Subscription {
-		//We get the stated of the devicetopo, for each path we build an update and send it out.
+		//We get the stated of the device, for each path we build an update and send it out.
 		update, err := getUpdate(request.Prefix, sub.Path)
 		if err != nil {
 			log.Error("Error while collecting data for subscribe once or poll ", err)

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -21,10 +21,10 @@ import (
 	"github.com/onosproject/onos-config/pkg/manager"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"google.golang.org/grpc/codes"
@@ -145,7 +145,7 @@ func listenOnChannel(stream gnmi.GNMI_SubscribeServer, mgr *manager.Manager, has
 
 func collector(stream gnmi.GNMI_SubscribeServer, request *gnmi.SubscriptionList, resChan chan result, mode gnmi.SubscriptionList_Mode) {
 	for _, sub := range request.Subscription {
-		//We get the stated of the device, for each path we build an update and send it out.
+		//We get the stated of the devicetopo, for each path we build an update and send it out.
 		update, err := getUpdate(request.Prefix, sub.Path)
 		if err != nil {
 			log.Error("Error while collecting data for subscribe once or poll ", err)
@@ -183,7 +183,7 @@ func listenForUpdates(changeChan chan events.ConfigEvent, stream gnmi.GNMI_Subsc
 		if targetPresent && changeInternal != nil {
 			//if the device is registered it has a listener, if not we assume the device is not in the system and
 			// send an immediate response
-			respChan, ok := mgr.Dispatcher.GetResponseListener(device.ID(target))
+			respChan, ok := mgr.Dispatcher.GetResponseListener(devicetopo.ID(target))
 			if ok {
 				go listenForDeviceUpdates(respChan, changeInternal, subs, target, stream, resChan)
 			} else {
@@ -267,7 +267,7 @@ func matchRegex(path string, subs []*regexp.Regexp) bool {
 	return false
 }
 
-func buildAndSendUpdate(pathGnmi *gnmi.Path, target string, value *types.TypedValue, stream gnmi.GNMI_SubscribeServer) error {
+func buildAndSendUpdate(pathGnmi *gnmi.Path, target string, value *devicechangetypes.TypedValue, stream gnmi.GNMI_SubscribeServer) error {
 	pathGnmi.Target = target
 	var response *gnmi.SubscribeResponse
 	var errGet error
@@ -335,7 +335,7 @@ func buildSubscribeResponse(notification *gnmi.Notification, target string) (*gn
 	response := &gnmi.SubscribeResponse{
 		Response: responseUpdate,
 	}
-	_, errDevice := manager.GetManager().DeviceStore.Get(device.ID(target))
+	_, errDevice := manager.GetManager().DeviceStore.Get(devicetopo.ID(target))
 	if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
 		response.Extension = []*gnmi_ext.Extension{
 			{

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -220,9 +220,9 @@ func Test_WrongDevice(t *testing.T) {
 	targets["Device1"] = struct{}{}
 	subs = append(subs, utils.MatchWildcardRegexp("/cont1a/*/leaf3c"))
 	go listenForUpdates(changeChan, serverFake, mgr, targets, subs, resChan)
-	config1Value05, _ := types.NewChangeValue("/cont1a/cont2a/leaf2c", types.NewTypedValueString("def"), false)
-	config1Value09, _ := types.NewChangeValue("/cont1a/list2a[name=txout2]", types.NewTypedValueEmpty(), true)
-	change1, _ := change.NewChange([]*types.ChangeValue{config1Value05, config1Value09}, "Remove txout 2")
+	config1Value05, _ := devicechangetypes.NewChangeValue("/cont1a/cont2a/leaf2c", devicechangetypes.NewTypedValueString("def"), false)
+	config1Value09, _ := devicechangetypes.NewChangeValue("/cont1a/list2a[name=txout2]", devicechangetypes.NewTypedValueEmpty(), true)
+	change1, _ := change.NewChange([]*devicechangetypes.ChangeValue{config1Value05, config1Value09}, "Remove txout 2")
 	changeChan <- events.NewConfigEvent("Device1", change1.ID, true)
 	select {
 	case response = <-responsesChan:
@@ -261,9 +261,9 @@ func Test_WrongPath(t *testing.T) {
 	subsStr := make([]*regexp.Regexp, 0)
 	subsStr = append(subsStr, utils.MatchWildcardRegexp(subscriptionPathStr))
 	go listenForUpdates(changeChan, serverFake, mgr, targets, subsStr, resChan)
-	config1Value05, _ := types.NewChangeValue("/test1:cont1a/cont2a/leaf2c", types.NewTypedValueString("def"), false)
-	config1Value09, _ := types.NewChangeValue("/test1:cont1a/list2a[name=txout2]", types.NewTypedValueEmpty(), true)
-	change1, _ := change.NewChange([]*types.ChangeValue{config1Value05, config1Value09}, "Remove txout 2")
+	config1Value05, _ := devicechangetypes.NewChangeValue("/test1:cont1a/cont2a/leaf2c", devicechangetypes.NewTypedValueString("def"), false)
+	config1Value09, _ := devicechangetypes.NewChangeValue("/test1:cont1a/list2a[name=txout2]", devicechangetypes.NewTypedValueEmpty(), true)
+	change1, _ := change.NewChange([]*devicechangetypes.ChangeValue{config1Value05, config1Value09}, "Remove txout 2")
 	changeChan <- events.NewConfigEvent("Device1", change1.ID, true)
 	select {
 	case response = <-responsesChan:
@@ -441,8 +441,8 @@ func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
 	server, mgr, mockStores := setUp(t)
 
 	targetStr := "Device1"
-	target := device.ID(targetStr)
-	presentDevice := &device.Device{
+	target := devicetopo.ID(targetStr)
+	presentDevice := &devicetopo.Device{
 		ID: target,
 	}
 

--- a/pkg/northbound/testUtils.go
+++ b/pkg/northbound/testUtils.go
@@ -21,8 +21,8 @@ import (
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/manager"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	log "k8s.io/klog"
 	"sync"
@@ -55,11 +55,11 @@ func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) *manage
 		log.Error("Unable to load manager")
 	}
 
-	opStateValuesDevice2 := make(map[string]*types.TypedValue)
-	opStateValuesDevice2["/cont1a/cont2a/leaf2c"] = types.NewTypedValueString("test1")
-	opStateValuesDevice2["/cont1b-state/leaf2d"] = types.NewTypedValueUint64(12345)
+	opStateValuesDevice2 := make(map[string]*devicechangetypes.TypedValue)
+	opStateValuesDevice2["/cont1a/cont2a/leaf2c"] = devicechangetypes.NewTypedValueString("test1")
+	opStateValuesDevice2["/cont1b-state/leaf2d"] = devicechangetypes.NewTypedValueUint64(12345)
 
-	manager.GetManager().OperationalStateCache[device.ID("Device2")] = opStateValuesDevice2
+	manager.GetManager().OperationalStateCache[devicetopo.ID("Device2")] = opStateValuesDevice2
 	go manager.GetManager().Dispatcher.ListenOperationalState(manager.GetManager().OperationalStateChannel)
 
 	config := NewServerConfig("", "", "")
@@ -87,14 +87,14 @@ func SetUpServer(port int16, service Service, waitGroup *sync.WaitGroup) *manage
 		time.Sleep(100 * time.Millisecond)
 		opStateEventWrong := events.NewOperationalStateEvent("Device1",
 			"/cont1a/cont2a/leaf2d",
-			types.NewTypedValueString("testNotRelevant"),
+			devicechangetypes.NewTypedValueString("testNotRelevant"),
 			events.EventItemUpdated)
 		manager.GetManager().OperationalStateChannel <- opStateEventWrong
 
 		time.Sleep(100 * time.Millisecond)
 		opStateEvent := events.NewOperationalStateEvent("Device2",
 			"/cont1a/cont2a/leaf2c",
-			types.NewTypedValueString("test2"),
+			devicechangetypes.NewTypedValueString("test2"),
 			events.EventItemUpdated)
 		manager.GetManager().OperationalStateChannel <- opStateEvent
 	}()

--- a/pkg/southbound/clientManager.go
+++ b/pkg/southbound/clientManager.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/certs"
 	"github.com/onosproject/onos-config/pkg/utils"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"io/ioutil"
 	log "k8s.io/klog"
 	"strings"
@@ -35,7 +35,7 @@ import (
 
 var targets = make(map[DeviceID]interface{})
 
-func createDestination(device devicepb.Device) (*client.Destination, DeviceID) {
+func createDestination(device devicetopo.Device) (*client.Destination, DeviceID) {
 	d := &client.Destination{}
 	d.Addrs = []string{device.Address}
 	d.Target = device.Target
@@ -93,7 +93,7 @@ func GetTarget(key DeviceID) (*Target, error) {
 // ConnectTarget connects to a given Device according to the passed information establishing a channel to it.
 //TODO make asyc
 //TODO lock channel to allow one request to device at each time
-func (target *Target) ConnectTarget(ctx context.Context, device devicepb.Device) (DeviceID, error) {
+func (target *Target) ConnectTarget(ctx context.Context, device devicetopo.Device) (DeviceID, error) {
 	dest, key := createDestination(device)
 	c, err := GnmiClientFactory(ctx, *dest)
 

--- a/pkg/southbound/clientManager_test.go
+++ b/pkg/southbound/clientManager_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/onosproject/onos-config/pkg/utils"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/client"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"gotest.tools/assert"
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	device                    devicepb.Device
+	device                    devicetopo.Device
 	saveGnmiClientFactory     func(ctx context.Context, d client.Destination) (GnmiClient, error)
 	saveGnmiBaseClientFactory func() BaseClientInterface
 )
@@ -121,11 +121,11 @@ func setUp(t *testing.T) {
 	}
 
 	timeout := 10 * time.Second
-	device = devicepb.Device{
-		ID:      devicepb.ID("localhost-1"),
+	device = devicetopo.Device{
+		ID:      devicetopo.ID("localhost-1"),
 		Address: "localhost:10161",
 		Version: "1.0.0",
-		Credentials: devicepb.Credentials{
+		Credentials: devicetopo.Credentials{
 			User:     "devicesim",
 			Password: "notused",
 		},

--- a/pkg/southbound/defs.go
+++ b/pkg/southbound/defs.go
@@ -16,7 +16,7 @@ package southbound
 
 import (
 	"context"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/client"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 )
@@ -28,7 +28,7 @@ type DeviceID struct {
 
 // TargetIf defines the API for Target
 type TargetIf interface {
-	ConnectTarget(ctx context.Context, device devicepb.Device) (DeviceID, error)
+	ConnectTarget(ctx context.Context, device devicetopo.Device) (DeviceID, error)
 	//Capabilities(ctx context.Context, request *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error)
 	CapabilitiesWithString(ctx context.Context, request string) (*gpb.CapabilityResponse, error)
 	Get(ctx context.Context, request *gpb.GetRequest) (*gpb.GetResponse, error)

--- a/pkg/southbound/synchronizer/factory_test.go
+++ b/pkg/southbound/synchronizer/factory_test.go
@@ -19,19 +19,18 @@ import (
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/store"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"gotest.tools/assert"
 	"testing"
 	"time"
 )
 
 func factorySetUp() (*store.ChangeStore, *store.ConfigurationStore,
-	chan *devicepb.ListResponse, chan<- events.OperationalStateEvent,
+	chan *devicetopo.ListResponse, chan<- events.OperationalStateEvent,
 	chan events.DeviceResponse, *dispatcher.Dispatcher,
-	*modelregistry.ModelRegistry, map[device.ID]types.TypedValueMap, error) {
+	*modelregistry.ModelRegistry, map[devicetopo.ID]devicechangetypes.TypedValueMap, error) {
 
 	changeStore, err := store.LoadChangeStore("../../../configs/changeStore-sample.json")
 	if err != nil {
@@ -44,9 +43,9 @@ func factorySetUp() (*store.ChangeStore, *store.ConfigurationStore,
 
 	dispatcher := dispatcher.NewDispatcher()
 	modelregistry := new(modelregistry.ModelRegistry)
-	opStateCache := make(map[device.ID]types.TypedValueMap)
+	opStateCache := make(map[devicetopo.ID]devicechangetypes.TypedValueMap)
 	return &changeStore, &configStore,
-		make(chan *devicepb.ListResponse),
+		make(chan *devicetopo.ListResponse),
 		make(chan events.OperationalStateEvent),
 		make(chan events.DeviceResponse),
 		dispatcher, modelregistry, opStateCache, nil
@@ -75,21 +74,21 @@ func TestFactory_Revert(t *testing.T) {
 
 	timeout := time.Millisecond * 500
 	device1NameStr := "factoryTd"
-	device1 := device.Device{
-		ID:          device.ID(device1NameStr),
+	device1 := devicetopo.Device{
+		ID:          devicetopo.ID(device1NameStr),
 		Revision:    0,
 		Address:     "1.2.3.4:11161",
 		Target:      "",
 		Version:     "1.0.0",
 		Timeout:     &timeout,
-		Credentials: device.Credentials{},
-		TLS:         device.TlsConfig{},
+		Credentials: devicetopo.Credentials{},
+		TLS:         devicetopo.TlsConfig{},
 		Type:        "TestDevice",
 		Role:        "leaf",
 		Attributes:  nil,
 	}
-	topoEvent := devicepb.ListResponse{
-		Type:   devicepb.ListResponse_ADDED,
+	topoEvent := devicetopo.ListResponse{
+		Type:   devicetopo.ListResponse_ADDED,
 		Device: &device1,
 	}
 

--- a/pkg/store/change/change.go
+++ b/pkg/store/change/change.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"io"
 	"sort"
 	"time"
@@ -40,7 +40,7 @@ type Change struct {
 	ID          ID
 	Description string
 	Created     time.Time
-	Config      []*types.ChangeValue
+	Config      []*devicechangetypes.ChangeValue
 }
 
 // Stringer method for the Change
@@ -77,7 +77,7 @@ func (c Change) IsValid() error {
 // the description or the time. This way changes that have an identical meaning
 // can be identified
 // Deprecated: NewChange is method for creating a legacy internal Change
-func NewChange(config []*types.ChangeValue, desc string) (*Change, error) {
+func NewChange(config []*devicechangetypes.ChangeValue, desc string) (*Change, error) {
 	h := sha1.New()
 	t := time.Now()
 
@@ -122,7 +122,7 @@ func NewChange(config []*types.ChangeValue, desc string) (*Change, error) {
 // the description or the time. This way changes that have an identical meaning
 // can be identified
 // Deprecated: NewChangeValuesNoRemoval is method for creating a legacy internal Change
-func NewChangeValuesNoRemoval(config []*types.PathValue, desc string) (*Change, error) {
+func NewChangeValuesNoRemoval(config []*devicechangetypes.PathValue, desc string) (*Change, error) {
 	h := sha1.New()
 	t := time.Now()
 
@@ -150,10 +150,10 @@ func NewChangeValuesNoRemoval(config []*types.PathValue, desc string) (*Change, 
 
 	hash := h.Sum(nil)
 
-	configColl := make([]*types.ChangeValue, 0)
+	configColl := make([]*devicechangetypes.ChangeValue, 0)
 
 	for _, c := range config {
-		configColl = append(configColl, &types.ChangeValue{
+		configColl = append(configColl, &devicechangetypes.ChangeValue{
 			Path:    c.GetPath(),
 			Value:   c.GetValue(),
 			Removed: false})

--- a/pkg/store/change/change_test.go
+++ b/pkg/store/change/change_test.go
@@ -18,7 +18,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"encoding/json"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	"io"
 	log "k8s.io/klog"
@@ -66,23 +66,23 @@ const (
 func TestMain(m *testing.M) {
 	var err error
 	log.SetOutput(os.Stdout)
-	config1Value01, _ := types.NewChangeValue(Test1Cont1A, types.NewTypedValueEmpty(), false)
-	config1Value02, _ := types.NewChangeValue(Test1Cont1ACont2A, types.NewTypedValueEmpty(), false)
-	config1Value03, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2A, types.NewTypedValueUint64(ValueLeaf2A13), false)
-	config1Value04, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2B, types.NewTypedValueDecimal64(ValueLeaf2B159D, ValueLeaf2B159P), false)
-	config1Value05, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2C, types.NewTypedValueString(ValueLeaf2CAbc), false)
-	config1Value06, _ := types.NewChangeValue(Test1Cont1ALeaf1A, types.NewTypedValueString(ValueLeaf1AAbcdef), false)
-	config1Value07, _ := types.NewChangeValue(Test1Cont1AList2ATxout1, types.NewTypedValueEmpty(), false)
-	config1Value08, _ := types.NewChangeValue(Test1Cont1AList2ATxout1Txpwr, types.NewTypedValueUint64(ValueTxout1Txpwr8), false)
-	config1Value09, _ := types.NewChangeValue(Test1Cont1AList2ATxout2, types.NewTypedValueEmpty(), false)
-	config1Value10, _ := types.NewChangeValue(Test1Cont1AList2ATxout2Txpwr, types.NewTypedValueUint64(ValueTxout2Txpwr10), false)
-	config1Value11, _ := types.NewChangeValue(Test1Leaftoplevel, types.NewTypedValueString(ValueLeaftopWxy1234), false)
-	config1Value12, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2D, types.NewTypedValueBool(true), false)
-	config1Value13, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2E, types.NewLeafListInt64Tv([]int{ValueLeaf2E1, ValueLeaf2E2, ValueLeaf2E3}), false)
+	config1Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1A, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value02, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2A, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value03, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2A, devicechangetypes.NewTypedValueUint64(ValueLeaf2A13), false)
+	config1Value04, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechangetypes.NewTypedValueDecimal64(ValueLeaf2B159D, ValueLeaf2B159P), false)
+	config1Value05, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString(ValueLeaf2CAbc), false)
+	config1Value06, _ := devicechangetypes.NewChangeValue(Test1Cont1ALeaf1A, devicechangetypes.NewTypedValueString(ValueLeaf1AAbcdef), false)
+	config1Value07, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout1, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value08, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout1Txpwr, devicechangetypes.NewTypedValueUint64(ValueTxout1Txpwr8), false)
+	config1Value09, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout2, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value10, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout2Txpwr, devicechangetypes.NewTypedValueUint64(ValueTxout2Txpwr10), false)
+	config1Value11, _ := devicechangetypes.NewChangeValue(Test1Leaftoplevel, devicechangetypes.NewTypedValueString(ValueLeaftopWxy1234), false)
+	config1Value12, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2D, devicechangetypes.NewTypedValueBool(true), false)
+	config1Value13, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2E, devicechangetypes.NewLeafListInt64Tv([]int{ValueLeaf2E1, ValueLeaf2E2, ValueLeaf2E3}), false)
 	valueLeaf2FBa, _ := base64.StdEncoding.DecodeString(ValueLeaf2F)
-	config1Value14, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2F, types.NewTypedValueBytes(valueLeaf2FBa), false)
+	config1Value14, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2F, devicechangetypes.NewTypedValueBytes(valueLeaf2FBa), false)
 
-	change1, err = NewChange([]*types.ChangeValue{
+	change1, err = NewChange([]*devicechangetypes.ChangeValue{
 		config1Value01, config1Value02, config1Value03, config1Value04, config1Value05,
 		config1Value06, config1Value07, config1Value08, config1Value09, config1Value10,
 		config1Value11, config1Value12, config1Value13, config1Value14,
@@ -100,11 +100,11 @@ func Test_ConfigValue(t *testing.T) {
 	path := "/cont1a/cont2a/leaf2a"
 	value := 13
 
-	configValue2a, _ := types.NewChangeValue(path, types.NewTypedValueUint64(uint(value)), false)
+	configValue2a, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueUint64(uint(value)), false)
 
 	assert.Equal(t, configValue2a.Path, path)
 	assert.Equal(t, configValue2a.GetValue().ValueToString(), "13")
-	assert.Equal(t, configValue2a.GetValue().GetType(), types.ValueType_UINT)
+	assert.Equal(t, configValue2a.GetValue().GetType(), devicechangetypes.ValueType_UINT)
 	assert.Equal(t, configValue2a.GetPath(), "/cont1a/cont2a/leaf2a")
 	assert.Equal(t, configValue2a.GetRemoved(), false)
 }
@@ -141,35 +141,35 @@ func Test_changecreation(t *testing.T) {
 
 func Test_badpath(t *testing.T) {
 	badpath := "does_not_have_any_slash"
-	conf1, err1 := types.NewChangeValue(badpath, types.NewTypedValueString("123"), false)
+	conf1, err1 := devicechangetypes.NewChangeValue(badpath, devicechangetypes.NewTypedValueString("123"), false)
 
 	assert.Error(t, err1, badpath, "Expected error on ", badpath)
 
 	assert.Assert(t, conf1 == nil, "Expected config to be empty on error")
 
 	badpath = "//two/contiguous/slashes"
-	_, err2 := types.NewChangeValue(badpath, types.NewTypedValueString("123"), false)
+	_, err2 := devicechangetypes.NewChangeValue(badpath, devicechangetypes.NewTypedValueString("123"), false)
 	assert.ErrorContains(t, err2, badpath, "Expected error on path", badpath)
 
 	badpath = "/test*"
-	_, err3 := types.NewChangeValue(badpath, types.NewTypedValueString("123"), false)
+	_, err3 := devicechangetypes.NewChangeValue(badpath, devicechangetypes.NewTypedValueString("123"), false)
 	assert.ErrorContains(t, err3, badpath, "Expected error on path", badpath)
 }
 
 func Test_changeValueString(t *testing.T) {
-	cv1, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2A, types.NewTypedValueUint64(123), false)
+	cv1, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2A, devicechangetypes.NewTypedValueUint64(123), false)
 
 	assert.Equal(t, cv1.GetValue().ValueToString(), "123",
 		"Expected changeValue to produce string")
 }
 
 func Test_changeString(t *testing.T) {
-	cv1, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2A, types.NewTypedValueUint64(123), false)
-	cv2, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2B, types.NewTypedValueString("ABC"), false)
-	cv3, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2C, types.NewTypedValueString("Hello"), false)
-	cv4, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2D, types.NewTypedValueBool(true), false)
+	cv1, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2A, devicechangetypes.NewTypedValueUint64(123), false)
+	cv2, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechangetypes.NewTypedValueString("ABC"), false)
+	cv3, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString("Hello"), false)
+	cv4, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2D, devicechangetypes.NewTypedValueBool(true), false)
 
-	changeObj, _ := NewChange([]*types.ChangeValue{cv1, cv2, cv3, cv4}, "Test Change")
+	changeObj, _ := NewChange([]*devicechangetypes.ChangeValue{cv1, cv2, cv3, cv4}, "Test Change")
 
 	var expected = `"Config":[` +
 		`{"Path":"/cont1a/cont2a/leaf2a","Value":{"Bytes":"ewAAAAAAAAA=","Type":3}},` +

--- a/pkg/store/change/device/store_test.go
+++ b/pkg/store/change/device/store_test.go
@@ -17,8 +17,8 @@ package device
 import (
 	"github.com/onosproject/onos-config/pkg/types"
 	"github.com/onosproject/onos-config/pkg/types/change"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -37,56 +37,56 @@ func TestDeviceStore(t *testing.T) {
 	assert.NoError(t, err)
 	defer store2.Close()
 
-	device1 := device.ID("device-1")
-	device2 := device.ID("device-2")
+	device1 := devicetopo.ID("device-1")
+	device2 := devicetopo.ID("device-2")
 
-	ch1 := make(chan *devicechange.DeviceChange)
+	ch1 := make(chan *devicechangetypes.DeviceChange)
 	err = store2.Watch(device1, ch1)
 	assert.NoError(t, err)
 
-	ch2 := make(chan *devicechange.DeviceChange)
+	ch2 := make(chan *devicechangetypes.DeviceChange)
 	err = store2.Watch(device2, ch2)
 	assert.NoError(t, err)
 
-	change1 := &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+	change1 := &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    types.ID("network-change-1"),
 			Index: 1,
 		},
-		Change: &devicechange.Change{
+		Change: &devicechangetypes.Change{
 			DeviceID: device1,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "foo",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 				{
 					Path: "bar",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Hello world again!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},
 		},
 	}
 
-	change2 := &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+	change2 := &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    types.ID("network-change-2"),
 			Index: 2,
 		},
-		Change: &devicechange.Change{
+		Change: &devicechangetypes.Change{
 			DeviceID: device1,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "baz",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("Goodbye world!"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},
@@ -96,33 +96,33 @@ func TestDeviceStore(t *testing.T) {
 	// Create a new change
 	err = store1.Create(change1)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("network-change-1:device-1"), change1.ID)
-	assert.Equal(t, devicechange.Index(1), change1.Index)
-	assert.NotEqual(t, devicechange.Revision(0), change1.Revision)
+	assert.Equal(t, devicechangetypes.ID("network-change-1:device-1"), change1.ID)
+	assert.Equal(t, devicechangetypes.Index(1), change1.Index)
+	assert.NotEqual(t, devicechangetypes.Revision(0), change1.Revision)
 
 	// Get the change
-	change1, err = store2.Get(devicechange.ID("network-change-1:device-1"))
+	change1, err = store2.Get(devicechangetypes.ID("network-change-1:device-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, change1)
-	assert.Equal(t, devicechange.ID("network-change-1:device-1"), change1.ID)
-	assert.Equal(t, devicechange.Index(1), change1.Index)
-	assert.NotEqual(t, devicechange.Revision(0), change1.Revision)
+	assert.Equal(t, devicechangetypes.ID("network-change-1:device-1"), change1.ID)
+	assert.Equal(t, devicechangetypes.Index(1), change1.Index)
+	assert.NotEqual(t, devicechangetypes.Revision(0), change1.Revision)
 
 	// Append another change
 	err = store2.Create(change2)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("network-change-2:device-1"), change2.ID)
-	assert.Equal(t, devicechange.Index(2), change2.Index)
-	assert.NotEqual(t, devicechange.Revision(0), change2.Revision)
+	assert.Equal(t, devicechangetypes.ID("network-change-2:device-1"), change2.ID)
+	assert.Equal(t, devicechangetypes.Index(2), change2.Index)
+	assert.NotEqual(t, devicechangetypes.Revision(0), change2.Revision)
 
-	change3 := &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+	change3 := &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    types.ID("network-change-3"),
 			Index: 3,
 		},
-		Change: &devicechange.Change{
+		Change: &devicechangetypes.Change{
 			DeviceID: device1,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path:    "foo",
 					Removed: true,
@@ -134,24 +134,24 @@ func TestDeviceStore(t *testing.T) {
 	// Append another change
 	err = store1.Create(change3)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("network-change-3:device-1"), change3.ID)
-	assert.Equal(t, devicechange.Index(3), change3.Index)
-	assert.NotEqual(t, devicechange.Revision(0), change3.Revision)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-1"), change3.ID)
+	assert.Equal(t, devicechangetypes.Index(3), change3.Index)
+	assert.NotEqual(t, devicechangetypes.Revision(0), change3.Revision)
 
 	// For two devices
-	change4 := &devicechange.DeviceChange{
-		NetworkChange: devicechange.NetworkChangeRef{
+	change4 := &devicechangetypes.DeviceChange{
+		NetworkChange: devicechangetypes.NetworkChangeRef{
 			ID:    types.ID("network-change-3"),
 			Index: 3,
 		},
-		Change: &devicechange.Change{
+		Change: &devicechangetypes.Change{
 			DeviceID: device2,
-			Values: []*devicechange.ChangeValue{
+			Values: []*devicechangetypes.ChangeValue{
 				{
 					Path: "foo",
-					Value: &devicechange.TypedValue{
+					Value: &devicechangetypes.TypedValue{
 						Bytes: []byte("bar"),
-						Type:  devicechange.ValueType_STRING,
+						Type:  devicechangetypes.ValueType_STRING,
 					},
 				},
 			},
@@ -161,19 +161,19 @@ func TestDeviceStore(t *testing.T) {
 	// Append another change
 	err = store1.Create(change4)
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.ID("network-change-3:device-2"), change4.ID)
-	assert.Equal(t, devicechange.Index(1), change4.Index)
-	assert.NotEqual(t, devicechange.Revision(0), change4.Revision)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-2"), change4.ID)
+	assert.Equal(t, devicechangetypes.Index(1), change4.Index)
+	assert.NotEqual(t, devicechangetypes.Revision(0), change4.Revision)
 
 	// Verify events were received for the changes
 	changeEvent := nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("network-change-1:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-1:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("network-change-3:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch2)
-	assert.Equal(t, devicechange.ID("network-change-3:device-2"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-2"), changeEvent.ID)
 
 	// Update one of the changes
 	change2.Status.State = change.State_RUNNING
@@ -183,7 +183,7 @@ func TestDeviceStore(t *testing.T) {
 	assert.NotEqual(t, revision, change2.Revision)
 
 	// Read and then update the change
-	change2, err = store2.Get(devicechange.ID("network-change-2:device-1"))
+	change2, err = store2.Get(devicechangetypes.ID("network-change-2:device-1"))
 	assert.NoError(t, err)
 	assert.NotNil(t, change2)
 	change2.Status.State = change.State_RUNNING
@@ -193,9 +193,9 @@ func TestDeviceStore(t *testing.T) {
 	assert.NotEqual(t, revision, change2.Revision)
 
 	// Verify that concurrent updates fail
-	change31, err := store1.Get(devicechange.ID("network-change-3:device-1"))
+	change31, err := store1.Get(devicechangetypes.ID("network-change-3:device-1"))
 	assert.NoError(t, err)
-	change32, err := store2.Get(devicechange.ID("network-change-3:device-1"))
+	change32, err := store2.Get(devicechangetypes.ID("network-change-3:device-1"))
 	assert.NoError(t, err)
 
 	change31.Status.State = change.State_RUNNING
@@ -208,23 +208,23 @@ func TestDeviceStore(t *testing.T) {
 
 	// Verify device events were received again
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, ch1)
-	assert.Equal(t, devicechange.ID("network-change-3:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-1"), changeEvent.ID)
 
 	// List the changes for a device
-	changes := make(chan *devicechange.DeviceChange)
+	changes := make(chan *devicechangetypes.DeviceChange)
 	err = store1.List(device1, changes)
 	assert.NoError(t, err)
 
 	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("network-change-1:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-1:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("network-change-2:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-2:device-1"), changeEvent.ID)
 	changeEvent = nextDeviceChange(t, changes)
-	assert.Equal(t, devicechange.ID("network-change-3:device-1"), changeEvent.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-1"), changeEvent.ID)
 
 	select {
 	case _, ok := <-changes:
@@ -241,17 +241,17 @@ func TestDeviceStore(t *testing.T) {
 	assert.Nil(t, change2)
 
 	// Ensure existing changes are replayed in order on watch
-	watches := make(chan *devicechange.DeviceChange)
+	watches := make(chan *devicechangetypes.DeviceChange)
 	err = store1.Watch(device1, watches)
 	assert.NoError(t, err)
 
 	change := nextDeviceChange(t, watches)
-	assert.Equal(t, devicechange.ID("network-change-1:device-1"), change.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-1:device-1"), change.ID)
 	change = nextDeviceChange(t, watches)
-	assert.Equal(t, devicechange.ID("network-change-3:device-1"), change.ID)
+	assert.Equal(t, devicechangetypes.ID("network-change-3:device-1"), change.ID)
 }
 
-func nextDeviceChange(t *testing.T, ch chan *devicechange.DeviceChange) *devicechange.DeviceChange {
+func nextDeviceChange(t *testing.T, ch chan *devicechangetypes.DeviceChange) *devicechangetypes.DeviceChange {
 	select {
 	case change := <-ch:
 		return change

--- a/pkg/store/change/device/utils.go
+++ b/pkg/store/change/device/utils.go
@@ -15,7 +15,7 @@
 package device
 
 import (
-	"github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"sort"
 	"strings"
@@ -25,13 +25,13 @@ import (
 // This gets the change up to and including the latest
 // Use "nBack" to specify a number of changes back to go
 // If there are not as many changes in the history as nBack nothing is returned
-func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.Change, changeStore Store,
-	nBack int) ([]*device.PathValue, error) {
+func ExtractFullConfig(deviceID devicetopo.ID, newChange *devicechangetypes.Change, changeStore Store,
+	nBack int) ([]*devicechangetypes.PathValue, error) {
 
 	// Have to use a slice to have a consistent output order
-	consolidatedConfig := make([]*device.PathValue, 0)
+	consolidatedConfig := make([]*devicechangetypes.PathValue, 0)
 
-	changeChan := make(chan *device.DeviceChange)
+	changeChan := make(chan *devicechangetypes.DeviceChange)
 
 	err := changeStore.List(deviceID, changeChan)
 
@@ -48,7 +48,7 @@ func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.Change, changeS
 			consolidatedConfig = getPathValue(storeChange.Change, consolidatedConfig)
 		}
 	} else {
-		changes := make([]*device.DeviceChange, 0)
+		changes := make([]*devicechangetypes.DeviceChange, 0)
 		for storeChange := range changeChan {
 			changes = append(changes, storeChange)
 		}
@@ -65,7 +65,7 @@ func ExtractFullConfig(deviceID devicetopo.ID, newChange *device.Change, changeS
 	return consolidatedConfig, nil
 }
 
-func getPathValue(storeChange *device.Change, consolidatedConfig []*device.PathValue) []*device.PathValue {
+func getPathValue(storeChange *devicechangetypes.Change, consolidatedConfig []*devicechangetypes.PathValue) []*devicechangetypes.PathValue {
 	for _, changeValue := range storeChange.Values {
 		if changeValue.Removed {
 			// Delete everything at that path and all below it
@@ -92,7 +92,7 @@ func getPathValue(storeChange *device.Change, consolidatedConfig []*device.PathV
 				}
 			}
 			if !alreadyExists {
-				copyCv := device.PathValue{
+				copyCv := devicechangetypes.PathValue{
 					Path:  changeValue.GetPath(),
 					Value: changeValue.GetValue(),
 				}

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/utils"
-	networkchange "github.com/onosproject/onos-config/pkg/types/change/network"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 	"io"
@@ -107,36 +107,36 @@ type Store interface {
 	io.Closer
 
 	// Get gets a network configuration
-	Get(id networkchange.ID) (*networkchange.NetworkChange, error)
+	Get(id networkchangetypes.ID) (*networkchangetypes.NetworkChange, error)
 
 	// GetByIndex gets a network change by index
-	GetByIndex(index networkchange.Index) (*networkchange.NetworkChange, error)
+	GetByIndex(index networkchangetypes.Index) (*networkchangetypes.NetworkChange, error)
 
 	// GetPrev gets the previous network change by index
-	GetPrev(index networkchange.Index) (*networkchange.NetworkChange, error)
+	GetPrev(index networkchangetypes.Index) (*networkchangetypes.NetworkChange, error)
 
 	// GetNext gets the next network change by index
-	GetNext(index networkchange.Index) (*networkchange.NetworkChange, error)
+	GetNext(index networkchangetypes.Index) (*networkchangetypes.NetworkChange, error)
 
 	// Create creates a new network configuration
-	Create(config *networkchange.NetworkChange) error
+	Create(config *networkchangetypes.NetworkChange) error
 
 	// Update updates an existing network configuration
-	Update(config *networkchange.NetworkChange) error
+	Update(config *networkchangetypes.NetworkChange) error
 
 	// Delete deletes a network configuration
-	Delete(config *networkchange.NetworkChange) error
+	Delete(config *networkchangetypes.NetworkChange) error
 
 	// List lists network configurations
-	List(chan<- *networkchange.NetworkChange) error
+	List(chan<- *networkchangetypes.NetworkChange) error
 
 	// Watch watches the network configuration store for changes
-	Watch(chan<- *networkchange.NetworkChange) error
+	Watch(chan<- *networkchangetypes.NetworkChange) error
 }
 
 // newChangeID creates a new network change ID
-func newChangeID() networkchange.ID {
-	return networkchange.ID(uuid.New().String())
+func newChangeID() networkchangetypes.ID {
+	return networkchangetypes.ID(uuid.New().String())
 }
 
 // atomixStore is the default implementation of the NetworkConfig store
@@ -144,7 +144,7 @@ type atomixStore struct {
 	changes indexedmap.IndexedMap
 }
 
-func (s *atomixStore) Get(id networkchange.ID) (*networkchange.NetworkChange, error) {
+func (s *atomixStore) Get(id networkchangetypes.ID) (*networkchangetypes.NetworkChange, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -157,7 +157,7 @@ func (s *atomixStore) Get(id networkchange.ID) (*networkchange.NetworkChange, er
 	return decodeChange(entry)
 }
 
-func (s *atomixStore) GetByIndex(index networkchange.Index) (*networkchange.NetworkChange, error) {
+func (s *atomixStore) GetByIndex(index networkchangetypes.Index) (*networkchangetypes.NetworkChange, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -170,7 +170,7 @@ func (s *atomixStore) GetByIndex(index networkchange.Index) (*networkchange.Netw
 	return decodeChange(entry)
 }
 
-func (s *atomixStore) GetPrev(index networkchange.Index) (*networkchange.NetworkChange, error) {
+func (s *atomixStore) GetPrev(index networkchangetypes.Index) (*networkchangetypes.NetworkChange, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -183,7 +183,7 @@ func (s *atomixStore) GetPrev(index networkchange.Index) (*networkchange.Network
 	return decodeChange(entry)
 }
 
-func (s *atomixStore) GetNext(index networkchange.Index) (*networkchange.NetworkChange, error) {
+func (s *atomixStore) GetNext(index networkchangetypes.Index) (*networkchangetypes.NetworkChange, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
@@ -196,7 +196,7 @@ func (s *atomixStore) GetNext(index networkchange.Index) (*networkchange.Network
 	return decodeChange(entry)
 }
 
-func (s *atomixStore) Create(change *networkchange.NetworkChange) error {
+func (s *atomixStore) Create(change *networkchangetypes.NetworkChange) error {
 	if change.ID == "" {
 		change.ID = newChangeID()
 	}
@@ -217,14 +217,14 @@ func (s *atomixStore) Create(change *networkchange.NetworkChange) error {
 		return err
 	}
 
-	change.Index = networkchange.Index(entry.Index)
-	change.Revision = networkchange.Revision(entry.Version)
+	change.Index = networkchangetypes.Index(entry.Index)
+	change.Revision = networkchangetypes.Revision(entry.Version)
 	change.Created = entry.Created
 	change.Updated = entry.Updated
 	return nil
 }
 
-func (s *atomixStore) Update(change *networkchange.NetworkChange) error {
+func (s *atomixStore) Update(change *networkchangetypes.NetworkChange) error {
 	if change.Revision == 0 {
 		return errors.New("not a stored object")
 	}
@@ -242,12 +242,12 @@ func (s *atomixStore) Update(change *networkchange.NetworkChange) error {
 		return err
 	}
 
-	change.Revision = networkchange.Revision(entry.Version)
+	change.Revision = networkchangetypes.Revision(entry.Version)
 	change.Updated = entry.Updated
 	return nil
 }
 
-func (s *atomixStore) Delete(change *networkchange.NetworkChange) error {
+func (s *atomixStore) Delete(change *networkchangetypes.NetworkChange) error {
 	if change.Revision == 0 {
 		return errors.New("not a stored object")
 	}
@@ -265,7 +265,7 @@ func (s *atomixStore) Delete(change *networkchange.NetworkChange) error {
 	return nil
 }
 
-func (s *atomixStore) List(ch chan<- *networkchange.NetworkChange) error {
+func (s *atomixStore) List(ch chan<- *networkchangetypes.NetworkChange) error {
 	mapCh := make(chan *indexedmap.Entry)
 	if err := s.changes.Entries(context.Background(), mapCh); err != nil {
 		return err
@@ -282,7 +282,7 @@ func (s *atomixStore) List(ch chan<- *networkchange.NetworkChange) error {
 	return nil
 }
 
-func (s *atomixStore) Watch(ch chan<- *networkchange.NetworkChange) error {
+func (s *atomixStore) Watch(ch chan<- *networkchangetypes.NetworkChange) error {
 	mapCh := make(chan *indexedmap.Event)
 	if err := s.changes.Watch(context.Background(), mapCh, indexedmap.WithReplay()); err != nil {
 		return err
@@ -303,14 +303,14 @@ func (s *atomixStore) Close() error {
 	return s.changes.Close()
 }
 
-func decodeChange(entry *indexedmap.Entry) (*networkchange.NetworkChange, error) {
-	change := &networkchange.NetworkChange{}
+func decodeChange(entry *indexedmap.Entry) (*networkchangetypes.NetworkChange, error) {
+	change := &networkchangetypes.NetworkChange{}
 	if err := proto.Unmarshal(entry.Value, change); err != nil {
 		return nil, err
 	}
-	change.ID = networkchange.ID(entry.Key)
-	change.Index = networkchange.Index(entry.Index)
-	change.Revision = networkchange.Revision(entry.Version)
+	change.ID = networkchangetypes.ID(entry.Key)
+	change.Index = networkchangetypes.Index(entry.Index)
+	change.Revision = networkchangetypes.Revision(entry.Version)
 	change.Created = entry.Created
 	change.Updated = entry.Updated
 	return change, nil

--- a/pkg/store/configuration.go
+++ b/pkg/store/configuration.go
@@ -17,7 +17,7 @@ package store
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	log "k8s.io/klog"
 	"regexp"
 	"sort"
@@ -50,10 +50,10 @@ type Configuration struct {
 // Use "nBack" to specify a number of changes back to go
 // If there are not as many changes in the history as nBack nothing is returned
 // Deprecated: ExtractFullConfig is a method on the legacy Configuration
-func (b Configuration) ExtractFullConfig(newChange *change.Change, changeStore map[string]*change.Change, nBack int) []*types.PathValue {
+func (b Configuration) ExtractFullConfig(newChange *change.Change, changeStore map[string]*change.Change, nBack int) []*devicechangetypes.PathValue {
 
 	// Have to use a slice to have a consistent output order
-	consolidatedConfig := make([]*types.PathValue, 0)
+	consolidatedConfig := make([]*devicechangetypes.PathValue, 0)
 
 	for _, changeID := range b.Changes[0 : len(b.Changes)-nBack] {
 		existingChange, ok := changeStore[B64(changeID)]
@@ -93,7 +93,7 @@ func (b Configuration) ExtractFullConfig(newChange *change.Change, changeStore m
 					}
 				}
 				if !alreadyExists {
-					copyCv := types.PathValue{
+					copyCv := devicechangetypes.PathValue{
 						Path:  changeValue.GetPath(),
 						Value: changeValue.GetValue(),
 					}

--- a/pkg/store/device/store.go
+++ b/pkg/store/device/store.go
@@ -17,7 +17,7 @@ package device
 import (
 	"context"
 	"github.com/atomix/atomix-go-client/pkg/client/util"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	"io"
 	"time"
@@ -28,16 +28,16 @@ const topoAddress = "onos-topo:5150"
 // Store is a device store
 type Store interface {
 	// Get gets a device by ID
-	Get(devicepb.ID) (*devicepb.Device, error)
+	Get(devicetopo.ID) (*devicetopo.Device, error)
 
 	// Update updates a given device
-	Update(*devicepb.Device) (*devicepb.Device, error)
+	Update(*devicetopo.Device) (*devicetopo.Device, error)
 
 	// List lists the devices in the store
-	List(chan<- *devicepb.Device) error
+	List(chan<- *devicetopo.Device) error
 
 	// Watch watches the device store for changes
-	Watch(chan<- *devicepb.ListResponse) error
+	Watch(chan<- *devicetopo.ListResponse) error
 }
 
 // NewTopoStore returns a new topo-based device store
@@ -52,7 +52,7 @@ func NewTopoStore(opts ...grpc.DialOption) (Store, error) {
 		return nil, err
 	}
 
-	client := devicepb.NewDeviceServiceClient(conn)
+	client := devicetopo.NewDeviceServiceClient(conn)
 
 	return &topoStore{
 		client: client,
@@ -60,19 +60,19 @@ func NewTopoStore(opts ...grpc.DialOption) (Store, error) {
 }
 
 // NewStore returns a new device store for the given client
-func NewStore(client devicepb.DeviceServiceClient) (Store, error) {
+func NewStore(client devicetopo.DeviceServiceClient) (Store, error) {
 	return &topoStore{client: client}, nil
 }
 
 // A device Store that uses the topo service to propagate devices
 type topoStore struct {
-	client devicepb.DeviceServiceClient
+	client devicetopo.DeviceServiceClient
 }
 
-func (s *topoStore) Get(id devicepb.ID) (*devicepb.Device, error) {
+func (s *topoStore) Get(id devicetopo.ID) (*devicetopo.Device, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	response, err := s.client.Get(ctx, &devicepb.GetRequest{
+	response, err := s.client.Get(ctx, &devicetopo.GetRequest{
 		ID: id,
 	})
 	if err != nil {
@@ -81,10 +81,10 @@ func (s *topoStore) Get(id devicepb.ID) (*devicepb.Device, error) {
 	return response.Device, nil
 }
 
-func (s *topoStore) Update(updatedDevice *devicepb.Device) (*devicepb.Device, error) {
+func (s *topoStore) Update(updatedDevice *devicetopo.Device) (*devicetopo.Device, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	updateReq := &devicepb.UpdateRequest{
+	updateReq := &devicetopo.UpdateRequest{
 		Device: updatedDevice,
 	}
 	response, err := s.client.Update(ctx, updateReq)
@@ -94,8 +94,8 @@ func (s *topoStore) Update(updatedDevice *devicepb.Device) (*devicepb.Device, er
 	return response.Device, nil
 }
 
-func (s *topoStore) List(ch chan<- *devicepb.Device) error {
-	list, err := s.client.List(context.Background(), &devicepb.ListRequest{})
+func (s *topoStore) List(ch chan<- *devicetopo.Device) error {
+	list, err := s.client.List(context.Background(), &devicetopo.ListRequest{})
 	if err != nil {
 		return err
 	}
@@ -115,8 +115,8 @@ func (s *topoStore) List(ch chan<- *devicepb.Device) error {
 	return nil
 }
 
-func (s *topoStore) Watch(ch chan<- *devicepb.ListResponse) error {
-	list, err := s.client.List(context.Background(), &devicepb.ListRequest{
+func (s *topoStore) Watch(ch chan<- *devicetopo.ListResponse) error {
+	list, err := s.client.List(context.Background(), &devicetopo.ListRequest{
 		Subscribe: true,
 	})
 	if err != nil {

--- a/pkg/store/device/store_test.go
+++ b/pkg/store/device/store_test.go
@@ -16,7 +16,7 @@ package device
 
 import (
 	"github.com/golang/mock/gomock"
-	devicepb "github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
@@ -26,19 +26,19 @@ import (
 func TestDeviceStore(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	device1 := &devicepb.Device{
+	device1 := &devicetopo.Device{
 		ID:       "device-1",
 		Revision: 1,
 		Address:  "device-1:1234",
 		Version:  "1.0.0",
 	}
-	device2 := &devicepb.Device{
+	device2 := &devicetopo.Device{
 		ID:       "device-1",
 		Revision: 1,
 		Address:  "device-1:1234",
 		Version:  "1.0.0",
 	}
-	device3 := &devicepb.Device{
+	device3 := &devicetopo.Device{
 		ID:       "device-1",
 		Revision: 1,
 		Address:  "device-1:1234",
@@ -46,18 +46,18 @@ func TestDeviceStore(t *testing.T) {
 	}
 
 	stream := NewMockDeviceService_ListClient(ctrl)
-	stream.EXPECT().Recv().Return(&devicepb.ListResponse{Device: device1}, nil)
-	stream.EXPECT().Recv().Return(&devicepb.ListResponse{Device: device2}, nil)
-	stream.EXPECT().Recv().Return(&devicepb.ListResponse{Device: device3}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: device1}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: device2}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: device3}, nil)
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 
-	stream.EXPECT().Recv().Return(&devicepb.ListResponse{Device: device1}, nil)
-	stream.EXPECT().Recv().Return(&devicepb.ListResponse{Device: device2}, nil)
-	stream.EXPECT().Recv().Return(&devicepb.ListResponse{Device: device3}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: device1}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: device2}, nil)
+	stream.EXPECT().Recv().Return(&devicetopo.ListResponse{Device: device3}, nil)
 
 	client := NewMockDeviceServiceClient(ctrl)
 	client.EXPECT().List(gomock.Any(), gomock.Any()).Return(stream, nil)
-	client.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&devicepb.GetResponse{Device: device1}, nil)
+	client.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&devicetopo.GetResponse{Device: device1}, nil)
 
 	store := topoStore{
 		client: client,
@@ -67,7 +67,7 @@ func TestDeviceStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, device1.ID, device.ID)
 
-	ch := make(chan *devicepb.Device)
+	ch := make(chan *devicetopo.Device)
 	err = store.List(ch)
 	assert.NoError(t, err)
 
@@ -82,29 +82,29 @@ func TestDeviceStore(t *testing.T) {
 func TestUpdateDevice(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	device1 := &devicepb.Device{
+	device1 := &devicetopo.Device{
 		ID:       "device-1",
 		Revision: 1,
 		Address:  "device-1:1234",
 		Version:  "1.0.0",
 	}
 
-	device1Connected := &devicepb.Device{
+	device1Connected := &devicetopo.Device{
 		ID:       "device-1",
 		Revision: 1,
 		Address:  "device-1:1234",
 		Version:  "1.0.0",
 	}
 
-	protocolState := new(devicepb.ProtocolState)
-	protocolState.Protocol = devicepb.Protocol_GNMI
-	protocolState.ConnectivityState = devicepb.ConnectivityState_REACHABLE
-	protocolState.ChannelState = devicepb.ChannelState_CONNECTED
-	protocolState.ServiceState = devicepb.ServiceState_AVAILABLE
+	protocolState := new(devicetopo.ProtocolState)
+	protocolState.Protocol = devicetopo.Protocol_GNMI
+	protocolState.ConnectivityState = devicetopo.ConnectivityState_REACHABLE
+	protocolState.ChannelState = devicetopo.ChannelState_CONNECTED
+	protocolState.ServiceState = devicetopo.ServiceState_AVAILABLE
 	device1Connected.Protocols = append(device1Connected.Protocols, protocolState)
 
 	client := NewMockDeviceServiceClient(ctrl)
-	client.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&devicepb.GetResponse{Device: device1}, nil)
+	client.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&devicetopo.GetResponse{Device: device1}, nil)
 
 	store := topoStore{
 		client: client,
@@ -114,19 +114,19 @@ func TestUpdateDevice(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, device1.ID, device.ID)
 
-	client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(&devicepb.UpdateResponse{Device: device1Connected}, nil)
+	client.EXPECT().Update(gomock.Any(), gomock.Any()).Return(&devicetopo.UpdateResponse{Device: device1Connected}, nil)
 
 	deviceUpdated, err := store.Update(device1Connected)
 	assert.NoError(t, err)
 	assert.Equal(t, deviceUpdated.ID, device1Connected.ID)
-	assert.Equal(t, deviceUpdated.Protocols[0].Protocol, devicepb.Protocol_GNMI)
-	assert.Equal(t, deviceUpdated.Protocols[0].ConnectivityState, devicepb.ConnectivityState_REACHABLE)
-	assert.Equal(t, deviceUpdated.Protocols[0].ChannelState, devicepb.ChannelState_CONNECTED)
-	assert.Equal(t, deviceUpdated.Protocols[0].ServiceState, devicepb.ServiceState_AVAILABLE)
+	assert.Equal(t, deviceUpdated.Protocols[0].Protocol, devicetopo.Protocol_GNMI)
+	assert.Equal(t, deviceUpdated.Protocols[0].ConnectivityState, devicetopo.ConnectivityState_REACHABLE)
+	assert.Equal(t, deviceUpdated.Protocols[0].ChannelState, devicetopo.ChannelState_CONNECTED)
+	assert.Equal(t, deviceUpdated.Protocols[0].ServiceState, devicetopo.ServiceState_AVAILABLE)
 
 }
 
-func nextDevice(t *testing.T, ch chan *devicepb.Device) *devicepb.Device {
+func nextDevice(t *testing.T, ch chan *devicetopo.Device) *devicetopo.Device {
 	select {
 	case d := <-ch:
 		return d

--- a/pkg/store/jsonToValues.go
+++ b/pkg/store/jsonToValues.go
@@ -17,15 +17,15 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 )
 
 // DecomposeTree breaks a JSON file down in to paths and values without any external
-// context - a second stage is required to align these paths to the specific types
+// context - a second stage is required to align these paths to the specific devicechangetypes
 // got from the Read Only paths of the Model. Also the second stage is necessary
 // resolve list indices, and leaf lists. This second stage is done in the model
 // registry to avoid circular dependencies here.
-func DecomposeTree(genericJSON []byte) ([]*types.PathValue, error) {
+func DecomposeTree(genericJSON []byte) ([]*devicechangetypes.PathValue, error) {
 	var f interface{}
 	err := json.Unmarshal(genericJSON, &f)
 	if err != nil {
@@ -37,10 +37,10 @@ func DecomposeTree(genericJSON []byte) ([]*types.PathValue, error) {
 
 // extractValuesIntermediate recursively walks a JSON tree to create a flat set
 // of paths and values.
-// Note: it is not possible to find indices of lists and accurate types directly
+// Note: it is not possible to find indices of lists and accurate devicechangetypes directly
 // from json - for that the RO Paths must be consulted
-func extractValuesIntermediate(f interface{}, parentPath string) []*types.PathValue {
-	changes := make([]*types.PathValue, 0)
+func extractValuesIntermediate(f interface{}, parentPath string) []*devicechangetypes.PathValue {
+	changes := make([]*devicechangetypes.PathValue, 0)
 
 	switch value := f.(type) {
 	case map[string]interface{}:
@@ -55,13 +55,13 @@ func extractValuesIntermediate(f interface{}, parentPath string) []*types.PathVa
 			changes = append(changes, objs...)
 		}
 	case string:
-		newCv := types.PathValue{Path: parentPath, Value: types.NewTypedValueString(value)}
+		newCv := devicechangetypes.PathValue{Path: parentPath, Value: devicechangetypes.NewTypedValueString(value)}
 		changes = append(changes, &newCv)
 	case bool:
-		newCv := types.PathValue{Path: parentPath, Value: types.NewTypedValueBool(value)}
+		newCv := devicechangetypes.PathValue{Path: parentPath, Value: devicechangetypes.NewTypedValueBool(value)}
 		changes = append(changes, &newCv)
 	case float64:
-		newCv := types.PathValue{Path: parentPath, Value: types.NewTypedValueFloat(float32(value))}
+		newCv := devicechangetypes.PathValue{Path: parentPath, Value: devicechangetypes.NewTypedValueFloat(float32(value))}
 		changes = append(changes, &newCv)
 	default:
 		fmt.Println("Unexpected type", value)

--- a/pkg/store/jsonToValues_test.go
+++ b/pkg/store/jsonToValues_test.go
@@ -16,7 +16,7 @@ package store
 
 import (
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	"io/ioutil"
 	"regexp"
@@ -69,15 +69,15 @@ func Test_DecomposeTree(t *testing.T) {
 			"/system/openflow/controllers/controller[*]/connections/example-ll[*]",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/conn-type",
 			"/interfaces/interface[*]/name":
-			assert.Equal(t, v.GetValue().GetType(), types.ValueType_STRING, newPath)
+			assert.Equal(t, v.GetValue().GetType(), devicechangetypes.ValueType_STRING, newPath)
 		case
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/discombobulator":
-			assert.Equal(t, v.GetValue().GetType(), types.ValueType_BOOL, newPath)
+			assert.Equal(t, v.GetValue().GetType(), devicechangetypes.ValueType_BOOL, newPath)
 		case
 			"/system/openflow/controllers/controller[*]/connections/connections-type",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/aux-id",
 			"/system/openflow/controllers/controller[*]/connections/connections-freq":
-			assert.Equal(t, v.GetValue().GetType(), types.ValueType_FLOAT, newPath)
+			assert.Equal(t, v.GetValue().GetType(), devicechangetypes.ValueType_FLOAT, newPath)
 		default:
 			t.Fatal("Unexpected jsonPath", newPath)
 		}
@@ -118,13 +118,13 @@ func Test_DecomposeTree2(t *testing.T) {
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/address",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/source-interface",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/transport":
-			assert.Equal(t, v.GetValue().GetType(), types.ValueType_STRING, newPath)
+			assert.Equal(t, v.GetValue().GetType(), devicechangetypes.ValueType_STRING, newPath)
 		case
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/aux-id",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/aux-id",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/priority",
 			"/system/openflow/controllers/controller[*]/connections/connection[*]/state/port":
-			assert.Equal(t, v.GetValue().GetType(), types.ValueType_FLOAT, newPath)
+			assert.Equal(t, v.GetValue().GetType(), devicechangetypes.ValueType_FLOAT, newPath)
 		default:
 			t.Fatal("Unexpected jsonPath", newPath)
 		}

--- a/pkg/store/mastership/election.go
+++ b/pkg/store/mastership/election.go
@@ -23,7 +23,7 @@ import (
 	"github.com/atomix/atomix-go-client/pkg/client/primitive"
 	"github.com/atomix/atomix-go-client/pkg/client/session"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	"io"
 	"sync"
@@ -31,7 +31,7 @@ import (
 )
 
 // newAtomixElection returns a new persistent device mastership election
-func newAtomixElection(deviceID device.ID, group *client.PartitionGroup) (deviceMastershipElection, error) {
+func newAtomixElection(deviceID devicetopo.ID, group *client.PartitionGroup) (deviceMastershipElection, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	election, err := group.GetElection(ctx, fmt.Sprintf("mastership-%s", deviceID), session.WithID(string(cluster.GetNodeID())), session.WithTimeout(15*time.Second))
 	cancel()
@@ -42,7 +42,7 @@ func newAtomixElection(deviceID device.ID, group *client.PartitionGroup) (device
 }
 
 // newLocalElection returns a new local device mastership election
-func newLocalElection(deviceID device.ID, nodeID cluster.NodeID, conn *grpc.ClientConn) (deviceMastershipElection, error) {
+func newLocalElection(deviceID devicetopo.ID, nodeID cluster.NodeID, conn *grpc.ClientConn) (deviceMastershipElection, error) {
 	name := primitive.Name{
 		Namespace: "local",
 		Name:      fmt.Sprintf("mastership-%s", deviceID),
@@ -55,7 +55,7 @@ func newLocalElection(deviceID device.ID, nodeID cluster.NodeID, conn *grpc.Clie
 }
 
 // newDeviceMastershipElection creates and enters a new device mastership election
-func newDeviceMastershipElection(deviceID device.ID, election election.Election) (deviceMastershipElection, error) {
+func newDeviceMastershipElection(deviceID devicetopo.ID, election election.Election) (deviceMastershipElection, error) {
 	deviceElection := &atomixDeviceMastershipElection{
 		deviceID: deviceID,
 		election: election,
@@ -75,7 +75,7 @@ type deviceMastershipElection interface {
 	NodeID() cluster.NodeID
 
 	// DeviceID returns the device for which this election provides mastership
-	DeviceID() device.ID
+	DeviceID() devicetopo.ID
 
 	// isMaster returns a bool indicating whether the local node is the master for the device
 	isMaster() (bool, error)
@@ -86,7 +86,7 @@ type deviceMastershipElection interface {
 
 // atomixDeviceMastershipElection is a persistent device mastership election
 type atomixDeviceMastershipElection struct {
-	deviceID   device.ID
+	deviceID   devicetopo.ID
 	election   election.Election
 	mastership *Mastership
 	watchers   []chan<- Mastership
@@ -97,7 +97,7 @@ func (e *atomixDeviceMastershipElection) NodeID() cluster.NodeID {
 	return cluster.NodeID(e.election.ID())
 }
 
-func (e *atomixDeviceMastershipElection) DeviceID() device.ID {
+func (e *atomixDeviceMastershipElection) DeviceID() devicetopo.ID {
 	return e.deviceID
 }
 

--- a/pkg/store/mastership/election_test.go
+++ b/pkg/store/mastership/election_test.go
@@ -17,7 +17,7 @@ package mastership
 import (
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -25,17 +25,17 @@ import (
 func TestMastershipElection(t *testing.T) {
 	node, conn := utils.StartLocalNode()
 
-	store1, err := newLocalElection(device.ID("test"), "a", conn)
+	store1, err := newLocalElection(devicetopo.ID("test"), "a", conn)
 	assert.NoError(t, err)
 
-	store2, err := newLocalElection(device.ID("test"), "b", conn)
+	store2, err := newLocalElection(devicetopo.ID("test"), "b", conn)
 	assert.NoError(t, err)
 
 	store2Ch := make(chan Mastership)
 	err = store2.watch(store2Ch)
 	assert.NoError(t, err)
 
-	store3, err := newLocalElection(device.ID("test"), "c", conn)
+	store3, err := newLocalElection(devicetopo.ID("test"), "c", conn)
 	assert.NoError(t, err)
 
 	store3Ch := make(chan Mastership)

--- a/pkg/store/mastership/store.go
+++ b/pkg/store/mastership/store.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	"io"
 	"sync"
@@ -35,16 +35,16 @@ type Store interface {
 	NodeID() cluster.NodeID
 
 	// IsMaster returns a boolean indicating whether the local node is the master for the given device
-	IsMaster(id device.ID) (bool, error)
+	IsMaster(id devicetopo.ID) (bool, error)
 
 	// Watch watches the store for mastership changes
-	Watch(device.ID, chan<- Mastership) error
+	Watch(devicetopo.ID, chan<- Mastership) error
 }
 
 // Mastership contains information about a device mastership term
 type Mastership struct {
 	// Device is the identifier of the device to which this mastership related
-	Device device.ID
+	Device devicetopo.ID
 
 	// Term is the mastership term
 	Term Term
@@ -67,10 +67,10 @@ func NewAtomixStore() (Store, error) {
 
 	return &atomixStore{
 		nodeID: cluster.GetNodeID(),
-		newElection: func(id device.ID) (deviceMastershipElection, error) {
+		newElection: func(id devicetopo.ID) (deviceMastershipElection, error) {
 			return newAtomixElection(id, group)
 		},
-		elections: make(map[device.ID]deviceMastershipElection),
+		elections: make(map[devicetopo.ID]deviceMastershipElection),
 	}, nil
 }
 
@@ -90,23 +90,23 @@ func NewLocalStore(clusterID string, nodeID cluster.NodeID) (Store, error) {
 func newLocalStore(nodeID cluster.NodeID, conn *grpc.ClientConn) (Store, error) {
 	return &atomixStore{
 		nodeID: nodeID,
-		newElection: func(id device.ID) (deviceMastershipElection, error) {
+		newElection: func(id devicetopo.ID) (deviceMastershipElection, error) {
 			return newLocalElection(id, nodeID, conn)
 		},
-		elections: make(map[device.ID]deviceMastershipElection),
+		elections: make(map[devicetopo.ID]deviceMastershipElection),
 	}, nil
 }
 
 // atomixStore is the default implementation of the NetworkConfig store
 type atomixStore struct {
 	nodeID      cluster.NodeID
-	newElection func(device.ID) (deviceMastershipElection, error)
-	elections   map[device.ID]deviceMastershipElection
+	newElection func(devicetopo.ID) (deviceMastershipElection, error)
+	elections   map[devicetopo.ID]deviceMastershipElection
 	mu          sync.RWMutex
 }
 
 // getElection gets the mastership election for the given device
-func (s *atomixStore) getElection(deviceID device.ID) (deviceMastershipElection, error) {
+func (s *atomixStore) getElection(deviceID devicetopo.ID) (deviceMastershipElection, error) {
 	s.mu.RLock()
 	election, ok := s.elections[deviceID]
 	s.mu.RUnlock()
@@ -131,7 +131,7 @@ func (s *atomixStore) NodeID() cluster.NodeID {
 	return s.nodeID
 }
 
-func (s *atomixStore) IsMaster(deviceID device.ID) (bool, error) {
+func (s *atomixStore) IsMaster(deviceID devicetopo.ID) (bool, error) {
 	election, err := s.getElection(deviceID)
 	if err != nil {
 		return false, err
@@ -139,7 +139,7 @@ func (s *atomixStore) IsMaster(deviceID device.ID) (bool, error) {
 	return election.isMaster()
 }
 
-func (s *atomixStore) Watch(deviceID device.ID, ch chan<- Mastership) error {
+func (s *atomixStore) Watch(deviceID devicetopo.ID, ch chan<- Mastership) error {
 	election, err := s.getElection(deviceID)
 	if err != nil {
 		return err

--- a/pkg/store/mastership/store_test.go
+++ b/pkg/store/mastership/store_test.go
@@ -17,7 +17,7 @@ package mastership
 import (
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/utils"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -29,8 +29,8 @@ func TestMastershipStore(t *testing.T) {
 	node2 := cluster.NodeID("node2")
 	node3 := cluster.NodeID("node3")
 
-	device1 := device.ID("device1")
-	device2 := device.ID("device2")
+	device1 := devicetopo.ID("device1")
+	device2 := devicetopo.ID("device2")
 
 	// Create three stores for three different nodes
 	store1, err := newLocalStore(node1, conn)

--- a/pkg/store/snapshot/device/store.go
+++ b/pkg/store/snapshot/device/store.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/onosproject/onos-config/pkg/store/utils"
 	devicesnapshot "github.com/onosproject/onos-config/pkg/types/snapshot/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 	"io"
@@ -140,7 +140,7 @@ type Store interface {
 	Store(snapshot *devicesnapshot.Snapshot) error
 
 	// Load loads a snapshot
-	Load(id device.ID) (*devicesnapshot.Snapshot, error)
+	Load(id devicetopo.ID) (*devicesnapshot.Snapshot, error)
 
 	// Load loads all snapshots
 	LoadAll(ch chan<- *devicesnapshot.Snapshot) error
@@ -282,7 +282,7 @@ func (s *atomixStore) Store(snapshot *devicesnapshot.Snapshot) error {
 	return nil
 }
 
-func (s *atomixStore) Load(id device.ID) (*devicesnapshot.Snapshot, error) {
+func (s *atomixStore) Load(id devicetopo.ID) (*devicesnapshot.Snapshot, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 

--- a/pkg/store/snapshot/device/store_test.go
+++ b/pkg/store/snapshot/device/store_test.go
@@ -17,7 +17,7 @@ package device
 import (
 	"github.com/onosproject/onos-config/pkg/types/snapshot"
 	devicesnapshot "github.com/onosproject/onos-config/pkg/types/snapshot/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
@@ -36,8 +36,8 @@ func TestDeviceSnapshotStore(t *testing.T) {
 	assert.NoError(t, err)
 	defer store2.Close()
 
-	device1 := device.ID("device-1")
-	device2 := device.ID("device-2")
+	device1 := devicetopo.ID("device-1")
+	device2 := devicetopo.ID("device-2")
 
 	ch := make(chan *devicesnapshot.DeviceSnapshot)
 	err = store2.Watch(ch)

--- a/pkg/store/store-api_test.go
+++ b/pkg/store/store-api_test.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/store/change"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	log "k8s.io/klog"
 	"os"
@@ -74,18 +74,18 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		change1, change2, change3, change4 *change.Change
 	)
 
-	config1Value01, _ := types.NewChangeValue(Test1Cont1A, types.NewTypedValueEmpty(), false)
-	config1Value02, _ := types.NewChangeValue(Test1Cont1ACont2A, types.NewTypedValueEmpty(), false)
-	config1Value03, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2A, types.NewTypedValueUint64(ValueLeaf2A13), false)
-	config1Value04, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2B, types.NewTypedValueFloat(ValueLeaf2B159), false)
-	config1Value05, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2C, types.NewTypedValueString(ValueLeaf2CAbc), false)
-	config1Value06, _ := types.NewChangeValue(Test1Cont1ALeaf1A, types.NewTypedValueString(ValueLeaf1AAbcdef), false)
-	config1Value07, _ := types.NewChangeValue(Test1Cont1AList2ATxout1, types.NewTypedValueEmpty(), false)
-	config1Value08, _ := types.NewChangeValue(Test1Cont1AList2ATxout1Txpwr, types.NewTypedValueUint64(ValueTxout1Txpwr8), false)
-	config1Value09, _ := types.NewChangeValue(Test1Cont1AList2ATxout2, types.NewTypedValueEmpty(), false)
-	config1Value10, _ := types.NewChangeValue(Test1Cont1AList2ATxout2Txpwr, types.NewTypedValueUint64(ValueTxout2Txpwr10), false)
-	config1Value11, _ := types.NewChangeValue(Test1Leaftoplevel, types.NewTypedValueString(ValueLeaftopWxy1234), false)
-	change1, err = change.NewChange([]*types.ChangeValue{
+	config1Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1A, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value02, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2A, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value03, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2A, devicechangetypes.NewTypedValueUint64(ValueLeaf2A13), false)
+	config1Value04, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechangetypes.NewTypedValueFloat(ValueLeaf2B159), false)
+	config1Value05, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString(ValueLeaf2CAbc), false)
+	config1Value06, _ := devicechangetypes.NewChangeValue(Test1Cont1ALeaf1A, devicechangetypes.NewTypedValueString(ValueLeaf1AAbcdef), false)
+	config1Value07, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout1, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value08, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout1Txpwr, devicechangetypes.NewTypedValueUint64(ValueTxout1Txpwr8), false)
+	config1Value09, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout2, devicechangetypes.NewTypedValueEmpty(), false)
+	config1Value10, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout2Txpwr, devicechangetypes.NewTypedValueUint64(ValueTxout2Txpwr10), false)
+	config1Value11, _ := devicechangetypes.NewChangeValue(Test1Leaftoplevel, devicechangetypes.NewTypedValueString(ValueLeaftopWxy1234), false)
+	change1, err = change.NewChange([]*devicechangetypes.ChangeValue{
 		config1Value01, config1Value02, config1Value03, config1Value04, config1Value05,
 		config1Value06, config1Value07, config1Value08, config1Value09, config1Value10,
 		config1Value11,
@@ -95,10 +95,10 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		os.Exit(-1)
 	}
 
-	config2Value01, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2B, types.NewTypedValueFloat(ValueLeaf2B314), false)
-	config2Value02, _ := types.NewChangeValue(Test1Cont1AList2ATxout3, types.NewTypedValueEmpty(), false)
-	config2Value03, _ := types.NewChangeValue(Test1Cont1AList2ATxout3Txpwr, types.NewTypedValueUint64(ValueTxout3Txpwr16), false)
-	change2, err = change.NewChange([]*types.ChangeValue{
+	config2Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechangetypes.NewTypedValueFloat(ValueLeaf2B314), false)
+	config2Value02, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout3, devicechangetypes.NewTypedValueEmpty(), false)
+	config2Value03, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout3Txpwr, devicechangetypes.NewTypedValueUint64(ValueTxout3Txpwr16), false)
+	change2, err = change.NewChange([]*devicechangetypes.ChangeValue{
 		config2Value01, config2Value02, config2Value03,
 	}, "Trim power level")
 	if err != nil {
@@ -106,9 +106,9 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		os.Exit(-1)
 	}
 
-	config3Value01, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2C, types.NewTypedValueString(ValueLeaf2CDef), false)
-	config3Value02, _ := types.NewChangeValue(Test1Cont1AList2ATxout2, types.NewTypedValueEmpty(), true)
-	change3, err = change.NewChange([]*types.ChangeValue{
+	config3Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString(ValueLeaf2CDef), false)
+	config3Value02, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout2, devicechangetypes.NewTypedValueEmpty(), true)
+	change3, err = change.NewChange([]*devicechangetypes.ChangeValue{
 		config3Value01, config3Value02,
 	}, "Remove txout 2")
 	if err != nil {
@@ -132,9 +132,9 @@ func setUp() (device1V, device2V *Configuration, changeStore map[string]*change.
 		os.Exit(-1)
 	}
 
-	config4Value01, _ := types.NewChangeValue(Test1Cont1ACont2ALeaf2C, types.NewTypedValueString(ValueLeaf2CGhi), false)
-	config4Value02, _ := types.NewChangeValue(Test1Cont1AList2ATxout1, types.NewTypedValueEmpty(), true)
-	change4, err = change.NewChange([]*types.ChangeValue{
+	config4Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString(ValueLeaf2CGhi), false)
+	config4Value02, _ := devicechangetypes.NewChangeValue(Test1Cont1AList2ATxout1, devicechangetypes.NewTypedValueEmpty(), true)
+	change4, err = change.NewChange([]*devicechangetypes.ChangeValue{
 		config4Value01, config4Value02,
 	}, "Remove txout 1")
 	if err != nil {
@@ -357,8 +357,8 @@ func BenchmarkCreateChangeValue(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		path := fmt.Sprintf("/test-%s", strconv.Itoa(b.N))
-		cv, _ := types.NewChangeValue(path, types.NewTypedValueUint64(uint(i)), false)
-		err := types.IsPathValid(cv.Path)
+		cv, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueUint64(uint(i)), false)
+		err := devicechangetypes.IsPathValid(cv.Path)
 		assert.NilError(b, err, "path not valid %s", err)
 
 	}
@@ -366,10 +366,10 @@ func BenchmarkCreateChangeValue(b *testing.B) {
 
 func BenchmarkCreateChange(b *testing.B) {
 
-	changeValues := []*types.ChangeValue{}
+	changeValues := []*devicechangetypes.ChangeValue{}
 	for i := 0; i < b.N; i++ {
 		path := fmt.Sprintf("/test%d", i)
-		cv, _ := types.NewChangeValue(path, types.NewTypedValueUint64(uint(i)), false)
+		cv, _ := devicechangetypes.NewChangeValue(path, devicechangetypes.NewTypedValueUint64(uint(i)), false)
 		changeValues = append(changeValues, cv)
 	}
 

--- a/pkg/store/tree.go
+++ b/pkg/store/tree.go
@@ -17,7 +17,7 @@ package store
 import (
 	"encoding/json"
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"strconv"
 	"strings"
@@ -32,7 +32,7 @@ const (
 
 // BuildTree is a function that takes an ordered array of ConfigValues and
 // produces a structured formatted JSON tree
-func BuildTree(values []*types.PathValue, floatAsStr bool) ([]byte, error) {
+func BuildTree(values []*devicechangetypes.PathValue, floatAsStr bool) ([]byte, error) {
 
 	root := make(map[string]interface{})
 	rootif := interface{}(root)
@@ -55,7 +55,7 @@ func BuildTree(values []*types.PathValue, floatAsStr bool) ([]byte, error) {
 // suitable for using with json.Marshal, which in turn can be used to feed in to
 // ygot.Unmarshall
 // This follows the approach in https://blog.golang.org/json-and-go "Generic JSON with interface{}"
-func addPathToTree(path string, value *types.TypedValue, nodeif *interface{}, floatAsStr bool) error {
+func addPathToTree(path string, value *devicechangetypes.TypedValue, nodeif *interface{}, floatAsStr bool) error {
 	pathelems := utils.SplitPath(path)
 
 	// Convert to its real type
@@ -153,46 +153,46 @@ func addPathToTree(path string, value *types.TypedValue, nodeif *interface{}, fl
 	return nil
 }
 
-func handleLeafValue(nodemap map[string]interface{}, value *types.TypedValue, pathelems []string, floatAsStr bool) {
+func handleLeafValue(nodemap map[string]interface{}, value *devicechangetypes.TypedValue, pathelems []string, floatAsStr bool) {
 	switch value.Type {
-	case types.ValueType_EMPTY:
+	case devicechangetypes.ValueType_EMPTY:
 		// NOOP
-	case types.ValueType_STRING:
-		(nodemap)[pathelems[0]] = (*types.TypedString)(value).String()
-	case types.ValueType_INT:
-		(nodemap)[pathelems[0]] = (*types.TypedInt64)(value).Int()
-	case types.ValueType_UINT:
-		(nodemap)[pathelems[0]] = (*types.TypedUint64)(value).Uint()
-	case types.ValueType_DECIMAL:
+	case devicechangetypes.ValueType_STRING:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedString)(value).String()
+	case devicechangetypes.ValueType_INT:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedInt64)(value).Int()
+	case devicechangetypes.ValueType_UINT:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedUint64)(value).Uint()
+	case devicechangetypes.ValueType_DECIMAL:
 		if floatAsStr {
-			(nodemap)[pathelems[0]] = (*types.TypedDecimal64)(value).String()
+			(nodemap)[pathelems[0]] = (*devicechangetypes.TypedDecimal64)(value).String()
 		} else {
-			(nodemap)[pathelems[0]] = (*types.TypedDecimal64)(value).Float()
+			(nodemap)[pathelems[0]] = (*devicechangetypes.TypedDecimal64)(value).Float()
 		}
-	case types.ValueType_FLOAT:
+	case devicechangetypes.ValueType_FLOAT:
 		if floatAsStr {
-			(nodemap)[pathelems[0]] = (*types.TypedFloat)(value).String()
+			(nodemap)[pathelems[0]] = (*devicechangetypes.TypedFloat)(value).String()
 		} else {
-			(nodemap)[pathelems[0]] = (*types.TypedFloat)(value).Float32()
+			(nodemap)[pathelems[0]] = (*devicechangetypes.TypedFloat)(value).Float32()
 		}
-	case types.ValueType_BOOL:
-		(nodemap)[pathelems[0]] = (*types.TypedBool)(value).Bool()
-	case types.ValueType_BYTES:
-		(nodemap)[pathelems[0]] = (*types.TypedBytes)(value).ByteArray()
-	case types.ValueType_LEAFLIST_STRING:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListString)(value).List()
-	case types.ValueType_LEAFLIST_INT:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListInt64)(value).List()
-	case types.ValueType_LEAFLIST_UINT:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListUint)(value).List()
-	case types.ValueType_LEAFLIST_BOOL:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListBool)(value).List()
-	case types.ValueType_LEAFLIST_DECIMAL:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListDecimal)(value).ListFloat()
-	case types.ValueType_LEAFLIST_FLOAT:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListFloat)(value).List()
-	case types.ValueType_LEAFLIST_BYTES:
-		(nodemap)[pathelems[0]] = (*types.TypedLeafListBytes)(value).List()
+	case devicechangetypes.ValueType_BOOL:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedBool)(value).Bool()
+	case devicechangetypes.ValueType_BYTES:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedBytes)(value).ByteArray()
+	case devicechangetypes.ValueType_LEAFLIST_STRING:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListString)(value).List()
+	case devicechangetypes.ValueType_LEAFLIST_INT:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListInt64)(value).List()
+	case devicechangetypes.ValueType_LEAFLIST_UINT:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListUint)(value).List()
+	case devicechangetypes.ValueType_LEAFLIST_BOOL:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListBool)(value).List()
+	case devicechangetypes.ValueType_LEAFLIST_DECIMAL:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListDecimal)(value).ListFloat()
+	case devicechangetypes.ValueType_LEAFLIST_FLOAT:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListFloat)(value).List()
+	case devicechangetypes.ValueType_LEAFLIST_BYTES:
+		(nodemap)[pathelems[0]] = (*devicechangetypes.TypedLeafListBytes)(value).List()
 	default:
 		(nodemap)[pathelems[0]] = fmt.Sprintf("unexpected %d", value.Type)
 	}

--- a/pkg/store/tree_test.go
+++ b/pkg/store/tree_test.go
@@ -15,7 +15,7 @@
 package store
 
 import (
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"gotest.tools/assert"
 	"testing"
 )
@@ -45,27 +45,27 @@ const (
 )
 
 var (
-	configValues []*types.PathValue
+	configValues []*devicechangetypes.PathValue
 )
 
 func setUpTree() {
-	configValues = make([]*types.PathValue, 13)
-	configValues[0] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2A, Value: types.NewTypedValueUint64(ValueLeaf2A12)}
+	configValues = make([]*devicechangetypes.PathValue, 13)
+	configValues[0] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2A, Value: devicechangetypes.NewTypedValueUint64(ValueLeaf2A12)}
 
-	configValues[1] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2B, Value: types.NewTypedValueFloat(ValueLeaf2B114)}
-	configValues[2] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2C, Value: types.NewTypedValueString(ValueLeaf2CMyValue)}
-	configValues[3] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2D, Value: types.NewTypedValueDecimal64(ValueLeaf2D114, 5)}
-	configValues[4] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2E, Value: types.NewTypedValueInt64(ValueLeaf2A12)}
-	configValues[5] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2F, Value: types.NewTypedValueBytes([]byte(ValueList2A2F))}
-	configValues[6] = &types.PathValue{Path: Test1Cont1ACont2ALeaf2G, Value: types.NewTypedValueBool(ValueList2A2G)}
-	configValues[7] = &types.PathValue{Path: Test1Cont1ALeaf1a, Value: types.NewTypedValueString(ValueLeaf1AMyValue)}
+	configValues[1] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2B, Value: devicechangetypes.NewTypedValueFloat(ValueLeaf2B114)}
+	configValues[2] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2C, Value: devicechangetypes.NewTypedValueString(ValueLeaf2CMyValue)}
+	configValues[3] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2D, Value: devicechangetypes.NewTypedValueDecimal64(ValueLeaf2D114, 5)}
+	configValues[4] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2E, Value: devicechangetypes.NewTypedValueInt64(ValueLeaf2A12)}
+	configValues[5] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2F, Value: devicechangetypes.NewTypedValueBytes([]byte(ValueList2A2F))}
+	configValues[6] = &devicechangetypes.PathValue{Path: Test1Cont1ACont2ALeaf2G, Value: devicechangetypes.NewTypedValueBool(ValueList2A2G)}
+	configValues[7] = &devicechangetypes.PathValue{Path: Test1Cont1ALeaf1a, Value: devicechangetypes.NewTypedValueString(ValueLeaf1AMyValue)}
 
-	configValues[8] = &types.PathValue{Path: Test1Cont1AList2a1t, Value: types.NewTypedValueUint64(ValueList2b1PwrT)}
-	configValues[9] = &types.PathValue{Path: Test1Cont1AList2a1r, Value: types.NewTypedValueUint64(ValueList2b1PwrR)}
-	configValues[10] = &types.PathValue{Path: Test1Cont1AList2a2t, Value: types.NewTypedValueUint64(ValueList2b2PwrT)}
-	configValues[11] = &types.PathValue{Path: Test1Cont1AList2a2r, Value: types.NewTypedValueUint64(ValueList2b2PwrR)}
+	configValues[8] = &devicechangetypes.PathValue{Path: Test1Cont1AList2a1t, Value: devicechangetypes.NewTypedValueUint64(ValueList2b1PwrT)}
+	configValues[9] = &devicechangetypes.PathValue{Path: Test1Cont1AList2a1r, Value: devicechangetypes.NewTypedValueUint64(ValueList2b1PwrR)}
+	configValues[10] = &devicechangetypes.PathValue{Path: Test1Cont1AList2a2t, Value: devicechangetypes.NewTypedValueUint64(ValueList2b2PwrT)}
+	configValues[11] = &devicechangetypes.PathValue{Path: Test1Cont1AList2a2r, Value: devicechangetypes.NewTypedValueUint64(ValueList2b2PwrR)}
 
-	configValues[12] = &types.PathValue{Path: Test1Leaftoplevel, Value: types.NewTypedValueString(ValueLeaftopWxy1234)}
+	configValues[12] = &devicechangetypes.PathValue{Path: Test1Leaftoplevel, Value: devicechangetypes.NewTypedValueString(ValueLeaftopWxy1234)}
 
 }
 

--- a/pkg/types/change/device/types.go
+++ b/pkg/types/change/device/types.go
@@ -16,7 +16,7 @@ package device
 
 import (
 	"github.com/onosproject/onos-config/pkg/types"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"strings"
 )
 
@@ -31,8 +31,8 @@ func (i ID) GetNetworkChangeID() types.ID {
 }
 
 // GetDeviceID returns the Device ID to which the change is targeted
-func (i ID) GetDeviceID() device.ID {
-	return device.ID(string(i)[strings.Index(string(i), separator)+1:])
+func (i ID) GetDeviceID() devicetopo.ID {
+	return devicetopo.ID(string(i)[strings.Index(string(i), separator)+1:])
 }
 
 // Index is the index of a network configuration

--- a/pkg/types/change/network/network.go
+++ b/pkg/types/change/network/network.go
@@ -16,13 +16,13 @@ package network
 
 import (
 	"fmt"
-	"github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	"regexp"
 	"time"
 )
 
 // NewNetworkChange creates a new network configuration
-func NewNetworkChange(networkChangeID string, changes []*device.Change) (*NetworkChange, error) {
+func NewNetworkChange(networkChangeID string, changes []*devicechangetypes.Change) (*NetworkChange, error) {
 	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
 	match := r1.FindString(networkChangeID)
 	if networkChangeID == "" {

--- a/pkg/types/change/network/types.go
+++ b/pkg/types/change/network/types.go
@@ -17,8 +17,8 @@ package network
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/types"
-	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 )
 
 const separator = ":"
@@ -27,8 +27,8 @@ const separator = ":"
 type ID types.ID
 
 // GetDeviceChangeID returns a device change ID for the given device ID
-func (i ID) GetDeviceChangeID(deviceID device.ID) devicechange.ID {
-	return devicechange.ID(fmt.Sprintf("%s%s%s", i, separator, deviceID))
+func (i ID) GetDeviceChangeID(deviceID devicetopo.ID) devicechangetypes.ID {
+	return devicechangetypes.ID(fmt.Sprintf("%s%s%s", i, separator, deviceID))
 }
 
 // Index is the index of a network configuration

--- a/pkg/types/snapshot/device/types.go
+++ b/pkg/types/snapshot/device/types.go
@@ -17,7 +17,7 @@ package device
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/types"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"strings"
 )
 
@@ -27,13 +27,13 @@ const separator = ":"
 type ID types.ID
 
 // GetSnapshotID returns the snapshot ID for the given network snapshot ID and device
-func GetSnapshotID(networkID types.ID, deviceID device.ID) ID {
+func GetSnapshotID(networkID types.ID, deviceID devicetopo.ID) ID {
 	return ID(fmt.Sprintf("%s%s%s", networkID, separator, deviceID))
 }
 
 // GetDeviceID returns the device ID for the snapshot ID
-func (i ID) GetDeviceID() device.ID {
-	return device.ID(string(i)[strings.Index(string(i), separator)+1:])
+func (i ID) GetDeviceID() devicetopo.ID {
+	return devicetopo.ID(string(i)[strings.Index(string(i), separator)+1:])
 }
 
 // Revision is a device snapshot revision number

--- a/pkg/utils/idUtils.go
+++ b/pkg/utils/idUtils.go
@@ -17,7 +17,7 @@ package utils
 
 import (
 	"fmt"
-	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 )
 
 // ToModelName simply joins together model name and version in a consistent way
@@ -26,6 +26,6 @@ func ToModelName(name string, version string) string {
 }
 
 // ToConfigName simply joins together device ID and version in a consistent way
-func ToConfigName(deviceID device.ID, version string) string {
+func ToConfigName(deviceID devicetopo.ID, version string) string {
 	return fmt.Sprintf("%s-%s", deviceID, version)
 }

--- a/pkg/utils/values/gnmiValueUtil.go
+++ b/pkg/utils/values/gnmiValueUtil.go
@@ -101,7 +101,7 @@ func handleLeafList(gnmiLl *gnmi.TypedValue_LeaflistVal) (*devicechangetypes.Typ
 	return nil, fmt.Errorf("Empty leaf list given")
 }
 
-// NativeTypeToGnmiTypedValue converts native byte array based values in to gnmi devicechangetypes
+// NativeTypeToGnmiTypedValue converts native byte array based values in to gnmi types
 func NativeTypeToGnmiTypedValue(typedValue *devicechangetypes.TypedValue) (*gnmi.TypedValue, error) {
 	if len(typedValue.Bytes) == 0 && typedValue.Type != devicechangetypes.ValueType_EMPTY {
 		return nil, fmt.Errorf("invalid TypedValue Length 0")

--- a/pkg/utils/values/gnmiValueUtil.go
+++ b/pkg/utils/values/gnmiValueUtil.go
@@ -17,38 +17,38 @@ package values
 
 import (
 	"fmt"
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
-	pb "github.com/openconfig/gnmi/proto/gnmi"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	gnmi "github.com/openconfig/gnmi/proto/gnmi"
 )
 
-// GnmiTypedValueToNativeType converts gnmi type based values in to native byte array types
-func GnmiTypedValueToNativeType(gnmiTv *pb.TypedValue) (*types.TypedValue, error) {
+// GnmiTypedValueToNativeType converts gnmi type based values in to native byte array devicechangetypes
+func GnmiTypedValueToNativeType(gnmiTv *gnmi.TypedValue) (*devicechangetypes.TypedValue, error) {
 
 	switch v := gnmiTv.GetValue().(type) {
-	case *pb.TypedValue_StringVal:
-		return types.NewTypedValueString(v.StringVal), nil
-	case *pb.TypedValue_AsciiVal:
-		return types.NewTypedValueString(v.AsciiVal), nil
-	case *pb.TypedValue_IntVal:
-		return types.NewTypedValueInt64(int(v.IntVal)), nil
-	case *pb.TypedValue_UintVal:
-		return types.NewTypedValueUint64(uint(v.UintVal)), nil
-	case *pb.TypedValue_BoolVal:
-		return types.NewTypedValueBool(v.BoolVal), nil
-	case *pb.TypedValue_BytesVal:
-		return types.NewTypedValueBytes(v.BytesVal), nil
-	case *pb.TypedValue_DecimalVal:
-		return types.NewTypedValueDecimal64(v.DecimalVal.Digits, v.DecimalVal.Precision), nil
-	case *pb.TypedValue_FloatVal:
-		return types.NewTypedValueFloat(v.FloatVal), nil
-	case *pb.TypedValue_LeaflistVal:
+	case *gnmi.TypedValue_StringVal:
+		return devicechangetypes.NewTypedValueString(v.StringVal), nil
+	case *gnmi.TypedValue_AsciiVal:
+		return devicechangetypes.NewTypedValueString(v.AsciiVal), nil
+	case *gnmi.TypedValue_IntVal:
+		return devicechangetypes.NewTypedValueInt64(int(v.IntVal)), nil
+	case *gnmi.TypedValue_UintVal:
+		return devicechangetypes.NewTypedValueUint64(uint(v.UintVal)), nil
+	case *gnmi.TypedValue_BoolVal:
+		return devicechangetypes.NewTypedValueBool(v.BoolVal), nil
+	case *gnmi.TypedValue_BytesVal:
+		return devicechangetypes.NewTypedValueBytes(v.BytesVal), nil
+	case *gnmi.TypedValue_DecimalVal:
+		return devicechangetypes.NewTypedValueDecimal64(v.DecimalVal.Digits, v.DecimalVal.Precision), nil
+	case *gnmi.TypedValue_FloatVal:
+		return devicechangetypes.NewTypedValueFloat(v.FloatVal), nil
+	case *gnmi.TypedValue_LeaflistVal:
 		return handleLeafList(v)
 	default:
 		return nil, fmt.Errorf("Not yet supported %v", v)
 	}
 }
 
-func handleLeafList(gnmiLl *pb.TypedValue_LeaflistVal) (*types.TypedValue, error) {
+func handleLeafList(gnmiLl *gnmi.TypedValue_LeaflistVal) (*devicechangetypes.TypedValue, error) {
 	stringList := make([]string, 0)
 	intList := make([]int, 0)
 	uintList := make([]uint, 0)
@@ -61,22 +61,22 @@ func handleLeafList(gnmiLl *pb.TypedValue_LeaflistVal) (*types.TypedValue, error
 	// All values will be of the same type, but we don't know what that is yet
 	for _, leaf := range gnmiLl.LeaflistVal.GetElement() {
 		switch u := leaf.GetValue().(type) {
-		case *pb.TypedValue_StringVal:
+		case *gnmi.TypedValue_StringVal:
 			stringList = append(stringList, u.StringVal)
-		case *pb.TypedValue_AsciiVal:
+		case *gnmi.TypedValue_AsciiVal:
 			stringList = append(stringList, u.AsciiVal)
-		case *pb.TypedValue_IntVal:
+		case *gnmi.TypedValue_IntVal:
 			intList = append(intList, int(u.IntVal))
-		case *pb.TypedValue_UintVal:
+		case *gnmi.TypedValue_UintVal:
 			uintList = append(uintList, uint(u.UintVal))
-		case *pb.TypedValue_BoolVal:
+		case *gnmi.TypedValue_BoolVal:
 			boolList = append(boolList, u.BoolVal)
-		case *pb.TypedValue_BytesVal:
+		case *gnmi.TypedValue_BytesVal:
 			bytesList = append(bytesList, u.BytesVal)
-		case *pb.TypedValue_DecimalVal:
+		case *gnmi.TypedValue_DecimalVal:
 			digitsList = append(digitsList, u.DecimalVal.Digits)
 			precision = u.DecimalVal.Precision
-		case *pb.TypedValue_FloatVal:
+		case *gnmi.TypedValue_FloatVal:
 			floatList = append(floatList, u.FloatVal)
 		default:
 			return nil, fmt.Errorf("Leaf list type Not yet supported %v", u)
@@ -84,131 +84,131 @@ func handleLeafList(gnmiLl *pb.TypedValue_LeaflistVal) (*types.TypedValue, error
 	}
 
 	if len(stringList) > 0 {
-		return types.NewLeafListStringTv(stringList), nil
+		return devicechangetypes.NewLeafListStringTv(stringList), nil
 	} else if len(intList) > 0 {
-		return types.NewLeafListInt64Tv(intList), nil
+		return devicechangetypes.NewLeafListInt64Tv(intList), nil
 	} else if len(uintList) > 0 {
-		return types.NewLeafListUint64Tv(uintList), nil
+		return devicechangetypes.NewLeafListUint64Tv(uintList), nil
 	} else if len(boolList) > 0 {
-		return types.NewLeafListBoolTv(boolList), nil
+		return devicechangetypes.NewLeafListBoolTv(boolList), nil
 	} else if len(bytesList) > 0 {
-		return types.NewLeafListBytesTv(bytesList), nil
+		return devicechangetypes.NewLeafListBytesTv(bytesList), nil
 	} else if len(digitsList) > 0 {
-		return types.NewLeafListDecimal64Tv(digitsList, precision), nil
+		return devicechangetypes.NewLeafListDecimal64Tv(digitsList, precision), nil
 	} else if len(floatList) > 0 {
-		return types.NewLeafListFloat32Tv(floatList), nil
+		return devicechangetypes.NewLeafListFloat32Tv(floatList), nil
 	}
 	return nil, fmt.Errorf("Empty leaf list given")
 }
 
-// NativeTypeToGnmiTypedValue converts native byte array based values in to gnmi types
-func NativeTypeToGnmiTypedValue(typedValue *types.TypedValue) (*pb.TypedValue, error) {
-	if len(typedValue.Bytes) == 0 && typedValue.Type != types.ValueType_EMPTY {
+// NativeTypeToGnmiTypedValue converts native byte array based values in to gnmi devicechangetypes
+func NativeTypeToGnmiTypedValue(typedValue *devicechangetypes.TypedValue) (*gnmi.TypedValue, error) {
+	if len(typedValue.Bytes) == 0 && typedValue.Type != devicechangetypes.ValueType_EMPTY {
 		return nil, fmt.Errorf("invalid TypedValue Length 0")
 	}
 	switch typedValue.Type {
-	case types.ValueType_EMPTY:
-		gnmiValue := &pb.TypedValue_AnyVal{AnyVal: nil}
-		return &pb.TypedValue{Value: gnmiValue}, nil
+	case devicechangetypes.ValueType_EMPTY:
+		gnmiValue := &gnmi.TypedValue_AnyVal{AnyVal: nil}
+		return &gnmi.TypedValue{Value: gnmiValue}, nil
 
-	case types.ValueType_STRING:
-		gnmiValue := pb.TypedValue_StringVal{StringVal: (*types.TypedString)(typedValue).String()}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_STRING:
+		gnmiValue := gnmi.TypedValue_StringVal{StringVal: (*devicechangetypes.TypedString)(typedValue).String()}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_INT:
-		gnmiValue := pb.TypedValue_IntVal{IntVal: int64((*types.TypedInt64)(typedValue).Int())}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_INT:
+		gnmiValue := gnmi.TypedValue_IntVal{IntVal: int64((*devicechangetypes.TypedInt64)(typedValue).Int())}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_UINT:
-		gnmiValue := pb.TypedValue_UintVal{UintVal: uint64((*types.TypedUint64)(typedValue).Uint())}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_UINT:
+		gnmiValue := gnmi.TypedValue_UintVal{UintVal: uint64((*devicechangetypes.TypedUint64)(typedValue).Uint())}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_BOOL:
-		gnmiValue := pb.TypedValue_BoolVal{BoolVal: (*types.TypedBool)(typedValue).Bool()}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_BOOL:
+		gnmiValue := gnmi.TypedValue_BoolVal{BoolVal: (*devicechangetypes.TypedBool)(typedValue).Bool()}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_DECIMAL:
-		digits, precision := (*types.TypedDecimal64)(typedValue).Decimal64()
-		gnmiValue := pb.TypedValue_DecimalVal{DecimalVal: &pb.Decimal64{Digits: digits, Precision: precision}}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_DECIMAL:
+		digits, precision := (*devicechangetypes.TypedDecimal64)(typedValue).Decimal64()
+		gnmiValue := gnmi.TypedValue_DecimalVal{DecimalVal: &gnmi.Decimal64{Digits: digits, Precision: precision}}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_FLOAT:
-		gnmiValue := pb.TypedValue_FloatVal{FloatVal: (*types.TypedFloat)(typedValue).Float32()}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_FLOAT:
+		gnmiValue := gnmi.TypedValue_FloatVal{FloatVal: (*devicechangetypes.TypedFloat)(typedValue).Float32()}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_BYTES:
-		gnmiValue := pb.TypedValue_BytesVal{BytesVal: (*types.TypedBytes)(typedValue).ByteArray()}
-		return &pb.TypedValue{Value: &gnmiValue}, nil
+	case devicechangetypes.ValueType_BYTES:
+		gnmiValue := gnmi.TypedValue_BytesVal{BytesVal: (*devicechangetypes.TypedBytes)(typedValue).ByteArray()}
+		return &gnmi.TypedValue{Value: &gnmiValue}, nil
 
-	case types.ValueType_LEAFLIST_STRING:
-		strings := (*types.TypedLeafListString)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_STRING:
+		strings := (*devicechangetypes.TypedLeafListString)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, s := range strings {
-			gnmiValue := pb.TypedValue_StringVal{StringVal: s}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_StringVal{StringVal: s}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
-	case types.ValueType_LEAFLIST_INT:
-		ints := (*types.TypedLeafListInt64)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_INT:
+		ints := (*devicechangetypes.TypedLeafListInt64)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, i := range ints {
-			gnmiValue := pb.TypedValue_IntVal{IntVal: int64(i)}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_IntVal{IntVal: int64(i)}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
-	case types.ValueType_LEAFLIST_UINT:
-		uints := (*types.TypedLeafListUint)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_UINT:
+		uints := (*devicechangetypes.TypedLeafListUint)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, u := range uints {
-			gnmiValue := pb.TypedValue_UintVal{UintVal: uint64(u)}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_UintVal{UintVal: uint64(u)}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
-	case types.ValueType_LEAFLIST_BOOL:
-		bools := (*types.TypedLeafListBool)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_BOOL:
+		bools := (*devicechangetypes.TypedLeafListBool)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, b := range bools {
-			gnmiValue := pb.TypedValue_BoolVal{BoolVal: b}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_BoolVal{BoolVal: b}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
-	case types.ValueType_LEAFLIST_DECIMAL:
-		digits, precision := (*types.TypedLeafListDecimal)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_DECIMAL:
+		digits, precision := (*devicechangetypes.TypedLeafListDecimal)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, d := range digits {
-			gnmiValue := pb.TypedValue_DecimalVal{DecimalVal: &pb.Decimal64{Digits: d, Precision: precision}}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_DecimalVal{DecimalVal: &gnmi.Decimal64{Digits: d, Precision: precision}}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
-	case types.ValueType_LEAFLIST_FLOAT:
-		floats := (*types.TypedLeafListFloat)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_FLOAT:
+		floats := (*devicechangetypes.TypedLeafListFloat)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, f := range floats {
-			gnmiValue := pb.TypedValue_FloatVal{FloatVal: f}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_FloatVal{FloatVal: f}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
-	case types.ValueType_LEAFLIST_BYTES:
-		bytes := (*types.TypedLeafListBytes)(typedValue).List()
-		gnmiTypedValues := make([]*pb.TypedValue, 0)
+	case devicechangetypes.ValueType_LEAFLIST_BYTES:
+		bytes := (*devicechangetypes.TypedLeafListBytes)(typedValue).List()
+		gnmiTypedValues := make([]*gnmi.TypedValue, 0)
 		for _, b := range bytes {
-			gnmiValue := pb.TypedValue_BytesVal{BytesVal: b}
-			gnmiTypedValues = append(gnmiTypedValues, &pb.TypedValue{Value: &gnmiValue})
+			gnmiValue := gnmi.TypedValue_BytesVal{BytesVal: b}
+			gnmiTypedValues = append(gnmiTypedValues, &gnmi.TypedValue{Value: &gnmiValue})
 		}
-		gnmiLeafList := pb.TypedValue_LeaflistVal{LeaflistVal: &pb.ScalarArray{Element: gnmiTypedValues}}
-		return &pb.TypedValue{Value: &gnmiLeafList}, nil
+		gnmiLeafList := gnmi.TypedValue_LeaflistVal{LeaflistVal: &gnmi.ScalarArray{Element: gnmiTypedValues}}
+		return &gnmi.TypedValue{Value: &gnmiLeafList}, nil
 
 	default:
 		return nil, fmt.Errorf("Unsupported type %d", typedValue.Type)

--- a/pkg/utils/values/gnmiValueUtil_test.go
+++ b/pkg/utils/values/gnmiValueUtil_test.go
@@ -17,8 +17,8 @@
 package values
 
 import (
-	types "github.com/onosproject/onos-config/pkg/types/change/device"
-	pb "github.com/openconfig/gnmi/proto/gnmi"
+	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	"github.com/openconfig/gnmi/proto/gnmi"
 	"gotest.tools/assert"
 	"reflect"
 	"testing"
@@ -36,74 +36,74 @@ const (
 ////////////////////////////////////////////////////////////////////////////////
 
 func Test_GnmiStringToNative(t *testing.T) {
-	gnmiValue := pb.TypedValue_StringVal{StringVal: testString}
-	nativeType, err := GnmiTypedValueToNativeType(&pb.TypedValue{Value: &gnmiValue})
+	gnmiValue := gnmi.TypedValue_StringVal{StringVal: testString}
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
 	assert.NilError(t, err)
 
-	nativeString := (*types.TypedString)(nativeType)
+	nativeString := (*devicechangetypes.TypedString)(nativeType)
 	assert.Equal(t, nativeString.String(), testString)
 }
 
 func Test_GnmiIntToNative(t *testing.T) {
-	gnmiValue := pb.TypedValue_IntVal{IntVal: testNegativeInt}
-	nativeType, err := GnmiTypedValueToNativeType(&pb.TypedValue{Value: &gnmiValue})
+	gnmiValue := gnmi.TypedValue_IntVal{IntVal: testNegativeInt}
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
 	assert.NilError(t, err)
 
-	nativeInt64 := (*types.TypedInt64)(nativeType)
+	nativeInt64 := (*devicechangetypes.TypedInt64)(nativeType)
 	assert.Equal(t, nativeInt64.Int(), testNegativeInt)
 }
 
 func Test_GnmiUintToNative(t *testing.T) {
-	gnmiValue := pb.TypedValue_UintVal{UintVal: uint64(testMaxUint)}
-	nativeType, err := GnmiTypedValueToNativeType(&pb.TypedValue{Value: &gnmiValue})
+	gnmiValue := gnmi.TypedValue_UintVal{UintVal: uint64(testMaxUint)}
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
 	assert.NilError(t, err)
 
-	nativeUint64 := (*types.TypedUint64)(nativeType)
+	nativeUint64 := (*devicechangetypes.TypedUint64)(nativeType)
 	assert.Equal(t, nativeUint64.Uint(), testMaxUint)
 }
 
 func Test_GnmiBoolToNative(t *testing.T) {
-	gnmiValue := pb.TypedValue_BoolVal{BoolVal: true}
-	nativeType, err := GnmiTypedValueToNativeType(&pb.TypedValue{Value: &gnmiValue})
+	gnmiValue := gnmi.TypedValue_BoolVal{BoolVal: true}
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
 	assert.NilError(t, err)
 
-	nativeBool := (*types.TypedBool)(nativeType)
+	nativeBool := (*devicechangetypes.TypedBool)(nativeType)
 	assert.Equal(t, nativeBool.Bool(), true)
 }
 
-var intTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
-				{Value: &pb.TypedValue_IntVal{IntVal: 100}},
-				{Value: &pb.TypedValue_IntVal{IntVal: 101}},
-				{Value: &pb.TypedValue_IntVal{IntVal: 102}},
-				{Value: &pb.TypedValue_IntVal{IntVal: 103}},
+var intTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
+				{Value: &gnmi.TypedValue_IntVal{IntVal: 100}},
+				{Value: &gnmi.TypedValue_IntVal{IntVal: 101}},
+				{Value: &gnmi.TypedValue_IntVal{IntVal: 102}},
+				{Value: &gnmi.TypedValue_IntVal{IntVal: 103}},
 			},
 		},
 	},
 }
 
-var uintTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
-				{Value: &pb.TypedValue_UintVal{UintVal: 100}},
-				{Value: &pb.TypedValue_UintVal{UintVal: 101}},
-				{Value: &pb.TypedValue_UintVal{UintVal: 102}},
-				{Value: &pb.TypedValue_UintVal{UintVal: 103}},
+var uintTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
+				{Value: &gnmi.TypedValue_UintVal{UintVal: 100}},
+				{Value: &gnmi.TypedValue_UintVal{UintVal: 101}},
+				{Value: &gnmi.TypedValue_UintVal{UintVal: 102}},
+				{Value: &gnmi.TypedValue_UintVal{UintVal: 103}},
 			},
 		},
 	},
 }
 
-var decimalTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
+var decimalTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
 				{
-					Value: &pb.TypedValue_DecimalVal{
-						DecimalVal: &pb.Decimal64{
+					Value: &gnmi.TypedValue_DecimalVal{
+						DecimalVal: &gnmi.Decimal64{
 							Digits:    6,
 							Precision: 0,
 						},
@@ -114,53 +114,53 @@ var decimalTestValue = &pb.TypedValue{
 	},
 }
 
-var booleanTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
-				{Value: &pb.TypedValue_BoolVal{BoolVal: true}},
-				{Value: &pb.TypedValue_BoolVal{BoolVal: false}},
-				{Value: &pb.TypedValue_BoolVal{BoolVal: true}},
-				{Value: &pb.TypedValue_BoolVal{BoolVal: false}},
+var booleanTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
+				{Value: &gnmi.TypedValue_BoolVal{BoolVal: true}},
+				{Value: &gnmi.TypedValue_BoolVal{BoolVal: false}},
+				{Value: &gnmi.TypedValue_BoolVal{BoolVal: true}},
+				{Value: &gnmi.TypedValue_BoolVal{BoolVal: false}},
 			},
 		},
 	},
 }
 
-var floatTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
-				{Value: &pb.TypedValue_FloatVal{FloatVal: 1.0}},
-				{Value: &pb.TypedValue_FloatVal{FloatVal: 2.0}},
-				{Value: &pb.TypedValue_FloatVal{FloatVal: 3.0}},
-				{Value: &pb.TypedValue_FloatVal{FloatVal: 4.0}},
+var floatTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
+				{Value: &gnmi.TypedValue_FloatVal{FloatVal: 1.0}},
+				{Value: &gnmi.TypedValue_FloatVal{FloatVal: 2.0}},
+				{Value: &gnmi.TypedValue_FloatVal{FloatVal: 3.0}},
+				{Value: &gnmi.TypedValue_FloatVal{FloatVal: 4.0}},
 			},
 		},
 	},
 }
 
-var bytesTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
-				{Value: &pb.TypedValue_BytesVal{BytesVal: []byte("abc")}},
-				{Value: &pb.TypedValue_BytesVal{BytesVal: []byte("def")}},
-				{Value: &pb.TypedValue_BytesVal{BytesVal: []byte("ghi")}},
-				{Value: &pb.TypedValue_BytesVal{BytesVal: []byte("jkl")}},
+var bytesTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
+				{Value: &gnmi.TypedValue_BytesVal{BytesVal: []byte("abc")}},
+				{Value: &gnmi.TypedValue_BytesVal{BytesVal: []byte("def")}},
+				{Value: &gnmi.TypedValue_BytesVal{BytesVal: []byte("ghi")}},
+				{Value: &gnmi.TypedValue_BytesVal{BytesVal: []byte("jkl")}},
 			},
 		},
 	},
 }
 
-var stringTestValue = &pb.TypedValue{
-	Value: &pb.TypedValue_LeaflistVal{
-		LeaflistVal: &pb.ScalarArray{
-			Element: []*pb.TypedValue{
-				{Value: &pb.TypedValue_StringVal{StringVal: "abc"}},
-				{Value: &pb.TypedValue_StringVal{StringVal: "def"}},
-				{Value: &pb.TypedValue_StringVal{StringVal: "ghi"}},
-				{Value: &pb.TypedValue_StringVal{StringVal: "jkl"}},
+var stringTestValue = &gnmi.TypedValue{
+	Value: &gnmi.TypedValue_LeaflistVal{
+		LeaflistVal: &gnmi.ScalarArray{
+			Element: []*gnmi.TypedValue{
+				{Value: &gnmi.TypedValue_StringVal{StringVal: "abc"}},
+				{Value: &gnmi.TypedValue_StringVal{StringVal: "def"}},
+				{Value: &gnmi.TypedValue_StringVal{StringVal: "ghi"}},
+				{Value: &gnmi.TypedValue_StringVal{StringVal: "jkl"}},
 			},
 		},
 	},
@@ -169,16 +169,16 @@ var stringTestValue = &pb.TypedValue{
 func Test_Leaflists(t *testing.T) {
 	testCases := []struct {
 		description  string
-		expectedType types.ValueType
-		testValue    *pb.TypedValue
+		expectedType devicechangetypes.ValueType
+		testValue    *gnmi.TypedValue
 	}{
-		{description: "Int", expectedType: types.ValueType_LEAFLIST_INT, testValue: intTestValue},
-		{description: "Uint", expectedType: types.ValueType_LEAFLIST_UINT, testValue: uintTestValue},
-		{description: "Decimal", expectedType: types.ValueType_LEAFLIST_DECIMAL, testValue: decimalTestValue},
-		{description: "Boolean", expectedType: types.ValueType_LEAFLIST_BOOL, testValue: booleanTestValue},
-		{description: "Float", expectedType: types.ValueType_LEAFLIST_FLOAT, testValue: floatTestValue},
-		{description: "Bytes", expectedType: types.ValueType_LEAFLIST_BYTES, testValue: bytesTestValue},
-		{description: "Strings", expectedType: types.ValueType_LEAFLIST_STRING, testValue: stringTestValue},
+		{description: "Int", expectedType: devicechangetypes.ValueType_LEAFLIST_INT, testValue: intTestValue},
+		{description: "Uint", expectedType: devicechangetypes.ValueType_LEAFLIST_UINT, testValue: uintTestValue},
+		{description: "Decimal", expectedType: devicechangetypes.ValueType_LEAFLIST_DECIMAL, testValue: decimalTestValue},
+		{description: "Boolean", expectedType: devicechangetypes.ValueType_LEAFLIST_BOOL, testValue: booleanTestValue},
+		{description: "Float", expectedType: devicechangetypes.ValueType_LEAFLIST_FLOAT, testValue: floatTestValue},
+		{description: "Bytes", expectedType: devicechangetypes.ValueType_LEAFLIST_BYTES, testValue: bytesTestValue},
+		{description: "Strings", expectedType: devicechangetypes.ValueType_LEAFLIST_STRING, testValue: stringTestValue},
 	}
 
 	for _, testCase := range testCases {
@@ -198,40 +198,40 @@ func Test_Leaflists(t *testing.T) {
 ////////////////////////////////////////////////////////////////////////////////
 
 func Test_NativeStringToGnmi(t *testing.T) {
-	nativeString := types.NewTypedValueString(testString)
+	nativeString := devicechangetypes.NewTypedValueString(testString)
 	gnmiString, err := NativeTypeToGnmiTypedValue(nativeString)
 	assert.NilError(t, err)
-	_, ok := gnmiString.Value.(*pb.TypedValue_StringVal)
+	_, ok := gnmiString.Value.(*gnmi.TypedValue_StringVal)
 	assert.Assert(t, ok)
 
 	assert.Equal(t, gnmiString.GetStringVal(), testString)
 }
 
 func Test_NativeIntToGnmi(t *testing.T) {
-	nativeInt := types.NewTypedValueInt64(testPositiveInt)
+	nativeInt := devicechangetypes.NewTypedValueInt64(testPositiveInt)
 	gnmiInt, err := NativeTypeToGnmiTypedValue(nativeInt)
 	assert.NilError(t, err)
-	_, ok := gnmiInt.Value.(*pb.TypedValue_IntVal)
+	_, ok := gnmiInt.Value.(*gnmi.TypedValue_IntVal)
 	assert.Assert(t, ok)
 
 	assert.Equal(t, int(gnmiInt.GetIntVal()), testPositiveInt)
 }
 
 func Test_NativeUintToGnmi(t *testing.T) {
-	nativeUint := types.NewTypedValueUint64(testMaxUint)
+	nativeUint := devicechangetypes.NewTypedValueUint64(testMaxUint)
 	gnmiUint, err := NativeTypeToGnmiTypedValue(nativeUint)
 	assert.NilError(t, err)
-	_, ok := gnmiUint.Value.(*pb.TypedValue_UintVal)
+	_, ok := gnmiUint.Value.(*gnmi.TypedValue_UintVal)
 	assert.Assert(t, ok)
 
 	assert.Equal(t, uint(gnmiUint.GetUintVal()), testMaxUint)
 }
 
 func Test_NativeBoolToGnmi(t *testing.T) {
-	nativeBool := types.NewTypedValueBool(true)
+	nativeBool := devicechangetypes.NewTypedValueBool(true)
 	gnmiBool, err := NativeTypeToGnmiTypedValue(nativeBool)
 	assert.NilError(t, err)
-	_, ok := gnmiBool.Value.(*pb.TypedValue_BoolVal)
+	_, ok := gnmiBool.Value.(*gnmi.TypedValue_BoolVal)
 	assert.Assert(t, ok)
 
 	assert.Equal(t, gnmiBool.GetBoolVal(), true)


### PR DESCRIPTION
Settling on one alias for these packages - many different aliases were used

- 	**devicechangetypes** "github.com/onosproject/onos-config/pkg/types/change/device"
- 	**networkchangetypes** "github.com/onosproject/onos-config/pkg/types/change/network"
- 	**devicetopo** "github.com/onosproject/onos-topo/pkg/northbound/device"