### PR TITLE
Support closing streams in client code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onosproject/onos-config
 go 1.12
 
 require (
-	github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba
+	github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef
 	github.com/atomix/atomix-go-local v0.0.0-20191021234710-cca1c26bf4d8
 	github.com/atomix/atomix-go-node v0.0.0-20191021234659-c841a97bec89
 	github.com/docker/docker v1.13.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/onosproject/onos-config
 go 1.12
 
 require (
-	github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04
+	github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba
 	github.com/atomix/atomix-go-local v0.0.0-20191021234710-cca1c26bf4d8
 	github.com/atomix/atomix-go-node v0.0.0-20191021234659-c841a97bec89
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/atomix/atomix-go-client v0.0.0-20191017214255-835d39bd51ae/go.mod h1:
 github.com/atomix/atomix-go-client v0.0.0-20191018192841-3644d110cbec/go.mod h1:bM51i8VXdxw3+vN5spPJWllkfsfpakHYo2bOkNj1xC4=
 github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04 h1:fluHrHxkZoEX2L9XCRi9SNiVa7QGO18LLnZDWed2PtQ=
 github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04/go.mod h1:6VGWcRlAruDx0+9iPL25TWrnlYyD7EQ5880wIUa+ZZc=
+github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba h1:p5YuTIlNv3iEH6hBCWlsUm442gB0LWqyDC2I4ttRl7Q=
+github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:lt/qUsFF29yT2ofmxOXfFzIz0poN22/Qa5SPdalgTKw=

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04 h1:fluHrHx
 github.com/atomix/atomix-go-client v0.0.0-20191021233457-2f26f1f47f04/go.mod h1:6VGWcRlAruDx0+9iPL25TWrnlYyD7EQ5880wIUa+ZZc=
 github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba h1:p5YuTIlNv3iEH6hBCWlsUm442gB0LWqyDC2I4ttRl7Q=
 github.com/atomix/atomix-go-client v0.0.0-20191022190829-be49dba96dba/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
+github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef h1:RePrb4E2X3WFfgkFc2NlfoWlt8xU5y/STl6VSIvWJAk=
+github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:lt/qUsFF29yT2ofmxOXfFzIz0poN22/Qa5SPdalgTKw=

--- a/pkg/controller/snapshot/device/controller.go
+++ b/pkg/controller/snapshot/device/controller.go
@@ -111,9 +111,11 @@ func (r *Reconciler) reconcileMark(deviceSnapshot *devicesnaptype.DeviceSnapshot
 
 	// List the changes for the device
 	changes := make(chan *devicechangetypes.DeviceChange)
-	if err := r.changes.List(deviceSnapshot.DeviceID, changes); err != nil {
+	ctx, err := r.changes.List(deviceSnapshot.DeviceID, changes)
+	if err != nil {
 		return false, err
 	}
+	defer ctx.Close()
 
 	// Iterate through changes and populate the snapshot
 	log.Infof("Taking snapshot of device %s", deviceSnapshot.DeviceID)
@@ -197,9 +199,11 @@ func (r *Reconciler) reconcileDelete(deviceSnapshot *devicesnaptype.DeviceSnapsh
 
 	// List the changes for the device
 	changes := make(chan *devicechangetypes.DeviceChange)
-	if err := r.changes.List(deviceSnapshot.DeviceID, changes); err != nil {
+	ctx, err := r.changes.List(deviceSnapshot.DeviceID, changes)
+	if err != nil {
 		return false, err
 	}
+	defer ctx.Close()
 
 	// Iterate through changes up to the current snapshot index and delete changes
 	count := 0

--- a/pkg/controller/snapshot/network/controller.go
+++ b/pkg/controller/snapshot/network/controller.go
@@ -142,9 +142,11 @@ func (r *Reconciler) createDeviceSnapshots(snapshot *networksnaptypes.NetworkSna
 
 	// List network changes
 	changes := make(chan *networkchangetypes.NetworkChange)
-	if err := r.networkChanges.List(changes); err != nil {
+	ctx, err := r.networkChanges.List(changes)
+	if err != nil {
 		return false, err
 	}
+	defer ctx.Close()
 
 	// Compute the maximum timestamp for changes to be deleted from the change store
 	var maxTimestamp *time.Time
@@ -324,9 +326,11 @@ func (r *Reconciler) reconcileRunningDelete(snapshot *networksnaptypes.NetworkSn
 func (r *Reconciler) deleteNetworkChanges(snapshot *networksnaptypes.NetworkSnapshot) (bool, error) {
 	// List network changes
 	changes := make(chan *networkchangetypes.NetworkChange)
-	if err := r.networkChanges.List(changes); err != nil {
+	ctx, err := r.networkChanges.List(changes)
+	if err != nil {
 		return false, err
 	}
+	defer ctx.Close()
 
 	// Iterate through network changes and mark changes marked for deletion
 	for change := range changes {

--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
+	"github.com/onosproject/onos-config/pkg/store/stream"
 	changetypes "github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
@@ -144,23 +145,25 @@ func listenForDeviceResponse(mgr *Manager, target string) error {
 }
 
 func listenForChangeNotification(mgr *Manager, changeID networkchangetypes.ID) error {
-	networkChan := make(chan *networkchangetypes.NetworkChange)
-	errWatch := mgr.NetworkChangesStore.Watch(networkChan, networkchangestore.WithChangeID(changeID))
+	networkChan := make(chan stream.Event)
+	ctx, errWatch := mgr.NetworkChangesStore.Watch(networkChan, networkchangestore.WithChangeID(changeID))
 	if errWatch != nil {
 		return fmt.Errorf("can't complete rollback operation on target due to %s", errWatch)
 	}
+	defer ctx.Close()
 	for changeEvent := range networkChan {
-		log.Infof("Received notification for change ID %s, phase %s, state %s", changeEvent.ID,
-			changeEvent.Status.Phase, changeEvent.Status.State)
-		if changeEvent.Status.Phase == changetypes.Phase_ROLLBACK {
-			switch changeStatus := changeEvent.Status.State; changeStatus {
+		change := changeEvent.Object.(*networkchangetypes.NetworkChange)
+		log.Infof("Received notification for change ID %s, phase %s, state %s", change.ID,
+			change.Status.Phase, change.Status.State)
+		if change.Status.Phase == changetypes.Phase_ROLLBACK {
+			switch changeStatus := change.Status.State; changeStatus {
 			case changetypes.State_COMPLETE:
 				log.Infof("Rollback succeeded for change %s ", changeID)
 				return nil
 			case changetypes.State_FAILED:
 				log.Infof("Received Change Status %s", changeStatus)
 				return fmt.Errorf("issue in setting config reson %s, error %s, rolling back change %s",
-					changeEvent.Status.Reason, changeEvent.Status.Message, changeID)
+					change.Status.Reason, change.Status.Message, changeID)
 			default:
 				continue
 			}

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -105,12 +105,14 @@ func setUpWatchMock(mockStores *MockStores) {
 		}).AnyTimes()
 
 	mockStores.DeviceChangesStore.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(deviceId devicetopo.ID, c chan<- *devicechangetypes.DeviceChange, opts ...networkchangestore.WatchOption) error {
+		func(deviceId devicetopo.ID, c chan<- stream.Event, opts ...networkchangestore.WatchOption) (stream.Context, error) {
 			go func() {
-				c <- &deviceChange
+				c <- stream.Event{Object: &deviceChange}
 				close(c)
 			}()
-			return nil
+			return stream.NewContext(func() {
+
+			}), nil
 		}).AnyTimes()
 }
 

--- a/pkg/store/change/device/store.go
+++ b/pkg/store/change/device/store.go
@@ -318,6 +318,7 @@ func (s *atomixStore) List(device devicetopo.ID, ch chan<- *devicechangetypes.De
 
 	mapCh := make(chan *indexedmap.Entry)
 	if err := changes.Entries(ctx, mapCh); err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -346,6 +347,7 @@ func (s *atomixStore) Watch(device devicetopo.ID, ch chan<- stream.Event, opts .
 	ctx, cancel := context.WithCancel(context.Background())
 	mapCh := make(chan *indexedmap.Event)
 	if err := changes.Watch(ctx, mapCh, watchOpts...); err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/pkg/store/change/device/utils/utils.go
+++ b/pkg/store/change/device/utils/utils.go
@@ -34,11 +34,13 @@ func ExtractFullConfig(deviceID devicetopo.ID, newChange *devicechangetypes.Chan
 
 	changeChan := make(chan *devicechangetypes.DeviceChange)
 
-	err := changeStore.List(deviceID, changeChan)
+	ctx, err := changeStore.List(deviceID, changeChan)
 
 	if err != nil {
 		return nil, err
 	}
+
+	defer ctx.Close()
 
 	if newChange != nil {
 		consolidatedConfig = getPathValue(newChange, consolidatedConfig)

--- a/pkg/store/change/device/utils/utils_test.go
+++ b/pkg/store/change/device/utils/utils_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/base64"
 	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-config/pkg/store/change/device"
+	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
@@ -337,7 +338,7 @@ func setUp(t *testing.T) (*devicechangetypes.DeviceChange, *devicechangetypes.De
 	mockChangeStore.EXPECT().Get(deviceChange4.ID).Return(deviceChange4, nil).AnyTimes()
 
 	mockChangeStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(device devicetopo.ID, c chan<- *devicechangetypes.DeviceChange) error {
+		func(device devicetopo.ID, c chan<- *devicechangetypes.DeviceChange) (stream.Context, error) {
 			go func() {
 				c <- deviceChange1
 				c <- deviceChange2
@@ -348,7 +349,9 @@ func setUp(t *testing.T) (*devicechangetypes.DeviceChange, *devicechangetypes.De
 				}
 				close(c)
 			}()
-			return nil
+			return stream.NewContext(func() {
+
+			}), nil
 		}).AnyTimes()
 
 	return deviceChange3, deviceChange4, mockChangeStore

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -304,6 +304,7 @@ func (s *atomixStore) List(ch chan<- *networkchangetypes.NetworkChange) (stream.
 
 	mapCh := make(chan *indexedmap.Entry)
 	if err := s.changes.Entries(ctx, mapCh); err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -328,6 +329,7 @@ func (s *atomixStore) Watch(ch chan<- stream.Event, opts ...WatchOption) (stream
 
 	mapCh := make(chan *indexedmap.Event)
 	if err := s.changes.Watch(ctx, mapCh, watchOpts...); err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
+	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-config/pkg/store/utils"
 	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
 	"google.golang.org/grpc"
@@ -128,10 +129,10 @@ type Store interface {
 	Delete(config *networkchangetypes.NetworkChange) error
 
 	// List lists network configurations
-	List(chan<- *networkchangetypes.NetworkChange) error
+	List(chan<- *networkchangetypes.NetworkChange) (stream.Context, error)
 
 	// Watch watches the network configuration store for changes
-	Watch(chan<- *networkchangetypes.NetworkChange, ...WatchOption) error
+	Watch(chan<- stream.Event, ...WatchOption) (stream.Context, error)
 }
 
 // WatchOption is a configuration option for Watch calls
@@ -298,10 +299,12 @@ func (s *atomixStore) Delete(change *networkchangetypes.NetworkChange) error {
 	return nil
 }
 
-func (s *atomixStore) List(ch chan<- *networkchangetypes.NetworkChange) error {
+func (s *atomixStore) List(ch chan<- *networkchangetypes.NetworkChange) (stream.Context, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	mapCh := make(chan *indexedmap.Entry)
-	if err := s.changes.Entries(context.Background(), mapCh); err != nil {
-		return err
+	if err := s.changes.Entries(ctx, mapCh); err != nil {
+		return nil, err
 	}
 
 	go func() {
@@ -312,29 +315,54 @@ func (s *atomixStore) List(ch chan<- *networkchangetypes.NetworkChange) error {
 			}
 		}
 	}()
-	return nil
+	return stream.NewCancelContext(cancel), nil
 }
 
-func (s *atomixStore) Watch(ch chan<- *networkchangetypes.NetworkChange, opts ...WatchOption) error {
+func (s *atomixStore) Watch(ch chan<- stream.Event, opts ...WatchOption) (stream.Context, error) {
 	watchOpts := make([]indexedmap.WatchOption, 0)
 	for _, opt := range opts {
 		watchOpts = opt.apply(watchOpts)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	mapCh := make(chan *indexedmap.Event)
-	if err := s.changes.Watch(context.Background(), mapCh, watchOpts...); err != nil {
-		return err
+	if err := s.changes.Watch(ctx, mapCh, watchOpts...); err != nil {
+		return nil, err
 	}
 
 	go func() {
 		defer close(ch)
 		for event := range mapCh {
-			if config, err := decodeChange(event.Entry); err == nil {
-				ch <- config
+			if change, err := decodeChange(event.Entry); err == nil {
+				switch event.Type {
+				case indexedmap.EventNone:
+					ch <- stream.Event{
+						Type:   stream.None,
+						Object: change,
+					}
+				case indexedmap.EventInserted:
+					ch <- stream.Event{
+						Type:   stream.Created,
+						Object: change,
+					}
+				case indexedmap.EventUpdated:
+					ch <- stream.Event{
+						Type:   stream.Updated,
+						Object: change,
+					}
+				case indexedmap.EventRemoved:
+					ch <- stream.Event{
+						Type:   stream.Deleted,
+						Object: change,
+					}
+				}
 			}
 		}
 	}()
-	return nil
+	return stream.NewContext(func() {
+		cancel()
+	}), nil
 }
 
 func (s *atomixStore) Close() error {

--- a/pkg/store/snapshot/device/store.go
+++ b/pkg/store/snapshot/device/store.go
@@ -238,6 +238,7 @@ func (s *atomixStore) List(ch chan<- *devicesnapshot.DeviceSnapshot) (stream.Con
 
 	mapCh := make(chan *_map.Entry)
 	if err := s.deviceSnapshots.Entries(ctx, mapCh); err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -257,6 +258,7 @@ func (s *atomixStore) Watch(ch chan<- stream.Event) (stream.Context, error) {
 
 	mapCh := make(chan *_map.Event)
 	if err := s.deviceSnapshots.Watch(ctx, mapCh, _map.WithReplay()); err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -326,6 +328,7 @@ func (s *atomixStore) LoadAll(ch chan<- *devicesnapshot.Snapshot) (stream.Contex
 
 	mapCh := make(chan *_map.Entry)
 	if err := s.snapshots.Entries(ctx, mapCh); err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/pkg/store/snapshot/network/store.go
+++ b/pkg/store/snapshot/network/store.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
+	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-config/pkg/store/utils"
 	networksnapshot "github.com/onosproject/onos-config/pkg/types/snapshot/network"
 	"google.golang.org/grpc"
@@ -121,10 +122,10 @@ type Store interface {
 	Delete(snapshot *networksnapshot.NetworkSnapshot) error
 
 	// List lists network snapshots
-	List(chan<- *networksnapshot.NetworkSnapshot) error
+	List(chan<- *networksnapshot.NetworkSnapshot) (stream.Context, error)
 
 	// Watch watches the network snapshot store for changes
-	Watch(chan<- *networksnapshot.NetworkSnapshot) error
+	Watch(chan<- stream.Event) (stream.Context, error)
 }
 
 // newSnapshotID creates a new network snapshot ID
@@ -232,10 +233,12 @@ func (s *atomixStore) Delete(snapshot *networksnapshot.NetworkSnapshot) error {
 	return nil
 }
 
-func (s *atomixStore) List(ch chan<- *networksnapshot.NetworkSnapshot) error {
+func (s *atomixStore) List(ch chan<- *networksnapshot.NetworkSnapshot) (stream.Context, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	mapCh := make(chan *indexedmap.Entry)
-	if err := s.snapshots.Entries(context.Background(), mapCh); err != nil {
-		return err
+	if err := s.snapshots.Entries(ctx, mapCh); err != nil {
+		return nil, err
 	}
 
 	go func() {
@@ -246,24 +249,47 @@ func (s *atomixStore) List(ch chan<- *networksnapshot.NetworkSnapshot) error {
 			}
 		}
 	}()
-	return nil
+	return stream.NewCancelContext(cancel), nil
 }
 
-func (s *atomixStore) Watch(ch chan<- *networksnapshot.NetworkSnapshot) error {
+func (s *atomixStore) Watch(ch chan<- stream.Event) (stream.Context, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
 	mapCh := make(chan *indexedmap.Event)
-	if err := s.snapshots.Watch(context.Background(), mapCh, indexedmap.WithReplay()); err != nil {
-		return err
+	if err := s.snapshots.Watch(ctx, mapCh, indexedmap.WithReplay()); err != nil {
+		return nil, err
 	}
 
 	go func() {
 		defer close(ch)
 		for event := range mapCh {
 			if snapshot, err := decodeSnapshot(event.Entry); err == nil {
-				ch <- snapshot
+				switch event.Type {
+				case indexedmap.EventNone:
+					ch <- stream.Event{
+						Type:   stream.None,
+						Object: snapshot,
+					}
+				case indexedmap.EventInserted:
+					ch <- stream.Event{
+						Type:   stream.Created,
+						Object: snapshot,
+					}
+				case indexedmap.EventUpdated:
+					ch <- stream.Event{
+						Type:   stream.Updated,
+						Object: snapshot,
+					}
+				case indexedmap.EventRemoved:
+					ch <- stream.Event{
+						Type:   stream.Deleted,
+						Object: snapshot,
+					}
+				}
 			}
 		}
 	}()
-	return nil
+	return stream.NewCancelContext(cancel), nil
 }
 
 func (s *atomixStore) Close() error {

--- a/pkg/store/snapshot/network/store.go
+++ b/pkg/store/snapshot/network/store.go
@@ -238,6 +238,7 @@ func (s *atomixStore) List(ch chan<- *networksnapshot.NetworkSnapshot) (stream.C
 
 	mapCh := make(chan *indexedmap.Entry)
 	if err := s.snapshots.Entries(ctx, mapCh); err != nil {
+		cancel()
 		return nil, err
 	}
 
@@ -257,6 +258,7 @@ func (s *atomixStore) Watch(ch chan<- stream.Event) (stream.Context, error) {
 
 	mapCh := make(chan *indexedmap.Event)
 	if err := s.snapshots.Watch(ctx, mapCh, indexedmap.WithReplay()); err != nil {
+		cancel()
 		return nil, err
 	}
 

--- a/pkg/store/stream/stream.go
+++ b/pkg/store/stream/stream.go
@@ -1,0 +1,72 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import "context"
+
+// Context is a stream context
+type Context interface {
+	// Close closes the stream. The stream channel will be closed and resources used by the
+	// stream will be released.
+	Close()
+}
+
+// CloseFunc is a Context Close function
+type CloseFunc func()
+
+// NewContext creates a new context with a close function
+func NewContext(close CloseFunc) Context {
+	return &closerContext{
+		close: close,
+	}
+}
+
+// NewCancelContext creates a new stream context from a context CancelFunc
+func NewCancelContext(cancel context.CancelFunc) Context {
+	return NewContext(func() {
+		cancel()
+	})
+}
+
+type closerContext struct {
+	close CloseFunc
+}
+
+func (c *closerContext) Close() {
+	c.close()
+}
+
+// EventType is a stream event type
+type EventType string
+
+const (
+	// None indicates an object was not changed
+	None EventType = ""
+	// Created indicates an object was created
+	Created EventType = "Created"
+	// Updated indicates an object was updated
+	Updated EventType = "Updated"
+	// Deleted indicates an object was deleted
+	Deleted EventType = "Deleted"
+)
+
+// Event is a stream event
+type Event struct {
+	// Type is the stream event type
+	Type EventType
+
+	// Object is the event object
+	Object interface{}
+}

--- a/pkg/test/mocks/store/device_changes_store_mock.go
+++ b/pkg/test/mocks/store/device_changes_store_mock.go
@@ -8,6 +8,7 @@ import (
 	indexedmap "github.com/atomix/atomix-go-client/pkg/client/indexedmap"
 	gomock "github.com/golang/mock/gomock"
 	device "github.com/onosproject/onos-config/pkg/store/change/device"
+	stream "github.com/onosproject/onos-config/pkg/store/stream"
 	device0 "github.com/onosproject/onos-config/pkg/types/change/device"
 	device1 "github.com/onosproject/onos-topo/pkg/northbound/device"
 	reflect "reflect"
@@ -108,11 +109,12 @@ func (mr *MockDeviceChangesStoreMockRecorder) Delete(config interface{}) *gomock
 }
 
 // List mocks base method
-func (m *MockDeviceChangesStore) List(arg0 device1.ID, arg1 chan<- *device0.DeviceChange) error {
+func (m *MockDeviceChangesStore) List(arg0 device1.ID, arg1 chan<- *device0.DeviceChange) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // List indicates an expected call of List
@@ -122,15 +124,16 @@ func (mr *MockDeviceChangesStoreMockRecorder) List(arg0, arg1 interface{}) *gomo
 }
 
 // Watch mocks base method
-func (m *MockDeviceChangesStore) Watch(arg0 device1.ID, arg1 chan<- *device0.DeviceChange, arg2 ...device.WatchOption) error {
+func (m *MockDeviceChangesStore) Watch(arg0 device1.ID, arg1 chan<- stream.Event, arg2 ...device.WatchOption) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
 	for _, a := range arg2 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Watch", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch

--- a/pkg/test/mocks/store/device_snapshot_store_mock.go
+++ b/pkg/test/mocks/store/device_snapshot_store_mock.go
@@ -6,6 +6,7 @@ package store
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	stream "github.com/onosproject/onos-config/pkg/store/stream"
 	device "github.com/onosproject/onos-config/pkg/types/snapshot/device"
 	device0 "github.com/onosproject/onos-topo/pkg/northbound/device"
 	reflect "reflect"
@@ -106,11 +107,12 @@ func (mr *MockDeviceSnapshotStoreMockRecorder) Delete(snapshot interface{}) *gom
 }
 
 // List mocks base method
-func (m *MockDeviceSnapshotStore) List(arg0 chan<- *device.DeviceSnapshot) error {
+func (m *MockDeviceSnapshotStore) List(arg0 chan<- *device.DeviceSnapshot) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // List indicates an expected call of List
@@ -120,11 +122,12 @@ func (mr *MockDeviceSnapshotStoreMockRecorder) List(arg0 interface{}) *gomock.Ca
 }
 
 // Watch mocks base method
-func (m *MockDeviceSnapshotStore) Watch(arg0 chan<- *device.DeviceSnapshot) error {
+func (m *MockDeviceSnapshotStore) Watch(arg0 chan<- stream.Event) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch
@@ -163,11 +166,12 @@ func (mr *MockDeviceSnapshotStoreMockRecorder) Load(id interface{}) *gomock.Call
 }
 
 // LoadAll mocks base method
-func (m *MockDeviceSnapshotStore) LoadAll(ch chan<- *device.Snapshot) error {
+func (m *MockDeviceSnapshotStore) LoadAll(ch chan<- *device.Snapshot) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LoadAll", ch)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // LoadAll indicates an expected call of LoadAll

--- a/pkg/test/mocks/store/network_changes_store_mock.go
+++ b/pkg/test/mocks/store/network_changes_store_mock.go
@@ -8,6 +8,7 @@ import (
 	indexedmap "github.com/atomix/atomix-go-client/pkg/client/indexedmap"
 	gomock "github.com/golang/mock/gomock"
 	network "github.com/onosproject/onos-config/pkg/store/change/network"
+	stream "github.com/onosproject/onos-config/pkg/store/stream"
 	network0 "github.com/onosproject/onos-config/pkg/types/change/network"
 	reflect "reflect"
 )
@@ -152,11 +153,12 @@ func (mr *MockNetworkChangesStoreMockRecorder) Delete(config interface{}) *gomoc
 }
 
 // List mocks base method
-func (m *MockNetworkChangesStore) List(arg0 chan<- *network0.NetworkChange) error {
+func (m *MockNetworkChangesStore) List(arg0 chan<- *network0.NetworkChange) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // List indicates an expected call of List
@@ -166,15 +168,16 @@ func (mr *MockNetworkChangesStoreMockRecorder) List(arg0 interface{}) *gomock.Ca
 }
 
 // Watch mocks base method
-func (m *MockNetworkChangesStore) Watch(arg0 chan<- *network0.NetworkChange, arg1 ...network.WatchOption) error {
+func (m *MockNetworkChangesStore) Watch(arg0 chan<- stream.Event, arg1 ...network.WatchOption) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Watch", varargs...)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch

--- a/pkg/test/mocks/store/network_snapshot_store_mock.go
+++ b/pkg/test/mocks/store/network_snapshot_store_mock.go
@@ -6,6 +6,7 @@ package store
 
 import (
 	gomock "github.com/golang/mock/gomock"
+	stream "github.com/onosproject/onos-config/pkg/store/stream"
 	network "github.com/onosproject/onos-config/pkg/types/snapshot/network"
 	reflect "reflect"
 )
@@ -120,11 +121,12 @@ func (mr *MockNetworkSnapshotStoreMockRecorder) Delete(snapshot interface{}) *go
 }
 
 // List mocks base method
-func (m *MockNetworkSnapshotStore) List(arg0 chan<- *network.NetworkSnapshot) error {
+func (m *MockNetworkSnapshotStore) List(arg0 chan<- *network.NetworkSnapshot) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // List indicates an expected call of List
@@ -134,11 +136,12 @@ func (mr *MockNetworkSnapshotStoreMockRecorder) List(arg0 interface{}) *gomock.C
 }
 
 // Watch mocks base method
-func (m *MockNetworkSnapshotStore) Watch(arg0 chan<- *network.NetworkSnapshot) error {
+func (m *MockNetworkSnapshotStore) Watch(arg0 chan<- stream.Event) (stream.Context, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(stream.Context)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch


### PR DESCRIPTION
#793 mentioned there was no way to ensure streams are closed when a `Watch` call is partially completed.

This PR adds a `stream.Context` which is returned by `List` and `Watch` calls in stores. The `stream.Context` allows client code to `Close()` the stream when they're done with it. This will cause the Atomix clients to close underlying gRPC streams.