### PR TITLE
Enable northbound set operation unit tests

### DIFF
--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -151,23 +151,8 @@ func Test_doSingleSet(t *testing.T) {
 
 // Test_doSingleSet shows how a value of 1 list can be set on a target
 func Test_doSingleSetList(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
 	pathElemsRefs, _ := utils.ParseGNMIElements(utils.SplitPath("/cont1a/list2a[name=a/b]/tx-power"))
 	typedValue := gnmi.TypedValue_UintVal{UintVal: 16}
 	value := gnmi.TypedValue{Value: &typedValue}
@@ -225,22 +210,7 @@ func Test_doSingleSetList(t *testing.T) {
 
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target
 func Test_do2SetsOnSameTarget(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	pathElemsRefs1, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2b"})
 	value1Str := gnmi.TypedValue_StringVal{StringVal: "newValue2b"}
@@ -283,22 +253,7 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 // Test_do2SetsOnDiffTargets shows how paths on multiple targets can be Set at
 // same time
 func Test_do2SetsOnDiffTargets(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	// Make the same change to 2 targets
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
@@ -341,21 +296,7 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 // Test_do2SetsOnOneTargetOneOnDiffTarget shows how multiple paths on multiple
 // targets can be Set at same time
 func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	// Make the same change to 2 targets
 	pathElemsRefs2a, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
@@ -411,21 +352,7 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 // a single target fails
 func Test_doDuplicateSetSingleTarget(t *testing.T) {
 	t.Skip("Not detecting error for duplicate change. Needs investigation")
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	// Make 2 changes
 	pathElemsRefs2a, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
@@ -480,21 +407,7 @@ func Test_doDuplicateSetSingleTarget(t *testing.T) {
 // duplicates it should fail
 func Test_doDuplicateSet2Targets(t *testing.T) {
 	t.Skip("Not detecting error for duplicate change. Needs investigation")
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	// Make 2 changes
 	pathElemsRefs2a, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
@@ -567,18 +480,7 @@ func Test_doDuplicateSet2Targets(t *testing.T) {
 // Note how the SetResponse does not include the dups
 func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 	t.Skip("Dupes not detected - needs investigation")
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	server, _, _, _ := setUpForSetTests(t)
 	// Make 2 changes
 	pathElemsRefs2a, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	valueStr2a := gnmi.TypedValue_StringVal{StringVal: "6thValue2a"}
@@ -666,21 +568,7 @@ func Test_doDuplicateSet1TargetNewOnOther(t *testing.T) {
 
 func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
 	t.Skip("Dupes not detected - needs investigation")
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	typedValue := gnmi.TypedValue_StringVal{StringVal: "Value2a"}
@@ -735,22 +623,7 @@ func Test_NetCfgSetWithDuplicateNameGiven(t *testing.T) {
 
 // Test_doSingleDelete shows how a value of 1 path can be deleted on a target
 func Test_doSingleDelete(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	deletePath := &gnmi.Path{Elem: pathElemsRefs.Elem, Target: "Device1"}
@@ -807,21 +680,7 @@ func Test_doSingleDelete(t *testing.T) {
 
 // Test_doUpdateDeleteSet shows how a request with a delete and an update can be applied on a target
 func Test_doUpdateDeleteSet(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
-	mgr.NetworkChangesStore = mockStores.NetworkChangesStore
-	setUpBaseNetworkStore(mockStores.NetworkChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
-		{
-			DeviceID: "Device1",
-			Version:  "1.0.0",
-			Type:     "TestDevice",
-		},
-	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	var deletePaths = make([]*gnmi.Path, 0)
-	var replacedPaths = make([]*gnmi.Update, 0)
-	var updatedPaths = make([]*gnmi.Update, 0)
+	server, deletePaths, replacedPaths, updatedPaths := setUpForSetTests(t)
 
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	typedValue := gnmi.TypedValue_StringVal{StringVal: "newValue2a"}

--- a/pkg/test/mocks/store/map_backed_network_changes_store_mock.go
+++ b/pkg/test/mocks/store/map_backed_network_changes_store_mock.go
@@ -23,7 +23,7 @@ import (
 )
 
 //SetUpMapBackedNetworkChangesStore : creates a map backed store for the given mock
-func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore MockNetworkChangesStore) {
+func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore *MockNetworkChangesStore) {
 	networkChangesList := make([]*networkchangetypes.NetworkChange, 0)
 	mockNetworkChangesStore.EXPECT().Create(gomock.Any()).DoAndReturn(
 		func(networkChange *networkchangetypes.NetworkChange) error {
@@ -63,7 +63,8 @@ func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore MockNetworkChange
 		func(c chan<- stream.Event, o ...networkstore.WatchOption) (stream.Context, error) {
 			go func() {
 				lastChange := networkChangesList[len(networkChangesList)-1]
-				if lastChange.Status.Phase == changetypes.Phase_ROLLBACK {
+				if lastChange.Status.Phase == changetypes.Phase_ROLLBACK ||
+					lastChange.Status.State == changetypes.State_PENDING {
 					lastChange.Status.State = changetypes.State_COMPLETE
 				}
 				event := stream.Event{

--- a/pkg/test/mocks/store/map_backed_network_changes_store_mock.go
+++ b/pkg/test/mocks/store/map_backed_network_changes_store_mock.go
@@ -1,0 +1,78 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"github.com/golang/mock/gomock"
+	networkstore "github.com/onosproject/onos-config/pkg/store/change/network"
+	"github.com/onosproject/onos-config/pkg/store/stream"
+	changetypes "github.com/onosproject/onos-config/pkg/types/change"
+	networkchangetypes "github.com/onosproject/onos-config/pkg/types/change/network"
+)
+
+//SetUpMapBackedNetworkChangesStore : creates a map backed store for the given mock
+func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore MockNetworkChangesStore) {
+	networkChangesList := make([]*networkchangetypes.NetworkChange, 0)
+	mockNetworkChangesStore.EXPECT().Create(gomock.Any()).DoAndReturn(
+		func(networkChange *networkchangetypes.NetworkChange) error {
+			networkChangesList = append(networkChangesList, networkChange)
+			return nil
+		}).AnyTimes()
+	mockNetworkChangesStore.EXPECT().Update(gomock.Any()).DoAndReturn(
+		func(networkChange *networkchangetypes.NetworkChange) error {
+			networkChangesList = append(networkChangesList, networkChange)
+			return nil
+		}).AnyTimes()
+	mockNetworkChangesStore.EXPECT().Get(gomock.Any()).DoAndReturn(
+		func(id networkchangetypes.ID) (*networkchangetypes.NetworkChange, error) {
+			var found *networkchangetypes.NetworkChange
+			for _, networkChange := range networkChangesList {
+				if networkChange.ID == id {
+					found = networkChange
+				}
+			}
+			if found != nil {
+				return found, nil
+			}
+			return nil, nil
+		}).AnyTimes()
+
+	mockNetworkChangesStore.EXPECT().List(gomock.Any()).DoAndReturn(
+		func(c chan<- *networkchangetypes.NetworkChange) error {
+			go func() {
+				for _, networkChange := range networkChangesList {
+					c <- networkChange
+				}
+				close(c)
+			}()
+			return nil
+		}).AnyTimes()
+	mockNetworkChangesStore.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(c chan<- stream.Event, o ...networkstore.WatchOption) (stream.Context, error) {
+			go func() {
+				lastChange := networkChangesList[len(networkChangesList)-1]
+				if lastChange.Status.Phase == changetypes.Phase_ROLLBACK {
+					lastChange.Status.State = changetypes.State_COMPLETE
+				}
+				event := stream.Event{
+					Type:   "",
+					Object: lastChange,
+				}
+				c <- event
+				close(c)
+			}()
+			return stream.NewContext(func() {}), nil
+		}).AnyTimes()
+}


### PR DESCRIPTION
This PR enables all of the positive Set operation unit tests in the northbound. The error tests that check detection of duplicates are still disabled, there is currently no way to detect those kinds of errors. The tests use a mock network change store backed by an in memory map that allows Set and Get operations.

In a future PR, the manager tests should be refactored to use this same mock. They currently have their own, very similar implementation.