### PR TITLE
Moving get and set gNMI responses to new atomix based workflow

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -279,13 +279,25 @@ func (m *Manager) Run() {
 	log.Info("Starting Manager")
 
 	// Start the NetworkChange controller
-	_ = m.networkChangeController.Start()
+	errNetworkCtrl := m.networkChangeController.Start()
+	if errNetworkCtrl != nil {
+		log.Error("Can't start controller ", errNetworkCtrl)
+	}
 	// Start the DeviceChange controller
-	_ = m.deviceChangeController.Start()
+	errDeviceChangeCtrl := m.deviceChangeController.Start()
+	if errDeviceChangeCtrl != nil {
+		log.Error("Can't start controller ", errDeviceChangeCtrl)
+	}
 	// Start the NetworkSnapshot controller
-	_ = m.networkSnapshotController.Start()
+	errNetworkSnapshotCtrl := m.networkSnapshotController.Start()
+	if errNetworkSnapshotCtrl != nil {
+		log.Error("Can't start controller ", errNetworkSnapshotCtrl)
+	}
 	// Start the DeviceSnapshot controller
-	_ = m.deviceSnapshotController.Start()
+	errDeviceSnapshotCtrl := m.deviceSnapshotController.Start()
+	if errDeviceSnapshotCtrl != nil {
+		log.Error("Can't start controller ", errDeviceSnapshotCtrl)
+	}
 
 	// Start the main dispatcher system
 	go m.Dispatcher.Listen(m.ChangesChannel)

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -106,6 +106,7 @@ func computeRollback(m *Manager, target string, configname store.ConfigName) (ch
 	return id, updates, deletes, nil
 }
 
+// Deprecated: listenForDeviceResponse works on legacy, non-atomix stores
 func listenForDeviceResponse(mgr *Manager, target string) error {
 	respChan, ok := mgr.Dispatcher.GetResponseListener(devicetopo.ID(target))
 	if !ok {

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -41,7 +41,8 @@ func (m *Manager) ValidateNetworkConfig(deviceName string, version string,
 
 	deviceConfig, _, err := m.getStoredConfig(deviceName, version, deviceType, true)
 	if err != nil {
-		return err
+		log.Errorf(" OLD - Error while setting config %s", err.Error())
+		//return err
 	}
 	deviceConfigTemporary, err := store.NewConfiguration(deviceConfig.Device, deviceConfig.Version,
 		deviceConfig.Type, deviceConfig.Changes)
@@ -264,6 +265,7 @@ func (m *Manager) computeNewNetworkConfig(targetUpdates map[string]devicechanget
 		}
 		log.Infof("Appending device change %v", newChange)
 		deviceChanges = append(deviceChanges, newChange)
+		delete(targetRemoves, target)
 	}
 
 	for target, removes := range targetRemoves {

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -169,23 +169,25 @@ func (m *Manager) SetNetworkConfig(deviceName string, version string,
 
 // SetNewNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
 func (m *Manager) SetNewNetworkConfig(targetUpdates map[string]devicechangetypes.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetopo.ID]TypeVersionInfo, netcfgchangename string) {
+	targetRemoves map[string][]string, deviceInfo map[devicetopo.ID]TypeVersionInfo, netcfgchangename string) error {
 	//TODO evaluate need of user and add it back if need be.
-	//TODO start watch and build update Result
-	//TODO return error
 	allDeviceChanges, errChanges := m.computeNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 	if errChanges != nil {
 		log.Error("Can't compute new network configs", errChanges)
+		return errChanges
 	}
 	newNetworkConfig, errNetChange := networkchangetypes.NewNetworkChange(netcfgchangename, allDeviceChanges)
 	if errNetChange != nil {
 		log.Error("Can't create new network config", errNetChange)
+		return errNetChange
 	}
 	//Writing to the atomix backed store too
 	errStoreNewChange := m.NetworkChangesStore.Create(newNetworkConfig)
 	if errStoreNewChange != nil {
 		log.Error("Can't write new network config to atomix store", errStoreNewChange)
+		return errStoreNewChange
 	}
+	return nil
 }
 
 // getStoredConfig looks for an exact match for the config name or then a partial match based on the device name

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -20,11 +20,11 @@ import (
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
+	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	devicetype "github.com/onosproject/onos-config/pkg/types/device"
 	"github.com/onosproject/onos-config/pkg/utils"
-	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
 	"strings"
 	"time"
@@ -170,22 +170,21 @@ func (m *Manager) SetNetworkConfig(deviceName string, version string,
 
 // SetNewNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
 func (m *Manager) SetNewNetworkConfig(targetUpdates map[string]devicechangetypes.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetopo.ID]TypeVersionInfo, netcfgchangename string) error {
+	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]devicestore.Info, netcfgchangename string) error {
 	//TODO evaluate need of user and add it back if need be.
+	//TODO start watch and build update Result
+	//TODO return an error if the device is new and extensions 101 and 102 are not specified
 	allDeviceChanges, errChanges := m.computeNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 	if errChanges != nil {
-		log.Error("Can't compute new network configs", errChanges)
 		return errChanges
 	}
 	newNetworkConfig, errNetChange := networkchangetypes.NewNetworkChange(netcfgchangename, allDeviceChanges)
 	if errNetChange != nil {
-		log.Error("Can't create new network config", errNetChange)
 		return errNetChange
 	}
 	//Writing to the atomix backed store too
 	errStoreNewChange := m.NetworkChangesStore.Create(newNetworkConfig)
 	if errStoreNewChange != nil {
-		log.Error("Can't write new network config to atomix store", errStoreNewChange)
 		return errStoreNewChange
 	}
 	return nil
@@ -248,15 +247,15 @@ func (m *Manager) getStoredConfig(deviceName string, version string,
 
 //computeNewNetworkConfig computes each device change
 func (m *Manager) computeNewNetworkConfig(targetUpdates map[string]devicechangetypes.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetopo.ID]TypeVersionInfo,
+	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]devicestore.Info,
 	description string) ([]*devicechangetypes.Change, error) {
 
 	deviceChanges := make([]*devicechangetypes.Change, 0)
 	for target, updates := range targetUpdates {
 		//FIXME this is a sequential job, not parallelized
 		//FIXME target is a device name with no version
-		version := deviceInfo[devicetopo.ID(target)].Version
-		deviceType := deviceInfo[devicetopo.ID(target)].DeviceType
+		version := deviceInfo[devicetype.ID(target)].Version
+		deviceType := deviceInfo[devicetype.ID(target)].Type
 		newChange, err := m.ComputeNewDeviceChange(
 			devicetype.ID(target), version, deviceType, updates, targetRemoves[target], description)
 		if err != nil {
@@ -268,9 +267,10 @@ func (m *Manager) computeNewNetworkConfig(targetUpdates map[string]devicechanget
 		delete(targetRemoves, target)
 	}
 
+	// Some targets might only have removes
 	for target, removes := range targetRemoves {
-		version := deviceInfo[devicetopo.ID(target)].Version
-		deviceType := deviceInfo[devicetopo.ID(target)].DeviceType
+		version := deviceInfo[devicetype.ID(target)].Version
+		deviceType := deviceInfo[devicetype.ID(target)].Type
 		newChange, err := m.ComputeNewDeviceChange(
 			devicetype.ID(target), version, deviceType, make(devicechangetypes.TypedValueMap), removes, description)
 		if err != nil {

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -184,6 +184,7 @@ func getUpdate(version devicetype.Version, prefix *gnmi.Path, path *gnmi.Path) (
 		pathAsString = utils.StrPath(prefix) + pathAsString
 	}
 	//TODO the following can be optimized by looking if the path is in the read only
+	//Currently un-hooked from the response, just generating values for comparison
 	configValues, err := manager.GetManager().GetTargetConfig(target, "",
 		pathAsString, 0)
 	if err != nil {
@@ -194,17 +195,18 @@ func getUpdate(version devicetype.Version, prefix *gnmi.Path, path *gnmi.Path) (
 		devicetype.ID(target), typeVersionInfo.Version, pathAsString, 0)
 	if errNewMethod != nil {
 		log.Error("Error while extracting config", errNewMethod)
+		return nil, errNewMethod
 	}
 
 	//TODO remove this print after the swap
-	log.Info("Old Config Values ", configValues)
-	log.Info("New Config Values from Atomix ", configValuesNew)
+	log.Info("UNUSED - Old Config Values ", configValues)
+	log.Info("USED - New Config Values from Atomix ", configValuesNew)
 
 	stateValues := manager.GetManager().GetTargetState(target, pathAsString)
 	//Merging the two results
-	configValues = append(configValues, stateValues...)
+	configValuesNew = append(configValuesNew, stateValues...)
 
-	return buildUpdate(prefix, path, configValues)
+	return buildUpdate(prefix, path, configValuesNew)
 }
 
 func buildUpdate(prefix *gnmi.Path, path *gnmi.Path, configValues []*devicechangetypes.PathValue) (*gnmi.Update, error) {

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -185,13 +185,15 @@ func getUpdate(version devicetype.Version, prefix *gnmi.Path, path *gnmi.Path) (
 	}
 	//TODO the following can be optimized by looking if the path is in the read only
 	//Currently un-hooked from the response, just generating values for comparison
-	configValues, err := manager.GetManager().GetTargetConfig(target, "",
+	//Deprecated
+	configValuesOld, err := manager.GetManager().GetTargetConfig(target, "",
 		pathAsString, 0)
 	if err != nil {
-		return nil, err
+		log.Error("UNUSED - OLD - Error while extracting config", err)
+		//return nil, err
 	}
 
-	configValuesNew, errNewMethod := manager.GetManager().GetTargetNewConfig(
+	configValues, errNewMethod := manager.GetManager().GetTargetNewConfig(
 		devicetype.ID(target), typeVersionInfo.Version, pathAsString, 0)
 	if errNewMethod != nil {
 		log.Error("Error while extracting config", errNewMethod)
@@ -199,14 +201,14 @@ func getUpdate(version devicetype.Version, prefix *gnmi.Path, path *gnmi.Path) (
 	}
 
 	//TODO remove this print after the swap
-	log.Info("UNUSED - Old Config Values ", configValues)
-	log.Info("USED - New Config Values from Atomix ", configValuesNew)
+	log.Info("UNUSED - OLD - Old Config Values ", configValuesOld)
+	log.Info("USED - NEW - New Config Values from Atomix ", configValues)
 
 	stateValues := manager.GetManager().GetTargetState(target, pathAsString)
 	//Merging the two results
-	configValuesNew = append(configValuesNew, stateValues...)
+	configValues = append(configValues, stateValues...)
 
-	return buildUpdate(prefix, path, configValuesNew)
+	return buildUpdate(prefix, path, configValues)
 }
 
 func buildUpdate(prefix *gnmi.Path, path *gnmi.Path, configValues []*devicechangetypes.PathValue) (*gnmi.Update, error) {

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -174,14 +174,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 
 	//TODO remove
 	//Deprecated
-	targetUpdatesCopy := make(mapTargetUpdates)
-	targetRemovesCopy := make(mapTargetRemoves)
-	for k,v := range targetUpdates{
-		targetUpdatesCopy[k] = v
-	}
-	for k,v := range targetRemoves{
-		targetRemovesCopy[k] = v
-	}
+	targetUpdatesCopy, targetRemovesCopy := oldMapCopies(targetUpdates, targetRemoves)
 	updateResultsOld, networkChanges, err :=
 		s.executeSetConfig(targetUpdatesCopy, targetRemovesCopy, version, deviceType, netcfgchangename)
 	if err != nil {
@@ -274,6 +267,18 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	log.Info("USED - NEW - atomix update response ", setResponse)
 
 	return setResponse, nil
+}
+
+func oldMapCopies(targetUpdates mapTargetUpdates, targetRemoves mapTargetRemoves) (mapTargetUpdates, mapTargetRemoves) {
+	targetUpdatesCopy := make(mapTargetUpdates)
+	targetRemovesCopy := make(mapTargetRemoves)
+	for k, v := range targetUpdates {
+		targetUpdatesCopy[k] = v
+	}
+	for k, v := range targetRemoves {
+		targetRemovesCopy[k] = v
+	}
+	return targetUpdatesCopy, targetRemovesCopy
 }
 
 func extractExtensions(req *gnmi.SetRequest) (string, string, string, error) {

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -25,6 +25,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
+	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	changetypes "github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
@@ -51,19 +52,16 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	// There is only one set of extensions in Set request, regardless of number of
 	// updates
 	var (
-		netcfgchangename    string // May be specified as 100 in extension
-		version             string // May be specified as 101 in extension
-		deviceType          string // May be specified as 102 in extension
+		netCfgChangeName    string             // May be specified as 100 in extension
+		version             devicetype.Version // May be specified as 101 in extension
+		deviceType          devicetype.Type    // May be specified as 102 in extension
 		disconnectedDevices []string
-		deviceInfo          map[devicetopo.ID]manager.TypeVersionInfo
 	)
 
 	disconnectedDevices = make([]string, 0)
 	targetUpdates := make(mapTargetUpdates)
 	targetRemoves := make(mapTargetRemoves)
 
-	deviceInfo = make(map[devicetopo.ID]manager.TypeVersionInfo)
-	log.Info("gNMI Set Request", req)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	//Update
@@ -94,19 +92,13 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		targetRemoves[target] = s.doDelete(u, targetRemoves)
 	}
 
-	netcfgchangename, version, deviceType, extErr := extractExtensions(req)
-	if extErr != nil {
-		return nil, extErr
+	netCfgChangeName, version, deviceType, err := extractExtensions(req)
+	if err != nil {
+		return nil, err
 	}
 
-	//TODO update to new methods
-	errRo := s.checkForReadOnly(deviceType, version, targetUpdates, targetRemoves)
-	if errRo != nil {
-		return nil, status.Error(codes.InvalidArgument, errRo.Error())
-	}
-
-	if netcfgchangename == "" {
-		netcfgchangename = namesgenerator.GetRandomName(0)
+	if netCfgChangeName == "" {
+		netCfgChangeName = namesgenerator.GetRandomName(0)
 	}
 
 	//Temporary map in order to not to modify the original removes but optimize calculations during validation
@@ -116,67 +108,47 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	mgr := manager.GetManager()
-
-	//TODO this can be parallelized with a pattern manager.go ValidateStores()
+	deviceInfo := make(map[devicetype.ID]devicestore.Info)
 	//Checking for wrong configuration against the device models for updates
-	for target, updates := range targetUpdates {
-		storedDevice, errDevice := mgr.DeviceStore.Get(devicetopo.ID(target))
+	for target := range targetUpdates {
+		deviceType, version, err = mgr.CheckCacheForDevice(devicetype.ID(target), deviceType, version)
+		if err != nil {
+			return nil, err
+		}
+		_, errDevice := mgr.DeviceStore.Get(devicetopo.ID(target))
 		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
 			disconnectedDevices = append(disconnectedDevices, target)
 		} else if errDevice != nil {
 			//handling gRPC errors
 			return nil, errDevice
-		}
-		typeVersionInfo, errTypeVersion := manager.GetManager().ExtractTypeAndVersion(devicetopo.ID(target),
-			storedDevice, version, deviceType)
-		if errTypeVersion != nil {
-			//TODO return instead of log
-			log.Error(errTypeVersion)
-			typeVersionInfo = manager.TypeVersionInfo{
-				DeviceType: "",
-				Version:    "",
-			}
-			//return nil, errTypeVersion
-		}
-		deviceInfo[devicetopo.ID(target)] = typeVersionInfo
-		err := validateChange(target, version, deviceType, deviceInfo, updates, targetRemoves[target])
-		if err != nil {
-			return nil, err
 		}
 		delete(targetRemovesTmp, target)
 	}
 	//Checking for wrong configuration against the device models for deletes
-	for target, removes := range targetRemovesTmp {
-		storedDevice, errDevice := mgr.DeviceStore.Get(devicetopo.ID(target))
+	for target := range targetRemovesTmp {
+		deviceType, version, err = mgr.CheckCacheForDevice(devicetype.ID(target), deviceType, version)
+		if err != nil {
+			return nil, err
+		}
+		_, errDevice := mgr.DeviceStore.Get(devicetopo.ID(target))
 		if errDevice != nil && status.Convert(errDevice).Code() == codes.NotFound {
 			disconnectedDevices = append(disconnectedDevices, target)
 		} else if errDevice != nil {
 			//handling gRPC errors
 			return nil, errDevice
 		}
-		typeVersionInfo, errTypeVersion := manager.GetManager().ExtractTypeAndVersion(devicetopo.ID(target),
-			storedDevice, version, deviceType)
-		if errTypeVersion != nil {
-			//TODO return instead of log
-			log.Error(errTypeVersion)
-			typeVersionInfo = manager.TypeVersionInfo{
-				DeviceType: "",
-				Version:    "",
-			}
-			//return nil, errTypeVersion
-		}
-		deviceInfo[devicetopo.ID(target)] = typeVersionInfo
-		err := validateChange(target, version, deviceType, deviceInfo, make(devicechangetypes.TypedValueMap), removes)
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	errRo := s.checkForReadOnlyNew(targetUpdates, targetRemoves)
+	if errRo != nil {
+		return nil, status.Error(codes.InvalidArgument, errRo.Error())
 	}
 
 	//TODO remove
 	//Deprecated
 	targetUpdatesCopy, targetRemovesCopy := oldMapCopies(targetUpdates, targetRemoves)
 	updateResultsOld, networkChanges, err :=
-		s.executeSetConfig(targetUpdatesCopy, targetRemovesCopy, version, deviceType, netcfgchangename)
+		s.executeSetConfig(targetUpdatesCopy, targetRemovesCopy, string(version), string(deviceType), netCfgChangeName)
 	if err != nil {
 		log.Errorf(" OLD - Error while setting config %s", err.Error())
 		//return nil, status.Error(codes.Internal, err.Error())
@@ -190,22 +162,22 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	// Look for use of this name already
 	//Deprecated TODO remove
 	for _, nwCfg := range mgr.NetworkStore.Store {
-		if nwCfg.Name == netcfgchangename {
+		if nwCfg.Name == netCfgChangeName {
 			err := status.Error(codes.InvalidArgument, fmt.Errorf(
-				"name %s is already used for a Network Configuration", netcfgchangename).Error())
+				"name %s is already used for a Network Configuration", netCfgChangeName).Error())
 			log.Error(err)
 			//return nil, err
 		}
 	}
 
-	networkConfig, err := store.NewNetworkConfiguration(netcfgchangename, "User1", networkChanges)
+	networkConfig, err := store.NewNetworkConfiguration(netCfgChangeName, "User1", networkChanges)
 	if err != nil {
 		log.Errorf(" OLD - Error while setting config %s", err.Error())
 		//return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	//Creating and setting the config on the new atomix Store
-	errSet := mgr.SetNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
+	errSet := mgr.SetNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netCfgChangeName)
 
 	if errSet != nil {
 		log.Errorf("Error while setting config in atomix %s", errSet.Error())
@@ -213,22 +185,21 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	//Obtaining response based on distributed store generated events
-	updateResults, errListen := listenAndBuildResponse(mgr, networkchangetypes.ID(netcfgchangename))
-
+	updateResultsAtomix, errListen := listenAndBuildResponse(mgr, networkchangetypes.ID(netCfgChangeName))
 	if errListen != nil {
 		log.Errorf("Error while building atomix based response %s", errListen.Error())
 		return nil, status.Error(codes.Internal, errListen.Error())
 	}
 
 	log.Info("UNUSED - OLD - update result ", updateResultsOld)
-	log.Info("USED - NEW - atomix update results ", updateResults)
+	log.Info("USED - NEW - atomix update results ", updateResultsAtomix)
 
 	extensions := []*gnmi_ext.Extension{
 		{
 			Ext: &gnmi_ext.Extension_RegisteredExt{
 				RegisteredExt: &gnmi_ext.RegisteredExtension{
 					Id:  GnmiExtensionNetwkChangeID,
-					Msg: []byte(netcfgchangename),
+					Msg: []byte(netCfgChangeName),
 				},
 			},
 		},
@@ -258,7 +229,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	setResponse := &gnmi.SetResponse{
-		Response:  updateResults,
+		Response:  updateResultsAtomix,
 		Timestamp: time.Now().Unix(),
 		Extension: extensions,
 	}
@@ -281,7 +252,7 @@ func oldMapCopies(targetUpdates mapTargetUpdates, targetRemoves mapTargetRemoves
 	return targetUpdatesCopy, targetRemovesCopy
 }
 
-func extractExtensions(req *gnmi.SetRequest) (string, string, string, error) {
+func extractExtensions(req *gnmi.SetRequest) (string, devicetype.Version, devicetype.Type, error) {
 	var netcfgchangename string
 	var version string
 	var deviceType string
@@ -299,7 +270,7 @@ func extractExtensions(req *gnmi.SetRequest) (string, string, string, error) {
 		log.Infof("Set called with extensions; 100: %s, 101: %s, 102: %s",
 			netcfgchangename, version, deviceType)
 	}
-	return netcfgchangename, version, deviceType, nil
+	return netcfgchangename, devicetype.Version(version), devicetype.Type(deviceType), nil
 }
 
 // This deals with either a path and a value (simple case) or a path with
@@ -370,68 +341,6 @@ func (s *Server) doDelete(u *gnmi.Path, targetRemoves mapTargetRemoves) []string
 	deletes = append(deletes, path)
 	return deletes
 
-}
-
-// Deprecated: checkForReadOnly works on legacy, non-atomix stores
-func (s *Server) checkForReadOnly(deviceType string, version string, targetUpdates mapTargetUpdates,
-	targetRemoves mapTargetRemoves) error {
-	//TODO update with new stores
-	configs := manager.GetManager().ConfigStore.Store
-
-	// Iterate through all the updates - many may use the same target - here we
-	// create a map of the models for all of the targets
-	targetModelTypes := make(map[string][]string)
-	for t := range targetUpdates { // map - just need the key
-		if _, ok := targetModelTypes[t]; ok {
-			continue
-		}
-		for _, config := range configs {
-			if config.Device == t {
-				m, ok := manager.GetManager().ModelRegistry.
-					ModelReadOnlyPaths[utils.ToModelName(devicetype.Type(config.Type), devicetype.Version(config.Version))]
-				if !ok {
-					log.Warningf("Cannot check for Read Only paths for %s %s because "+
-						"Model Plugin not available - continuing", config.Type, config.Version)
-					return nil
-				}
-				targetModelTypes[t] = modelregistry.Paths(m)
-			}
-		}
-	}
-	for t := range targetRemoves { // map - just need the key
-		if _, ok := targetModelTypes[t]; ok {
-			continue
-		}
-		for _, config := range configs {
-			if config.Device == t {
-				m, ok := manager.GetManager().ModelRegistry.
-					ModelReadOnlyPaths[utils.ToModelName(devicetype.Type(config.Type), devicetype.Version(config.Version))]
-				if !ok {
-					log.Warningf("Cannot check for Read Only paths for %s %s because "+
-						"Model Plugin not available - continuing", config.Type, config.Version)
-					return nil
-				}
-				targetModelTypes[t] = modelregistry.Paths(m)
-			}
-		}
-	}
-
-	// Now iterate through the consolidated set of targets and see if any are read-only paths
-	for t, update := range targetUpdates {
-		model := targetModelTypes[t]
-		for path := range update { // map - just need the key
-			for _, ropath := range model {
-				// Search through for list indices and replace with generic
-
-				modelPath := modelregistry.RemovePathIndices(path)
-				if strings.HasPrefix(modelPath, ropath) {
-					return fmt.Errorf("update contains a change to a read only path %s. Rejected", path)
-				}
-			}
-		}
-	}
-
-	return nil
 }
 
 // iterate through the updates and check that none of them include a `set` of a
@@ -721,27 +630,4 @@ func setChange(target string, version string, devicetype string, targetUpdates d
 		return nil, nil, false, err
 	}
 	return changeID, configName, false, nil
-}
-
-func validateChange(target string, version string, deviceType string, deviceTypeAndVersion map[devicetopo.ID]manager.TypeVersionInfo,
-	targetUpdates devicechangetypes.TypedValueMap, targetRemoves []string) error {
-	if len(targetUpdates) == 0 && len(targetRemoves) == 0 {
-		return fmt.Errorf("no updates found in change on %s - invalid", target)
-	}
-
-	err := manager.GetManager().ValidateNetworkConfig(target, version, deviceType, targetUpdates, targetRemoves)
-	if err != nil {
-		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
-			targetRemoves, target, err)
-		//return err
-	}
-	deviceInfo := deviceTypeAndVersion[devicetopo.ID(target)]
-	errNewValidation := manager.GetManager().ValidateNewNetworkConfig(devicetype.ID(target), deviceInfo.Version, deviceInfo.DeviceType,
-		targetUpdates, targetRemoves)
-	if errNewValidation != nil {
-		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
-			targetRemoves, target, errNewValidation)
-		return err
-	}
-	return nil
 }

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -174,8 +174,16 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 
 	//TODO remove
 	//Deprecated
+	targetUpdatesCopy := make(mapTargetUpdates)
+	targetRemovesCopy := make(mapTargetRemoves)
+	for k,v := range targetUpdates{
+		targetUpdatesCopy[k] = v
+	}
+	for k,v := range targetRemoves{
+		targetRemovesCopy[k] = v
+	}
 	updateResultsOld, networkChanges, err :=
-		s.executeSetConfig(targetUpdates, targetRemoves, version, deviceType, netcfgchangename)
+		s.executeSetConfig(targetUpdatesCopy, targetRemovesCopy, version, deviceType, netcfgchangename)
 	if err != nil {
 		log.Errorf(" OLD - Error while setting config %s", err.Error())
 		//return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -736,6 +736,7 @@ func validateChange(target string, version string, deviceType string, deviceType
 	if errNewValidation != nil {
 		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
 			targetRemoves, target, errNewValidation)
+		return err
 	}
 	return nil
 }

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -266,13 +266,12 @@ func listenForNewDeviceUpdates(stream gnmi.GNMI_SubscribeServer, mgr *manager.Ma
 						log.Warning("Error in parsing path ", err)
 						continue
 					}
-					log.Infof("NEW - Subscribe notification for %s on %s with value %s", pathGnmi, target, value.Value)
-					//TODO uncomment in swap patch
-					//err = buildAndSendUpdate(pathGnmi, target, value.Value, stream)
-					//if err != nil {
-					//	log.Error("Error in sending update path ", err)
-					//	resChan <- result{success: false, err: err}
-					//}
+					log.Infof("USED - NEW - Subscribe notification for %s on %s with value %s", pathGnmi, target, value.Value)
+					err = buildAndSendUpdate(pathGnmi, target, value.Value, stream)
+					if err != nil {
+						log.Error("Error in sending update path ", err)
+						resChan <- result{success: false, err: err}
+					}
 				}
 			}
 		}
@@ -289,12 +288,7 @@ func sendSubscribeResponse(changeInternal *change.Change, subs []*regexp.Regexp,
 				log.Warning("Error in parsing path ", err)
 				continue
 			}
-			log.Infof("OLD - Subscribe notification for %s on %s with value %s", pathGnmi, target, changeValue.GetValue())
-			err = buildAndSendUpdate(pathGnmi, target, changeValue.GetValue(), stream)
-			if err != nil {
-				log.Error("Error in sending update path ", err)
-				resChan <- result{success: false, err: err}
-			}
+			log.Infof("UNUSED - OLD - Subscribe notification for %s on %s with value %s", pathGnmi, target, changeValue.GetValue())
 		}
 	}
 }

--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -267,7 +267,7 @@ func listenForNewDeviceUpdates(stream gnmi.GNMI_SubscribeServer, mgr *manager.Ma
 						continue
 					}
 					log.Infof("USED - NEW - Subscribe notification for %s on %s with value %s", pathGnmi, target, value.Value)
-					err = buildAndSendUpdate(pathGnmi, target, value.Value, stream)
+					err = buildAndSendUpdate(pathGnmi, string(target), value.Value, stream)
 					if err != nil {
 						log.Error("Error in sending update path ", err)
 						resChan <- result{success: false, err: err}


### PR DESCRIPTION
THis PR moves the gNMI get and set methods to the atomix based workflow.

TODO list for reference at this point in time:
- Line 353 method checkForReadOnly, used at line 103
- ExtractTypeAndVersion line 411 of manager.go
- Lines 130 and 157 of set.go need to be update after finishing of ExtractTypeAndVersion
- make sure Line 91 of setconfig.go works with update ExtractTypeAndVersion
- RollbackConfig line 60 make sure it’s the last applied one
- Change Description line 383
- Line 172 of setconfig.go Check User
