### PR TITLE
Ensure parent NetworkChange ID is produced to NetworkChange controller on DeviceChange event

### DIFF
--- a/pkg/controller/change/network/watcher.go
+++ b/pkg/controller/change/network/watcher.go
@@ -126,7 +126,7 @@ func (w *DeviceWatcher) watchDevice(device devicetopo.ID, ch chan<- types.ID) {
 	w.wg.Add(1)
 	go func() {
 		for event := range deviceCh {
-			ch <- types.ID(event.Object.(*devicechangetypes.DeviceChange).ID)
+			ch <- types.ID(event.Object.(*devicechangetypes.DeviceChange).NetworkChange.ID)
 		}
 		w.wg.Done()
 	}()

--- a/pkg/controller/change/network/watcher_test.go
+++ b/pkg/controller/change/network/watcher_test.go
@@ -127,8 +127,6 @@ func TestNetworkWatcher(t *testing.T) {
 }
 
 func TestDeviceWatcher(t *testing.T) {
-	t.Skip("test disabled")
-
 	ctrl := gomock.NewController(t)
 
 	stream := NewMockDeviceService_ListClient(ctrl)


### PR DESCRIPTION
Fixes #803 