### PR TITLE
Previous - Computing the delta of a change that needs to be rolledback

### DIFF
--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -123,6 +123,8 @@ func computeNewRollback(m *Manager, rollbackChange *networkchangetypes.NetworkCh
 		},
 	}
 	prevChanges := make([]*devicechangetypes.Change, 0)
+	//TODO We might want to consider doing reverse iteration to get the previous value for a path instead of
+	// reading up to the previous change for the path. see comments on PR #805
 	for _, deviceChange := range rollbackChange.Changes {
 		previousValues := make([]*devicechangetypes.ChangeValue, 0)
 		for _, value := range deviceChange.Values {


### PR DESCRIPTION
This PR computes the full delta of the change that is requested to administratively rollback and applies it to the store as a new change containing all the reverse values for each path of the rollback requested one.
fixes #802 