### PR TITLE
Enable 'dogsled' anti-pattern linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - misspell
     - typecheck
     - errcheck
+    - dogsled
 run:
   skip-dirs:
     - modelplugin

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -93,7 +93,7 @@ func Test_getNoPathElems(t *testing.T) {
 
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
-	server, _, _, _, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
@@ -117,7 +117,7 @@ func Test_getAllDevices(t *testing.T) {
 
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
-	server, _, _, _, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 
 	request := gnmi.GetRequest{

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -293,16 +293,20 @@ func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *devicestore
 		}).AnyTimes()
 }
 
-func setUpForGetSetTests(t *testing.T) (*Server, []*gnmi.Path, []*gnmi.Update, []*gnmi.Update, *AllMocks) {
+func setUpForGetSetTests(t *testing.T) (*Server, *AllMocks) {
 	server, mgr, allMocks := setUp(t)
 	allMocks.MockStores.NetworkChangesStore = mockstore.NewMockNetworkChangesStore(gomock.NewController(t))
 	mgr.NetworkChangesStore = allMocks.MockStores.NetworkChangesStore
 	setUpBaseNetworkStore(allMocks.MockStores.NetworkChangesStore)
 	setUpBaseDevices(allMocks.MockStores, allMocks.MockDeviceCache)
+	return server, allMocks
+}
+
+func setUpPathsForGetSetTests() ([]*gnmi.Path, []*gnmi.Update, []*gnmi.Update) {
 	var deletePaths = make([]*gnmi.Path, 0)
 	var replacedPaths = make([]*gnmi.Update, 0)
 	var updatedPaths = make([]*gnmi.Update, 0)
-	return server, deletePaths, replacedPaths, updatedPaths, allMocks
+	return deletePaths, replacedPaths, updatedPaths
 }
 
 func tearDown(mgr *manager.Manager, wg *sync.WaitGroup) {

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -86,7 +86,8 @@ func setUpDeviceWithMultipleVersions(mocks *AllMocks, deviceName string) {
 
 // Test_doSingleSet shows how a value of 1 path can be set on a target
 func Test_doSingleSet(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, _ := setUpForGetSetTests(t)
+	server, _ := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	typedValue := gnmi.TypedValue_UintVal{UintVal: 16}
@@ -145,7 +146,8 @@ func Test_doSingleSet(t *testing.T) {
 
 // Test_doSingleSet shows how a value of 1 list can be set on a target
 func Test_doSingleSetList(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, _ := setUpForGetSetTests(t)
+	server, _ := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	pathElemsRefs, _ := utils.ParseGNMIElements(utils.SplitPath("/cont1a/list2a[name=a/b]/tx-power"))
 	typedValue := gnmi.TypedValue_UintVal{UintVal: 16}
@@ -204,7 +206,8 @@ func Test_doSingleSetList(t *testing.T) {
 
 // Test_do2SetsOnSameTarget shows how 2 paths can be changed on a target
 func Test_do2SetsOnSameTarget(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 	setUpLocalhostDeviceCache(mocks)
 
 	pathElemsRefs1, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2b"})
@@ -248,7 +251,8 @@ func Test_do2SetsOnSameTarget(t *testing.T) {
 // Test_do2SetsOnDiffTargets shows how paths on multiple targets can be Set at
 // same time
 func Test_do2SetsOnDiffTargets(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 	setUpLocalhostDeviceCache(mocks)
 
 	// Make the same change to 2 targets
@@ -292,7 +296,8 @@ func Test_do2SetsOnDiffTargets(t *testing.T) {
 // Test_do2SetsOnOneTargetOneOnDiffTarget shows how multiple paths on multiple
 // targets can be Set at same time
 func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 	setUpLocalhostDeviceCache(mocks)
 
 	// Make the same change to 2 targets
@@ -347,7 +352,8 @@ func Test_do2SetsOnOneTargetOneOnDiffTarget(t *testing.T) {
 
 // Test_doSingleDelete shows how a value of 1 path can be deleted on a target
 func Test_doSingleDelete(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, _ := setUpForGetSetTests(t)
+	server, _ := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	deletePath := &gnmi.Path{Elem: pathElemsRefs.Elem, Target: "Device1"}
@@ -404,7 +410,8 @@ func Test_doSingleDelete(t *testing.T) {
 
 // Test_doUpdateDeleteSet shows how a request with a delete and an update can be applied on a target
 func Test_doUpdateDeleteSet(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, _ := setUpForGetSetTests(t)
+	server, _ := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	pathElemsRefs, _ := utils.ParseGNMIElements([]string{"cont1a", "cont2a", "leaf2a"})
 	typedValue := gnmi.TypedValue_StringVal{StringVal: "newValue2a"}
@@ -541,7 +548,8 @@ func TestSet_checkForReadOnly(t *testing.T) {
 
 // Tests giving a new device without specifying a type
 func TestSet_MissingDeviceType(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	// Setting up mocks
 	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*devicestore.Info, 0))
@@ -568,7 +576,8 @@ func TestSet_MissingDeviceType(t *testing.T) {
 
 // Tests giving a device with multiple versions where the request doesn't specify which one
 func TestSet_ConflictingDeviceType(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	// Setting up mocks
 	const deviceName = "DeviceWithMultipleVersions"
@@ -595,7 +604,8 @@ func TestSet_ConflictingDeviceType(t *testing.T) {
 
 // Test giving a device with a type that doesn't match the type in the store
 func TestSet_BadDeviceType(t *testing.T) {
-	server, deletePaths, replacedPaths, updatedPaths, mocks := setUpForGetSetTests(t)
+	server, mocks := setUpForGetSetTests(t)
+	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	// Setting up mocks
 	const deviceName = "DeviceWithMultipleVersions"

--- a/pkg/southbound/synchronizer/synchronizer_test.go
+++ b/pkg/southbound/synchronizer/synchronizer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/test/mocks/southbound"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
-	topodevice "github.com/onosproject/onos-topo/api/device"
+	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -57,11 +57,17 @@ const (
 	gnmiVer070         = "0.7.0"
 )
 
-func synchronizerSetUp() (chan topodevice.ListResponse, chan events.OperationalStateEvent,
-	chan events.DeviceResponse, *dispatcher.Dispatcher,
-	*modelregistry.ModelRegistry, modelregistry.ReadOnlyPathMap,
-	devicechange.TypedValueMap, error) {
+type synchronizerParameters struct {
+	topoChan     chan devicetopo.ListResponse
+	opstateChan  chan events.OperationalStateEvent
+	responseChan chan events.DeviceResponse
+	dispatcher   *dispatcher.Dispatcher
+	models       *modelregistry.ModelRegistry
+	roPathMap    modelregistry.ReadOnlyPathMap
+	opstateCache devicechange.TypedValueMap
+}
 
+func synchronizerSetUp() (synchronizerParameters, error) {
 	dispatcher := dispatcher.NewDispatcher()
 	mr := new(modelregistry.ModelRegistry)
 	opStateCache := make(devicechange.TypedValueMap)
@@ -74,11 +80,16 @@ func synchronizerSetUp() (chan topodevice.ListResponse, chan events.OperationalS
 	roSubPath2[leaf2d] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
 	roSubPath2[list2bWcLeaf3c] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
 	roPathMap[cont1bState] = roSubPath2
-	return make(chan topodevice.ListResponse),
-		make(chan events.OperationalStateEvent),
-		make(chan events.DeviceResponse),
-		dispatcher, mr, roPathMap, opStateCache,
-		nil
+
+	return synchronizerParameters{
+		topoChan:     make(chan devicetopo.ListResponse),
+		opstateChan:  make(chan events.OperationalStateEvent),
+		responseChan: make(chan events.DeviceResponse),
+		dispatcher:   dispatcher,
+		models:       mr,
+		roPathMap:    roPathMap,
+		opstateCache: opStateCache,
+	}, nil
 }
 
 /**
@@ -89,17 +100,21 @@ func synchronizerSetUp() (chan topodevice.ListResponse, chan events.OperationalS
  * getting the OpState attributes
  */
 func TestNew(t *testing.T) {
-	topoChan, opstateChan, responseChan, dispatcher, models, roPathMap, opstateCache, err := synchronizerSetUp()
+	params, err := synchronizerSetUp()
 	assert.NilError(t, err, "Error in factorySetUp()")
-	assert.Assert(t, topoChan != nil)
-	assert.Assert(t, opstateChan != nil)
-	assert.Assert(t, responseChan != nil)
-	assert.Assert(t, dispatcher != nil)
-	assert.Assert(t, models != nil)
-	assert.Assert(t, roPathMap != nil)
-	assert.Assert(t, opstateCache != nil)
+	assert.Assert(t, params.topoChan != nil)
+	assert.Assert(t, params.opstateChan != nil)
+	assert.Assert(t, params.responseChan != nil)
+	assert.Assert(t, params.dispatcher != nil)
+	assert.Assert(t, params.models != nil)
+	assert.Assert(t, params.roPathMap != nil)
+	assert.Assert(t, params.opstateCache != nil)
 
-	_, textValue, _, _ := setUpStatePaths(t)
+	statePath, textValue, opPath, opValue := setUpStatePaths(t)
+	assert.Assert(t, statePath != nil)
+	assert.Assert(t, textValue != nil)
+	assert.Assert(t, opPath != nil)
+	assert.Assert(t, opValue != nil)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -141,7 +156,7 @@ func TestNew(t *testing.T) {
 
 	go func() {
 		// Handles any errors coming back from functions
-		for resp := range responseChan {
+		for resp := range params.responseChan {
 			assert.NilError(t, resp.Error(), "Expecting no error response")
 			// If all is running cleanly we should only get a response after Set
 			assert.Assert(t, strings.Contains(resp.Response(), `<path:<elem:<name:"cont1a" > elem:<name:"cont2a" >`))
@@ -149,7 +164,7 @@ func TestNew(t *testing.T) {
 	}()
 
 	s, err := New(context2.Background(), &mockDevice1,
-		opstateChan, responseChan, opstateCache, roPathMap, mockTarget,
+		params.opstateChan, params.responseChan, params.opstateCache, params.roPathMap, mockTarget,
 		modelregistry.GetStateExplicitRoPaths)
 	assert.NilError(t, err, "Creating s")
 	assert.Equal(t, string(s.ID), mock1NameStr)
@@ -163,7 +178,7 @@ func TestNew(t *testing.T) {
 
 	// Listen for OpState updates
 	go func() {
-		for o := range opstateChan {
+		for o := range params.opstateChan {
 			fmt.Println("OpState cache subscribe event received", o.Path(), o.EventType(), o.ItemAction())
 			assert.Equal(t, o.Subject(), mock1NameStr)
 		}
@@ -202,22 +217,22 @@ func TestNew(t *testing.T) {
 	).Return(nil).MinTimes(1)
 
 	// Called asynchronously as after building up the opStateCache it subscribes and waits
-	go s.syncOperationalStateByPaths(context2.Background(), mockTarget, responseChan)
+	go s.syncOperationalStateByPaths(context2.Background(), mockTarget, params.responseChan)
 
 	time.Sleep(200 * time.Millisecond) // Wait for response message
-	os1, ok := opstateCache[cont1bState+leaf2d]
+	os1, ok := params.opstateCache[cont1bState+leaf2d]
 	assert.Assert(t, ok, "Retrieving 1st path from Op State cache")
 	assert.Equal(t, os1.Type, devicechange.ValueType_UINT)
 	assert.Equal(t, os1.ValueToString(), "10001")
-	os2, ok := opstateCache[cont1aCont2aLeaf2c]
+	os2, ok := params.opstateCache[cont1aCont2aLeaf2c]
 	assert.Assert(t, ok, "Retrieving 2nd path from Op State cache")
 	assert.Equal(t, os2.Type, devicechange.ValueType_STRING)
 	assert.Equal(t, os2.ValueToString(), "Mock leaf2c value")
-	os3, ok := opstateCache[cont1bState+list2b100Leaf3c]
+	os3, ok := params.opstateCache[cont1bState+list2b100Leaf3c]
 	assert.Assert(t, ok, "Retrieving 3rd path from Op State cache")
 	assert.Equal(t, os3.Type, devicechange.ValueType_STRING)
 	assert.Equal(t, os3.ValueToString(), "mock Value in JSON")
-	os4, ok := opstateCache[cont1bState+list2b101Leaf3c]
+	os4, ok := params.opstateCache[cont1bState+list2b101Leaf3c]
 	assert.Assert(t, ok, "Retrieving 4th path from Op State cache")
 	assert.Equal(t, os4.Type, devicechange.ValueType_STRING)
 	assert.Equal(t, os4.ValueToString(), "Second mock Value")
@@ -312,7 +327,7 @@ func setUpStatePaths(t *testing.T) (*gnmi.Path, *gnmi.TypedValue, *gnmi.Path, *g
  * Also in this case we test the GetState_OpState for getting the OpState attribs
  */
 func TestNewWithExistingConfig(t *testing.T) {
-	_, opstateChan, responseChan, _, _, roPathMap, opstateCache, err := synchronizerSetUp()
+	params, err := synchronizerSetUp()
 	assert.NilError(t, err, "Error in factorySetUp()")
 
 	mockTarget, device1, capabilitiesResp := synchronizerBootstrap(t)
@@ -411,14 +426,14 @@ func TestNewWithExistingConfig(t *testing.T) {
 
 	go func() {
 		// Handles any errors coming back from functions
-		for resp := range responseChan {
+		for resp := range params.responseChan {
 			assert.NilError(t, resp.Error(), "Expecting no error response")
 			assert.Assert(t, strings.Contains(resp.Response(), `<path:<elem:<name:"cont1a" > elem:<name:"cont2a" >`))
 		}
 	}()
 
 	s, err := New(context2.Background(), device1,
-		opstateChan, responseChan, opstateCache, roPathMap, mockTarget, modelregistry.GetStateOpState)
+		params.opstateChan, params.responseChan, params.opstateCache, params.roPathMap, mockTarget, modelregistry.GetStateOpState)
 	assert.NilError(t, err, "Creating synchronizer")
 	assert.Equal(t, s.ID, device1.ID)
 	assert.Equal(t, s.Device.ID, device1.ID)
@@ -434,14 +449,14 @@ func TestNewWithExistingConfig(t *testing.T) {
 
 	// Listen for OpState updates
 	go func() {
-		for o := range opstateChan {
+		for o := range params.opstateChan {
 			fmt.Println("OpState cache subscribe event received", o.Path(), o.EventType(), o.ItemAction())
 			assert.Equal(t, o.Subject(), string("Device1"))
 		}
 	}()
 
 	// Called asynchronously as after building up the opStateCache it subscribes and waits
-	go s.syncOperationalStateByPartition(context2.Background(), mockTarget, responseChan)
+	go s.syncOperationalStateByPartition(context2.Background(), mockTarget, params.responseChan)
 	subscribeResp1 := gnmi.SubscribeResponse_Update{
 		Update: &gnmi.Notification{
 			Timestamp: time.Now().Unix(),
@@ -510,7 +525,7 @@ func TestNewWithExistingConfig(t *testing.T) {
 }
 
 func TestNewWithExistingConfigError(t *testing.T) {
-	_, opstateChan, responseChan, _, _, roPathMap, opstateCache, err := synchronizerSetUp()
+	params, err := synchronizerSetUp()
 	assert.NilError(t, err, "Error in factorySetUp()")
 
 	mockTarget, device1, capabilitiesResp := synchronizerBootstrap(t)
@@ -531,13 +546,13 @@ func TestNewWithExistingConfigError(t *testing.T) {
 	).Return(nil, status.Errorf(codes.Internal, "test, desc = error generated by mock"))
 
 	go func() {
-		for resp := range responseChan {
+		for resp := range params.responseChan {
 			assert.ErrorContains(t, resp.Error(), "error generated by mock")
 		}
 	}()
 
 	s, err := New(context2.Background(), device1,
-		opstateChan, responseChan, opstateCache, roPathMap, mockTarget, modelregistry.GetStateOpState)
+		params.opstateChan, params.responseChan, params.opstateCache, params.roPathMap, mockTarget, modelregistry.GetStateOpState)
 
 	assert.NilError(t, err, "Creating synchronizer")
 	assert.Equal(t, s.ID, device1.ID)

--- a/pkg/southbound/synchronizer/synchronizer_test.go
+++ b/pkg/southbound/synchronizer/synchronizer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/test/mocks/southbound"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
-	devicetopo "github.com/onosproject/onos-topo/pkg/northbound/device"
+	topodevice "github.com/onosproject/onos-topo/api/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -58,7 +58,7 @@ const (
 )
 
 type synchronizerParameters struct {
-	topoChan     chan devicetopo.ListResponse
+	topoChan     chan topodevice.ListResponse
 	opstateChan  chan events.OperationalStateEvent
 	responseChan chan events.DeviceResponse
 	dispatcher   *dispatcher.Dispatcher
@@ -82,7 +82,7 @@ func synchronizerSetUp() (synchronizerParameters, error) {
 	roPathMap[cont1bState] = roSubPath2
 
 	return synchronizerParameters{
-		topoChan:     make(chan devicetopo.ListResponse),
+		topoChan:     make(chan topodevice.ListResponse),
 		opstateChan:  make(chan events.OperationalStateEvent),
 		responseChan: make(chan events.DeviceResponse),
 		dispatcher:   dispatcher,


### PR DESCRIPTION
This PR enables the 'dogsled' anti-pattern linter. A 'dogsled' is where 3 or more return values from a function are ignored, like so:

x, _, _, _, _ := fn()

The linter is enabled, and several places where we were using this pattern were refactored.