### PR TITLE
Enable nakedret and scopelint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,8 @@ linters:
     - errcheck
     - dogsled
     - unconvert
+    - nakedret
+    - scopelint
 run:
   skip-dirs:
     - modelplugin

--- a/pkg/modelregistry/jsonvalues/convertjson.go
+++ b/pkg/modelregistry/jsonvalues/convertjson.go
@@ -148,12 +148,13 @@ func CorrectJSONPaths(jsonBase string, jsonPathValues []*devicechange.PathValue,
 	indexTable := make([]indexEntry, len(indexMap))
 	i := 0
 	for path, idxElem := range indexMap {
-		sort.Slice(idxElem, func(i, j int) bool {
-			return idxElem[i] < idxElem[j]
+		key := idxElem
+		sort.Slice(key, func(i, j int) bool {
+			return key[i] < key[j]
 		})
 		indexTable[i] = indexEntry{
 			path: path,
-			key:  idxElem,
+			key:  key,
 		}
 		i++
 	}


### PR DESCRIPTION
Enable two more linters. One checks for "naked returns" which we currently don't use. The other makes sure that loop induction variables are not referred to by address.

