### PR TITLE
Replay changes in device cache

### DIFF
--- a/pkg/store/device/cache.go
+++ b/pkg/store/device/cache.go
@@ -69,7 +69,7 @@ type networkChangeStoreCache struct {
 // listen starts listening for network changes
 func (c *networkChangeStoreCache) listen() error {
 	ch := make(chan stream.Event)
-	ctx, err := c.networkChangeStore.Watch(ch)
+	ctx, err := c.networkChangeStore.Watch(ch, networkchangestore.WithReplay())
 	if err != nil {
 		return err
 	}

--- a/pkg/store/device/cache_test.go
+++ b/pkg/store/device/cache_test.go
@@ -16,6 +16,7 @@ package device
 
 import (
 	"github.com/golang/mock/gomock"
+	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-config/pkg/test/mocks/store"
 	devicechangetype "github.com/onosproject/onos-config/pkg/types/change/device"
@@ -30,7 +31,7 @@ func TestDeviceCache(t *testing.T) {
 	chVal := &atomic.Value{}
 	ctrl := gomock.NewController(t)
 	netChangeStore := store.NewMockNetworkChangesStore(ctrl)
-	netChangeStore.EXPECT().Watch(gomock.Any()).DoAndReturn(func(ch chan<- stream.Event) (stream.Context, error) {
+	netChangeStore.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(ch chan<- stream.Event, opts ...networkchangestore.WatchOption) (stream.Context, error) {
 		chVal.Store(ch)
 		return stream.NewContext(func() {
 		}), nil


### PR DESCRIPTION
Fixes a bug in the device cache to force it to replay changes at startup.