### PR TITLE
Enabling rollback to be done on a per device basis in the device change controller

### DIFF
--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -15,6 +15,7 @@
 package device
 
 import (
+	"fmt"
 	"github.com/onosproject/onos-config/pkg/controller"
 	changestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
@@ -22,6 +23,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/types"
 	changetype "github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
+	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
@@ -156,8 +158,12 @@ func (r *Reconciler) reconcileRollback(change *devicechangetypes.DeviceChange) (
 // doRollback rolls back a change on the device
 func (r *Reconciler) doRollback(change *devicechangetypes.DeviceChange) error {
 	log.Infof("doRollback %v", change)
-	// TODO: Roll back the change
-	setRequest, err := values.NativeNewChangeToGnmiChange(change.Change)
+	deltaChange, err := r.computeNewRollback(change)
+	if err != nil {
+		return err
+	}
+	log.Infof("Rolling back %s with %s", change.Change, deltaChange)
+	setRequest, err := values.NativeNewChangeToGnmiChange(deltaChange)
 	if err != nil {
 		return err
 	}
@@ -178,6 +184,47 @@ func getProtocolState(device *devicetopo.Device) devicetopo.ChannelState {
 		return devicetopo.ChannelState_UNKNOWN_CHANNEL_STATE
 	}
 	return protocol.ChannelState
+}
+
+// computeRollback returns a change containing the previous value for each path of the rollbackChange
+func (r *Reconciler) computeNewRollback(deviceChange *devicechangetypes.DeviceChange) (*devicechangetypes.Change, error) {
+	prevChanges := make([]*devicechangetypes.Change, 0)
+	//TODO We might want to consider doing reverse iteration to get the previous value for a path instead of
+	// reading up to the previous change for the target. see comments on PR #805
+	previousValues := make([]*devicechangetypes.ChangeValue, 0)
+	prevValues, err := devicechangeutils.ExtractFullConfig(deviceChange.Change.DeviceID, nil, r.changes, 1)
+	if err != nil {
+		return nil, fmt.Errorf("can't get last config on network config %s for target %s, %s",
+			string(deviceChange.ID), deviceChange.Change.DeviceID, err)
+	}
+	rollbackChange := deviceChange.Change
+	for _, preVal := range prevValues {
+		for _, value := range rollbackChange.Values {
+			//Previously there was no such value configured, deleting from devicetopo
+			if preVal.Path == value.Path {
+				updateVal := &devicechangetypes.ChangeValue{
+					Path:    preVal.Path,
+					Value:   preVal.Value,
+					Removed: false,
+				}
+				previousValues = append(previousValues, updateVal)
+			} else {
+				deleteVal := &devicechangetypes.ChangeValue{
+					Path:    value.Path,
+					Value:   nil,
+					Removed: true,
+				}
+				previousValues = append(previousValues, deleteVal)
+			}
+		}
+
+	}
+	deltaChange := &devicechangetypes.Change{
+		DeviceID:      rollbackChange.DeviceID,
+		Values:        previousValues,
+	}
+	prevChanges = append(prevChanges, rollbackChange)
+	return deltaChange, nil
 }
 
 var _ controller.Reconciler = &Reconciler{}

--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/controller"
 	changestore "github.com/onosproject/onos-config/pkg/store/change/device"
+	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	mastershipstore "github.com/onosproject/onos-config/pkg/store/mastership"
 	"github.com/onosproject/onos-config/pkg/types"
 	changetype "github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
-	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	log "k8s.io/klog"
@@ -188,11 +188,10 @@ func getProtocolState(device *devicetopo.Device) devicetopo.ChannelState {
 
 // computeRollback returns a change containing the previous value for each path of the rollbackChange
 func (r *Reconciler) computeNewRollback(deviceChange *devicechangetypes.DeviceChange) (*devicechangetypes.Change, error) {
-	prevChanges := make([]*devicechangetypes.Change, 0)
 	//TODO We might want to consider doing reverse iteration to get the previous value for a path instead of
 	// reading up to the previous change for the target. see comments on PR #805
 	previousValues := make([]*devicechangetypes.ChangeValue, 0)
-	prevValues, err := devicechangeutils.ExtractFullConfig(deviceChange.Change.DeviceID, nil, r.changes, 1)
+	prevValues, err := devicechangeutils.ExtractFullConfig(deviceChange.Change.DeviceID, nil, r.changes, 0)
 	if err != nil {
 		return nil, fmt.Errorf("can't get last config on network config %s for target %s, %s",
 			string(deviceChange.ID), deviceChange.Change.DeviceID, err)
@@ -220,10 +219,9 @@ func (r *Reconciler) computeNewRollback(deviceChange *devicechangetypes.DeviceCh
 
 	}
 	deltaChange := &devicechangetypes.Change{
-		DeviceID:      rollbackChange.DeviceID,
-		Values:        previousValues,
+		DeviceID: rollbackChange.DeviceID,
+		Values:   previousValues,
 	}
-	prevChanges = append(prevChanges, rollbackChange)
 	return deltaChange, nil
 }
 

--- a/pkg/store/change/device/utils/utils.go
+++ b/pkg/store/change/device/utils/utils.go
@@ -15,7 +15,7 @@
 package utils
 
 import (
-	"github.com/onosproject/onos-config/pkg/store/change/device"
+	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"sort"
@@ -26,7 +26,7 @@ import (
 // This gets the change up to and including the latest
 // Use "nBack" to specify a number of changes back to go
 // If there are not as many changes in the history as nBack nothing is returned
-func ExtractFullConfig(deviceID devicetopo.ID, newChange *devicechangetypes.Change, changeStore device.Store,
+func ExtractFullConfig(deviceID devicetopo.ID, newChange *devicechangetypes.Change, changeStore devicechangestore.Store,
 	nBack int) ([]*devicechangetypes.PathValue, error) {
 
 	// Have to use a slice to have a consistent output order

--- a/pkg/store/change/device/utils/utils.go
+++ b/pkg/store/change/device/utils/utils.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
+	"github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"sort"
@@ -48,12 +49,16 @@ func ExtractFullConfig(deviceID devicetopo.ID, newChange *devicechangetypes.Chan
 
 	if nBack == 0 {
 		for storeChange := range changeChan {
-			consolidatedConfig = getPathValue(storeChange.Change, consolidatedConfig)
+			if storeChange.Status.State == change.State_COMPLETE && storeChange.Status.Phase != change.Phase_ROLLBACK {
+				consolidatedConfig = getPathValue(storeChange.Change, consolidatedConfig)
+			}
 		}
 	} else {
 		changes := make([]*devicechangetypes.DeviceChange, 0)
 		for storeChange := range changeChan {
-			changes = append(changes, storeChange)
+			if storeChange.Status.State == change.State_COMPLETE && storeChange.Status.Phase != change.Phase_ROLLBACK {
+				changes = append(changes, storeChange)
+			}
 		}
 		end := len(changes) - nBack
 		for _, storeChange := range changes[0:end] {

--- a/pkg/store/change/device/utils/utils_test.go
+++ b/pkg/store/change/device/utils/utils_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
+	changetypes "github.com/onosproject/onos-config/pkg/types/change"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"gotest.tools/assert"
@@ -288,6 +289,12 @@ func setUp(t *testing.T) (*devicechangetypes.DeviceChange, *devicechangetypes.De
 	deviceChange1 := &devicechangetypes.DeviceChange{
 		Change: &change1,
 		ID:     "Change1",
+		Status: changetypes.Status{
+			Phase:   changetypes.Phase_CHANGE,
+			State:   changetypes.State_COMPLETE,
+			Reason:  0,
+			Message: "",
+		},
 	}
 
 	config2Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechangetypes.NewTypedValueFloat(ValueLeaf2B314), false)
@@ -303,6 +310,12 @@ func setUp(t *testing.T) (*devicechangetypes.DeviceChange, *devicechangetypes.De
 	deviceChange2 := &devicechangetypes.DeviceChange{
 		Change: &change2,
 		ID:     "Change2",
+		Status: changetypes.Status{
+			Phase:   changetypes.Phase_CHANGE,
+			State:   changetypes.State_COMPLETE,
+			Reason:  0,
+			Message: "",
+		},
 	}
 
 	config3Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString(ValueLeaf2CDef), false)
@@ -317,6 +330,12 @@ func setUp(t *testing.T) (*devicechangetypes.DeviceChange, *devicechangetypes.De
 	deviceChange3 := &devicechangetypes.DeviceChange{
 		Change: &change3,
 		ID:     "Change3",
+		Status: changetypes.Status{
+			Phase:   changetypes.Phase_CHANGE,
+			State:   changetypes.State_COMPLETE,
+			Reason:  0,
+			Message: "",
+		},
 	}
 
 	config4Value01, _ := devicechangetypes.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechangetypes.NewTypedValueString(ValueLeaf2CGhi), false)
@@ -330,6 +349,12 @@ func setUp(t *testing.T) (*devicechangetypes.DeviceChange, *devicechangetypes.De
 	deviceChange4 := &devicechangetypes.DeviceChange{
 		Change: &change4,
 		ID:     "Change4",
+		Status: changetypes.Status{
+			Phase:   changetypes.Phase_CHANGE,
+			State:   changetypes.State_COMPLETE,
+			Reason:  0,
+			Message: "",
+		},
 	}
 
 	mockChangeStore.EXPECT().Get(deviceChange1.ID).Return(deviceChange1, nil).AnyTimes()


### PR DESCRIPTION
This PR enables rollback on a per device basis in the device/change/controller when the reconcileRollback is called. It computes the delta and sends it down to the device.. It does not store the resulting modifications to the network or change store. The network and change store have notion of rollback because the required change to be rolledback is placed in ROLLBACK state by the admin interface. 
ExtractFullConfig ignore changes in ROLLBACK to compute the full config. 

Fixes #802 