### PR TITLE
Upgrade Atomix client to support stream cancellation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onosproject/onos-config
 go 1.12
 
 require (
-	github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04
+	github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba
 	github.com/atomix/atomix-go-local v0.0.0-20191021234710-cca1c26bf4d8
 	github.com/atomix/atomix-go-node v0.0.0-20191021234659-c841a97bec89
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/atomix/atomix-go-client v0.0.0-20191017214255-835d39bd51ae/go.mod h1:
 github.com/atomix/atomix-go-client v0.0.0-20191018192841-3644d110cbec/go.mod h1:bM51i8VXdxw3+vN5spPJWllkfsfpakHYo2bOkNj1xC4=
 github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04 h1:fluHrHxkZoEX2L9XCRi9SNiVa7QGO18LLnZDWed2PtQ=
 github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04/go.mod h1:6VGWcRlAruDx0+9iPL25TWrnlYyD7EQ5880wIUa+ZZc=
+github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba h1:p5YuTIlNv3iEH6hBCWlsUm442gB0LWqyDC2I4ttRl7Q=
+github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:lt/qUsFF29yT2ofmxOXfFzIz0poN22/Qa5SPdalgTKw=


### PR DESCRIPTION
#793 notes that there's currently no way for clients to close event streams. This upgrade enables stream management via the `Context` passed in to a `Watch` call.

To cancel a watch, create a cancellable context and call the cancel function to close the stream:
```go
ctx, cancel := context.WithCancel(context.Background())
defer cancel()

ch := make(chan *netchangetypes.NetworkChange)
store.Watch(ch, netchangestore.WithChangeID(change.ID))
for event := range ch {
    ...
}
```