### PR TITLE
Enable 'unconvert' linter 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - typecheck
     - errcheck
     - dogsled
+    - unconvert
 run:
   skip-dirs:
     - modelplugin

--- a/api/types/change/device/typedvalue.go
+++ b/api/types/change/device/typedvalue.go
@@ -892,7 +892,7 @@ func NewLeafListBytes(values [][]byte) *TypedLeafListBytes {
 	bytes := make([]byte, 0)
 	typeopts := make([]int32, 0)
 	for _, v := range values {
-		bytes = append(bytes, []byte(v)...)
+		bytes = append(bytes, v...)
 		typeopts = append(typeopts, int32(len(v)))
 	}
 	typedLeafListBytes := TypedLeafListBytes{

--- a/api/types/change/device/typedvalue_test.go
+++ b/api/types/change/device/typedvalue_test.go
@@ -70,8 +70,8 @@ func Test_TypedValueEmpty(t *testing.T) {
 	tv := NewTypedValueEmpty()
 
 	assert.Equal(t, len(tv.Bytes), 0)
-	testConversion(t, (*TypedValue)(tv))
-	assert.Equal(t, (*TypedValue)(tv).ValueToString(), "")
+	testConversion(t, tv)
+	assert.Equal(t, tv.ValueToString(), "")
 
 	tv2, err := NewTypedValue([]byte{0x0, 0x0, 0x0}, ValueType_EMPTY, []int32{})
 	assert.NilError(t, err)
@@ -83,8 +83,8 @@ func Test_TypedValueString(t *testing.T) {
 	tv := NewTypedValueString(testString)
 
 	assert.Equal(t, len(tv.Bytes), 14)
-	testConversion(t, (*TypedValue)(tv))
-	assert.Equal(t, (*TypedValue)(tv).ValueToString(), testString)
+	testConversion(t, tv)
+	assert.Equal(t, tv.ValueToString(), testString)
 }
 
 func Test_TypedValueInt(t *testing.T) {
@@ -321,7 +321,7 @@ func Test_JsonSerializationInt(t *testing.T) {
 	assert.DeepEqual(t, unmarshalledTv.Bytes, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80})
 
 	uintVal := (*TypedInt64)(&unmarshalledTv).Int()
-	assert.Equal(t, uintVal, int(testNegativeInt))
+	assert.Equal(t, uintVal, testNegativeInt)
 	assert.Equal(t, unmarshalledTv.ValueToString(), "-9223372036854775808")
 }
 

--- a/pkg/controller/change/network/watcher.go
+++ b/pkg/controller/change/network/watcher.go
@@ -127,7 +127,7 @@ func (w *DeviceWatcher) watchDevice(deviceID device.VersionedID, ch chan<- types
 	w.wg.Add(1)
 	go func() {
 		for event := range deviceCh {
-			ch <- types.ID(event.Object.(*devicechange.DeviceChange).NetworkChange.ID)
+			ch <- event.Object.(*devicechange.DeviceChange).NetworkChange.ID
 		}
 		w.wg.Done()
 	}()

--- a/pkg/modelregistry/jsonvalues/convertJsonRo_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonRo_test.go
@@ -47,7 +47,7 @@ func (m modelPluginTest) UnmarshalConfigValues(jsonTree []byte) (*ygot.Validated
 	device := &ds1.Device{}
 	vgs := ygot.ValidatedGoStruct(device)
 
-	if err := ds1.Unmarshal([]byte(jsonTree), device); err != nil {
+	if err := ds1.Unmarshal(jsonTree, device); err != nil {
 		return nil, err
 	}
 

--- a/pkg/modelregistry/jsonvalues/convertJsonTdRo_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonTdRo_test.go
@@ -39,7 +39,7 @@ func (m modelPluginTestDevice) UnmarshalConfigValues(jsonTree []byte) (*ygot.Val
 	device := &td1.Device{}
 	vgs := ygot.ValidatedGoStruct(device)
 
-	if err := td1.Unmarshal([]byte(jsonTree), device); err != nil {
+	if err := td1.Unmarshal(jsonTree, device); err != nil {
 		return nil, err
 	}
 

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -66,7 +66,7 @@ func (m modelPluginTest) UnmarshalConfigValues(jsonTree []byte) (*ygot.Validated
 	device := &ds1.Device{}
 	vgs := ygot.ValidatedGoStruct(device)
 
-	if err := ds1.Unmarshal([]byte(jsonTree), device); err != nil {
+	if err := ds1.Unmarshal(jsonTree, device); err != nil {
 		return nil, err
 	}
 

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -263,7 +263,7 @@ func (s *Server) formatUpdateOrReplace(u *gnmi.Update,
 		// Iterate through configs to find match for target
 		for _, info := range infos {
 			rwPaths, ok = manager.GetManager().ModelRegistry.
-				ModelReadWritePaths[utils.ToModelName(devicetype.Type(info.Type), devicetype.Version(info.Version))]
+				ModelReadWritePaths[utils.ToModelName(info.Type, info.Version)]
 			if ok {
 				break
 			}

--- a/pkg/southbound/clientManager_test.go
+++ b/pkg/southbound/clientManager_test.go
@@ -122,7 +122,7 @@ func setUp(t *testing.T) {
 
 	timeout := 10 * time.Second
 	device = topodevice.Device{
-		ID:      topodevice.ID("localhost-1"),
+		ID:      "localhost-1",
 		Address: "localhost:10161",
 		Version: "1.0.0",
 		Credentials: topodevice.Credentials{
@@ -411,7 +411,7 @@ func Test_SetWithString(t *testing.T) {
 	target, _, ctx := getDevice1Target(t)
 
 	request := "delete: <elem: <name: 'system'> elem:<name:'config'> elem: <name: 'hostname'>>"
-	setResponse, setErr := target.SetWithString(ctx, string(request))
+	setResponse, setErr := target.SetWithString(ctx, request)
 
 	assert.NilError(t, setErr)
 	assert.Assert(t, setResponse != nil)

--- a/pkg/southbound/synchronizer/synchronizer_test.go
+++ b/pkg/southbound/synchronizer/synchronizer_test.go
@@ -337,7 +337,7 @@ func TestNewWithExistingConfig(t *testing.T) {
 	mockTarget.EXPECT().ConnectTarget(
 		gomock.Any(),
 		*device1,
-	).Return(topodevice.ID(device1.ID), nil)
+	).Return(device1.ID, nil)
 
 	mockTarget.EXPECT().CapabilitiesWithString(
 		gomock.Any(),
@@ -451,7 +451,7 @@ func TestNewWithExistingConfig(t *testing.T) {
 	go func() {
 		for o := range params.opstateChan {
 			fmt.Println("OpState cache subscribe event received", o.Path(), o.EventType(), o.ItemAction())
-			assert.Equal(t, o.Subject(), string("Device1"))
+			assert.Equal(t, o.Subject(), "Device1")
 		}
 	}()
 
@@ -533,7 +533,7 @@ func TestNewWithExistingConfigError(t *testing.T) {
 	mockTarget.EXPECT().ConnectTarget(
 		gomock.Any(),
 		*device1,
-	).Return(topodevice.ID(device1.ID), nil)
+	).Return(device1.ID, nil)
 
 	mockTarget.EXPECT().CapabilitiesWithString(
 		gomock.Any(),

--- a/pkg/store/tree.go
+++ b/pkg/store/tree.go
@@ -134,7 +134,7 @@ func addPathToTree(path string, value *devicechange.TypedValue, nodeif *interfac
 		elemMap, ok := (nodemap)[pathelems[0]]
 		if !ok {
 			elemMap = make(map[string]interface{})
-			elemIf := interface{}(elemMap)
+			elemIf := elemMap
 
 			err := addPathToTree(refinePath, value, &elemIf, floatAsStr)
 			if err != nil {


### PR DESCRIPTION
This PR enables the 'unconvert' linter which checks for unnecessary type conversions. Instances of unneeded conversions were also fixed.