### PR TITLE
Refactor mock store creation to use a struct to hold them all

### DIFF
--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -31,8 +31,8 @@ import (
 // See also the Test_getWithPrefixNoOtherPathsNoTarget below where the Target
 // is in the Prefix
 func Test_getNoTarget(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mocks := setUp(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	noTargetPath1 := gnmi.Path{Elem: make([]*gnmi.PathElem, 0)}
 	noTargetPath2 := gnmi.Path{Elem: make([]*gnmi.PathElem, 0)}
@@ -46,8 +46,8 @@ func Test_getNoTarget(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, _, mocks := setUp(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -63,16 +63,16 @@ func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 
 // Test_getNoPathElems tests for  Paths with no elements - should treat it like /
 func Test_getNoPathElems(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	server, _, mocks := setUp(t)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
 			Type:     "TestDevice",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	setUpListMock(mockStores)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	setUpListMock(mocks)
 
 	noPath1 := gnmi.Path{Target: "Device1"}
 	noPath2 := gnmi.Path{Target: "Device2"}
@@ -134,16 +134,16 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 }
 
 func Test_get2PathsWithPrefix(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	setUpChangesMock(mockStores.DeviceChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
+	server, _, mocks := setUp(t)
+	setUpChangesMock(mocks)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Type:     "Devicesim",
 			Version:  "1.0.0",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(4)
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -182,16 +182,16 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 }
 
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	setUpChangesMock(mockStores.DeviceChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
+	server, _, mocks := setUp(t)
+	setUpChangesMock(mocks)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Type:     "Devicesim",
 			Version:  "1.0.0",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -218,16 +218,16 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 }
 
 func Test_targetDoesNotExist(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device3")).Return([]*device.Info{
+	server, _, mocks := setUp(t)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device3")).Return([]*device.Info{
 		{
 			DeviceID: "Device3",
 			Type:     "Devicesim",
 			Version:  "1.0.0",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	setUpListMock(mockStores)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	setUpListMock(mocks)
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)
@@ -248,16 +248,16 @@ func Test_targetDoesNotExist(t *testing.T) {
 // Target does exist, but specified path does not
 // No error - just an empty value
 func Test_pathDoesNotExist(t *testing.T) {
-	server, _, mockStores := setUp(t)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
+	server, _, mocks := setUp(t)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Type:     "Devicesim",
 			Version:  "1.0.0",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
-	setUpListMock(mockStores)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	setUpListMock(mocks)
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
 	assert.NilError(t, err)

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -435,7 +435,7 @@ func Test_doUpdateDeleteSet(t *testing.T) {
 //TODO test with update and delete at the same time.
 
 func TestSet_checkForReadOnly(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
+	server, mgr, mocks := setUp(t)
 
 	modelPluginTestDevice1 := MockModelPlugin{
 		td1.UnzipSchema,
@@ -471,8 +471,8 @@ func TestSet_checkForReadOnly(t *testing.T) {
 		Version:  "1.0.0",
 	}
 
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-1")).Return([]*device.Info{&cacheInfo1v1, &cacheInfo1v2})
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-2")).Return([]*device.Info{&cacheInfo2v1})
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-1")).Return([]*device.Info{&cacheInfo1v1, &cacheInfo1v2})
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-2")).Return([]*device.Info{&cacheInfo2v1})
 
 	updateT1 := make(map[string]*devicechangetypes.TypedValue)
 	updateT1[cont1aCont2aLeaf2a] = devicechangetypes.NewTypedValueUint64(10)

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -79,18 +79,18 @@ func (x gNMISubscribeServerPollFake) Recv() (*gnmi.SubscribeRequest, error) {
 
 // Test_SubscribeLeafOnce tests subscribing with mode ONCE and then immediately receiving the subscription for a specific leaf.
 func Test_SubscribeLeafOnce(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
+	server, mgr, mocks := setUp(t)
 
-	setUpChangesMock(mockStores.DeviceChangesStore)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*device.Info, 0)).Times(1)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	setUpChangesMock(mocks)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*device.Info, 0)).Times(1)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
 			Type:     "Stratum",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -129,16 +129,16 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with updates for that path
 func Test_SubscribeLeafStream(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	server, mgr, mocks := setUp(t)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
 			Type:     "Stratum",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	mocks.MockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -201,8 +201,8 @@ func Test_SubscribeLeafStream(t *testing.T) {
 // Deprecated port to new
 func Test_WrongDevice(t *testing.T) {
 	t.Skip()
-	_, _, mockStores := setUp(t)
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	_, _, mocks := setUp(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -244,8 +244,8 @@ func Test_WrongDevice(t *testing.T) {
 
 func Test_WrongPath(t *testing.T) {
 	t.Skip("TODO - hangs, needs to be ported to new listening mechanism")
-	_, _, mockStores := setUp(t)
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	_, _, mocks := setUp(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 
 	path, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf4a"})
 
@@ -285,8 +285,8 @@ func Test_WrongPath(t *testing.T) {
 }
 
 func Test_ErrorDoubleSubscription(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
+	server, mgr, mocks := setUp(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found"))
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
 
@@ -324,16 +324,16 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 }
 
 func Test_Poll(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	server, mgr, mocks := setUp(t)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
 			Type:     "Stratum",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	setUpChangesMock(mockStores.DeviceChangesStore)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	setUpChangesMock(mocks)
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -393,17 +393,17 @@ func Test_Poll(t *testing.T) {
 
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with delete paths
 func Test_SubscribeLeafStreamDelete(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	server, mgr, mocks := setUp(t)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
 			Type:     "Stratum",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
-	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
-	setUpChangesMock(mockStores.DeviceChangesStore)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	mocks.MockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
+	setUpChangesMock(mocks)
 
 	var wg sync.WaitGroup
 	defer tearDown(mgr, &wg)
@@ -464,7 +464,7 @@ func Test_SubscribeLeafStreamDelete(t *testing.T) {
 // Test_SubscribeLeafStreamWithDeviceLoaded tests subscribing with mode STREAM for an existing device
 // and then issuing a set request with updates for that path
 func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
-	server, mgr, mockStores := setUp(t)
+	server, mgr, mocks := setUp(t)
 
 	targetStr := "Device1"
 	target := devicetopo.ID(targetStr)
@@ -472,16 +472,16 @@ func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
 		ID: target,
 	}
 
-	mockStores.DeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
 			Type:     "Stratum",
 		},
 	}).AnyTimes()
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(presentDevice, nil).AnyTimes()
-	mockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
-	setUpChangesMock(mockStores.DeviceChangesStore)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(presentDevice, nil).AnyTimes()
+	mocks.MockStores.NetworkChangesStore.EXPECT().Create(gomock.Any())
+	setUpChangesMock(mocks)
 
 	//configChan, respChan, err := mgr.Dispatcher.RegisterDevice(target)
 

--- a/pkg/test/mocks/store/mock_stores.go
+++ b/pkg/test/mocks/store/mock_stores.go
@@ -1,0 +1,26 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+// MockStores is a struct to hold all of the mocked stores for a test
+type MockStores struct {
+	DeviceStore          *MockDeviceStore
+	NetworkChangesStore  *MockNetworkChangesStore
+	DeviceChangesStore   *MockDeviceChangesStore
+	NetworkSnapshotStore *MockNetworkSnapshotStore
+	DeviceSnapshotStore  *MockDeviceSnapshotStore
+	LeadershipStore      *MockLeadershipStore
+	MastershipStore      *MockMastershipStore
+}


### PR DESCRIPTION
This PR groups all of the mock stores created to run tests into a single struct that can be shared. This eliminates code having to ignore many return values.