### PR TITLE
Change python script to use python3

### DIFF
--- a/build/licensing/boilerplate.py
+++ b/build/licensing/boilerplate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright 2019-present Open Networking Foundation.
 #

--- a/build/licensing/boilerplate.py.txt
+++ b/build/licensing/boilerplate.py.txt
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Copyright YEAR-present Open Networking Foundation.
 #


### PR DESCRIPTION
Python 2 End Of Life is 1st January 2020 - it has already been delayed 5 years

https://pythonclock.org/

I want to find a balance between what works on Mac and on Linux - this seems to work for both

https://howchoo.com/g/nwuznmzjmzm/how-to-install-and-use-python-3-on-macos

I will update the prerequisites.md, but that's in onos-docs