### PR TITLE
Implement unit tests for bad device types in gnmi Set() operations

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -350,40 +350,6 @@ func Test_SetNetworkConfig_NewConfig(t *testing.T) {
 	assert.Equal(t, value2C.Removed, true)
 }
 
-// When device type is given it is like extension 102 and allows a never heard of before config to be created - here it is missing
-func Test_SetNetworkConfig_NewConfig102Missing(t *testing.T) {
-	mgrTest, _ := setUp(t)
-
-	// Making change
-	updates := make(devicechangetypes.TypedValueMap)
-	deletes := []string{test1Cont1ACont2ALeaf2C}
-	updates[test1Cont1ACont2ALeaf2A] = devicechangetypes.NewTypedValueFloat(valueLeaf2B314)
-	updatesForDevice, deletesForDevice, deviceInfo := makeDeviceChanges("Device6", updates, deletes)
-
-	err := mgrTest.SetNetworkConfig(updatesForDevice, deletesForDevice, deviceInfo, "Test_SetNetworkConfig_Config")
-	// TODO - the error for the missing type is currently not detecting the error of the unknown device type
-	t.Skip()
-	assert.ErrorContains(t, err, "no configuration found matching 'Device6-1.0.0' and no device type () given Please specify version and device type in extensions 101 and 102")
-	//_, okupdate := configurationStoreTest["Device6-1.0.0"]
-	//assert.Assert(t, !okupdate, "Expecting not to find Device6-1.0.0")
-}
-
-func Test_SetBadNetworkConfig(t *testing.T) {
-
-	mgrTest, _ := setUp(t)
-
-	updates := make(devicechangetypes.TypedValueMap)
-	deletes := []string{test1Cont1ACont2ALeaf2A, test1Cont1ACont2ALeaf2C}
-	updates[test1Cont1ACont2ALeaf2B] = devicechangetypes.NewTypedValueFloat(valueLeaf2B159)
-	updatesForDevice1, deletesForDevice1, deviceInfo := makeDeviceChanges(device1, updates, deletes)
-
-	err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "Testing")
-	// TODO - Storing a new device without extensions 101 and 102 set does not currently throw an error
-	// enable test when an error can be seen
-	t.Skip()
-	assert.ErrorContains(t, err, "no configuration found")
-}
-
 func Test_SetMultipleSimilarNetworkConfig(t *testing.T) {
 
 	mgrTest, _ := setUp(t)

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -93,7 +93,8 @@ func Test_getNoPathElems(t *testing.T) {
 
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
-	server, _, _, _ := setUpForGetSetTests(t)
+	server, _, _, _, mocks := setUpForGetSetTests(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
 
@@ -116,7 +117,8 @@ func Test_getAllDevices(t *testing.T) {
 
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
-	server, _, _, _ := setUpForGetSetTests(t)
+	server, _, _, _, mocks := setUpForGetSetTests(t)
+	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 
 	request := gnmi.GetRequest{
 		Prefix: &gnmi.Path{Target: "*"},

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -263,7 +263,7 @@ func setUpBaseNetworkStore(store *mockstore.MockNetworkChangesStore) {
 }
 
 func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *devicestore.MockCache) {
-	deviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*devicestore.Info{
+	deviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*devicestore.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
@@ -271,7 +271,7 @@ func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *devicestore
 		},
 	}).AnyTimes()
 
-	mockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	mockStores.DeviceStore.EXPECT().Get(devicetopo.ID(device1)).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 	mockStores.DeviceStore.EXPECT().List(gomock.Any()).DoAndReturn(
 		func(c chan<- *devicetopo.Device) (stream.Context, error) {
 			go func() {
@@ -294,7 +294,7 @@ func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *devicestore
 		}).AnyTimes()
 }
 
-func setUpForGetSetTests(t *testing.T) (*Server, []*gnmi.Path, []*gnmi.Update, []*gnmi.Update) {
+func setUpForGetSetTests(t *testing.T) (*Server, []*gnmi.Path, []*gnmi.Update, []*gnmi.Update, *AllMocks) {
 	server, mgr, allMocks := setUp(t)
 	allMocks.MockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
 	mgr.NetworkChangesStore = allMocks.MockStores.NetworkChangesStore
@@ -303,7 +303,7 @@ func setUpForGetSetTests(t *testing.T) (*Server, []*gnmi.Path, []*gnmi.Update, [
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
-	return server, deletePaths, replacedPaths, updatedPaths
+	return server, deletePaths, replacedPaths, updatedPaths, allMocks
 }
 
 func tearDown(mgr *manager.Manager, wg *sync.WaitGroup) {


### PR DESCRIPTION
This moves the testing of the device versions passed in to get requests from the manager tests to the gnmi set tests.