### PR TITLE
Moving types.ID to devicetopo.ID

### DIFF
--- a/pkg/types/device/types.go
+++ b/pkg/types/device/types.go
@@ -17,6 +17,7 @@ package device
 import (
 	"fmt"
 	"github.com/onosproject/onos-config/pkg/types"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"strings"
 )
 
@@ -26,7 +27,7 @@ const separator = ":"
 type Type string
 
 // ID is a device ID
-type ID types.ID
+type ID devicetopo.ID
 
 // Version is a device version
 type Version string

--- a/pkg/types/device/types.go
+++ b/pkg/types/device/types.go
@@ -24,7 +24,7 @@ import (
 const separator = ":"
 
 // Type is a device type
-type Type string
+type Type devicetopo.Type
 
 // ID is a device ID
 type ID devicetopo.ID


### PR DESCRIPTION
This PR refers the device.types.ID to devicetopo.ID and Type to devicetopo.type
I'd go one step further and remove these two constants altogether and importing devicetopo.ID, devicetopo.Type everywhere but I want to hear everybody's opinion, especially @kuujo 