### PR TITLE
Remove references to deprecated stores from manager tests

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/change"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
@@ -187,7 +188,7 @@ func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigN
 		}).AnyTimes()
 
 	mockDeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(deviceID devicetopo.ID, c chan<- *devicechange.DeviceChange) error {
+		func(deviceID devicetopo.ID, c chan<- *devicechange.DeviceChange) (stream.Context, error) {
 			deviceChange := deviceChanges[deviceID]
 			go func() {
 				if deviceChange != nil {
@@ -195,10 +196,11 @@ func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigN
 				}
 				close(c)
 			}()
+			ctx := stream.NewContext(func() {})
 			if deviceChange != nil {
-				return nil
+				return ctx, nil
 			}
-			return errors.New("no Configuration found")
+			return ctx, errors.New("no Configuration found")
 		}).AnyTimes()
 	_ = mockDeviceChangesStore.Create(deviceChange1)
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -65,7 +65,6 @@ const (
 )
 
 func setUp(t *testing.T) (*Manager, *mockstore.MockDeviceStore, *mockstore.MockNetworkChangesStore, *mockstore.MockDeviceChangesStore) {
-
 	log.SetOutput(os.Stdout)
 	var (
 		mgrTest *Manager
@@ -475,7 +474,7 @@ func TestManager_GetAllDeviceIds(t *testing.T) {
 	assert.NilError(t, err, "SetTargetConfig error")
 
 	deviceIds := mgrTest.GetAllDeviceIds()
-	// TODO - this doesn't see the new devices
+	// TODO - GetAllDeviceIds() doesn't use the Atomix based stores yet
 	t.Skip()
 	assert.Equal(t, len(*deviceIds), 3)
 	assert.Assert(t, matchDeviceID((*deviceIds)[0], "Device1"))

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -24,6 +24,7 @@ import (
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
+	typeschange "github.com/onosproject/onos-config/pkg/types/change"
 	devicechange "github.com/onosproject/onos-config/pkg/types/change/device"
 	devicechangetypes "github.com/onosproject/onos-config/pkg/types/change/device"
 	types "github.com/onosproject/onos-config/pkg/types/change/device"
@@ -135,6 +136,7 @@ func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigN
 	deviceChange1 := &devicechange.DeviceChange{
 		Change: &change1,
 		ID:     "Change1",
+		Status: typeschange.Status{State: typeschange.State_COMPLETE},
 	}
 
 	now := time.Now()
@@ -143,6 +145,7 @@ func setUp(t *testing.T) (*Manager, map[string]*change.Change, map[store.ConfigN
 		Changes: []*types.Change{&change1},
 		Updated: now,
 		Created: now,
+		Status:  typeschange.Status{State: typeschange.State_COMPLETE},
 	}
 
 	// Mocks for stores

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -169,23 +169,24 @@ func (m *Manager) SetNetworkConfig(deviceName string, version string,
 
 // SetNewNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
 func (m *Manager) SetNewNetworkConfig(targetUpdates map[string]devicechangetypes.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetopo.ID]TypeVersionInfo, netcfgchangename string) {
+	targetRemoves map[string][]string, deviceInfo map[devicetopo.ID]TypeVersionInfo, netcfgchangename string) error {
 	//TODO evaluate need of user and add it back if need be.
 	//TODO start watch and build update Result
-	//TODO return error
+	//TODO return an error if the device is new and extensions 101 and 102 are not specified
 	allDeviceChanges, errChanges := m.computeNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 	if errChanges != nil {
-		log.Error("Can't compute new network configs", errChanges)
+		return errChanges
 	}
 	newNetworkConfig, errNetChange := networkchangetypes.NewNetworkChange(netcfgchangename, allDeviceChanges)
 	if errNetChange != nil {
-		log.Error("Can't create new network config", errNetChange)
+		return errNetChange
 	}
 	//Writing to the atomix backed store too
 	errStoreNewChange := m.NetworkChangesStore.Create(newNetworkConfig)
 	if errStoreNewChange != nil {
-		log.Error("Can't write new network config to atomix store", errStoreNewChange)
+		return errStoreNewChange
 	}
+	return nil
 }
 
 // getStoredConfig looks for an exact match for the config name or then a partial match based on the device name

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -196,7 +196,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	//Creating and setting the config on the new atomix Store
-	mgr.SetNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
+	_ = mgr.SetNewNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 
 	//Obtaining response based on distributed store generated events
 	updateResultsAtomix, errListen := listenAndBuildResponse(mgr, networkchangetypes.ID(netcfgchangename))


### PR DESCRIPTION
This PR removes most reference to the deprecated store types from the manager tests. There are still some references in the manager code to these stores, so minimal ones are still created. Test logic has been updated to use the new APIs with mocks of the Atomix based stores.