### PR TITLE
Add device type/version cache

### DIFF
--- a/pkg/store/device/cache.go
+++ b/pkg/store/device/cache.go
@@ -1,0 +1,106 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package device
+
+import (
+	"fmt"
+	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
+	"github.com/onosproject/onos-topo/pkg/northbound/device"
+	"io"
+	"sync"
+)
+
+const separator = ":"
+
+// newKey returns a new cache key
+func newKey(id device.ID, version string) string {
+	return fmt.Sprintf("%s%s%s", id, separator, version)
+}
+
+// Info is device type/version info
+type Info struct {
+	DeviceID device.ID
+	Type     string
+	Version  string
+}
+
+// Cache is a device type/version cache
+type Cache interface {
+	io.Closer
+
+	// GetDevices returns the set of devices in the cache
+	GetDevices() []Info
+}
+
+// NewCache returns a new cache based on the NetworkChange store
+func NewCache(networkChangeStore networkchangestore.Store) (Cache, error) {
+	cache := &networkChangeStoreCache{
+		networkChangeStore: networkChangeStore,
+		devices:            make(map[string]Info),
+	}
+	if err := cache.listen(); err != nil {
+		return nil, err
+	}
+	return cache, nil
+}
+
+// networkChangeStoreCache is a device cache based on the NetworkChange store
+type networkChangeStoreCache struct {
+	networkChangeStore networkchangestore.Store
+	devices            map[string]Info
+	mu                 sync.RWMutex
+}
+
+// listen starts listening for network changes
+func (c *networkChangeStoreCache) listen() error {
+	ch := make(chan *networkchangetypes.NetworkChange)
+	if err := c.networkChangeStore.Watch(ch); err != nil {
+		return err
+	}
+
+	go func() {
+		for netChange := range ch {
+			for _, devChange := range netChange.Changes {
+				key := newKey(devChange.DeviceID, devChange.DeviceVersion)
+				c.mu.Lock()
+				if _, ok := c.devices[key]; !ok {
+					c.devices[key] = Info{
+						DeviceID: devChange.DeviceID,
+						Type:     "",
+						Version:  devChange.DeviceVersion,
+					}
+				}
+				c.mu.Unlock()
+			}
+		}
+	}()
+	return nil
+}
+
+func (c *networkChangeStoreCache) GetDevices() []Info {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	devices := make([]Info, 0, len(c.devices))
+	for _, info := range c.devices {
+		devices = append(devices, info)
+	}
+	return devices
+}
+
+func (c *networkChangeStoreCache) Close() error {
+	return nil
+}

--- a/pkg/store/device/cache_test.go
+++ b/pkg/store/device/cache_test.go
@@ -1,0 +1,113 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package device
+
+import (
+	"github.com/golang/mock/gomock"
+	"github.com/onosproject/onos-config/pkg/store/stream"
+	"github.com/onosproject/onos-config/pkg/test/mocks/store"
+	devicechangetype "github.com/onosproject/onos-config/pkg/types/change/device"
+	networkchangetype "github.com/onosproject/onos-config/pkg/types/change/network"
+	"github.com/stretchr/testify/assert"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDeviceCache(t *testing.T) {
+	chVal := &atomic.Value{}
+	ctrl := gomock.NewController(t)
+	netChangeStore := store.NewMockNetworkChangesStore(ctrl)
+	netChangeStore.EXPECT().Watch(gomock.Any()).DoAndReturn(func(ch chan<- stream.Event) (stream.Context, error) {
+		chVal.Store(ch)
+		return stream.NewContext(func() {
+		}), nil
+	}).AnyTimes()
+
+	cache, err := NewCache(netChangeStore)
+	assert.NoError(t, err)
+
+	ch := chVal.Load().(chan<- stream.Event)
+	ch <- stream.Event{
+		Type: stream.Created,
+		Object: &networkchangetype.NetworkChange{
+			ID:    "network-change-1",
+			Index: 1,
+			Changes: []*devicechangetype.Change{
+				{
+					DeviceID:      "device-1",
+					DeviceType:    "Stratum",
+					DeviceVersion: "1.0.0",
+				},
+				{
+					DeviceID:      "device-2",
+					DeviceType:    "Stratum",
+					DeviceVersion: "1.0.0",
+				},
+			},
+		},
+	}
+	ch <- stream.Event{
+		Type: stream.Created,
+		Object: &networkchangetype.NetworkChange{
+			ID:    "network-change-1",
+			Index: 1,
+			Changes: []*devicechangetype.Change{
+				{
+					DeviceID:      "device-2",
+					DeviceType:    "Stratum",
+					DeviceVersion: "2.0.0",
+				},
+				{
+					DeviceID:      "device-1",
+					DeviceType:    "Stratum",
+					DeviceVersion: "1.0.0",
+				},
+			},
+		},
+	}
+	ch <- stream.Event{
+		Type: stream.Created,
+		Object: &networkchangetype.NetworkChange{
+			ID:    "network-change-1",
+			Index: 1,
+			Changes: []*devicechangetype.Change{
+				{
+					DeviceID:      "device-3",
+					DeviceType:    "NotStratum",
+					DeviceVersion: "1.0.0",
+				},
+			},
+		},
+	}
+
+	// Need to wait for the event to be read by the cache
+	time.Sleep(1 * time.Second)
+
+	devices := cache.GetDevicesByID("device-1")
+	assert.Len(t, devices, 1)
+
+	devices = cache.GetDevicesByID("device-2")
+	assert.Len(t, devices, 2)
+
+	devices = cache.GetDevices()
+	assert.Len(t, devices, 4)
+
+	devices = cache.GetDevicesByType("Stratum")
+	assert.Len(t, devices, 3)
+
+	devices = cache.GetDevicesByVersion("Stratum", "1.0.0")
+	assert.Len(t, devices, 2)
+}


### PR DESCRIPTION
This PR adds a cache for device types/versions needed to validate changes on the northbound. The cache listens for `NetworkChange` events and keeps track of the devices that have been specified through the northbound API. Using the `NetworkChange` store events ensures the cache is sequentially consistent as it's based on data from the strongly ordered `NetworkChange` store. Northbound APIs should use the cache to determine the device type/version for changes before writing them to the store. So the store informs the cache, and the cache informs later writes to the store.