### PR TITLE
Skip empty snapshots to avoid infinite reconciliation loop

### DIFF
--- a/pkg/controller/snapshot/network/controller.go
+++ b/pkg/controller/snapshot/network/controller.go
@@ -213,6 +213,12 @@ func (r *Reconciler) createDeviceSnapshots(snapshot *networksnaptypes.NetworkSna
 		})
 	}
 
+	// If there are no device snapshots to take, complete the snapshot successfully.
+	if len(refs) == 0 {
+		snapshot.Status.Phase = snaptypes.Phase_DELETE
+		snapshot.Status.State = snaptypes.State_COMPLETE
+	}
+
 	// Once the device snapshots have been created, update the network snapshot
 	snapshot.Refs = refs
 	if err := r.networkSnapshots.Update(snapshot); err != nil {


### PR DESCRIPTION
The `NetworkSnapshot` reconciler can enter an infinite loop when unable to create snapshots. This PR completes a snapshot when it has no data to snapshot.

Need to test before merging 