### PR TITLE
Don't lock a data structure across a channel send

### DIFF
--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -51,11 +51,11 @@ func (d *Dispatcher) ListenOperationalState(operationalStateChannel <-chan event
 	log.Info("Operational State Event listener initialized")
 
 	nbiChans := make([]chan events.OperationalStateEvent, 0)
-	d.nbiOpStateListenersLock.RLock()
+	d.nbiOpStateListenersLock.Lock()
 	for _, nbiChan := range d.nbiOpStateListeners {
 		nbiChans = append(nbiChans, nbiChan)
 	}
-	d.nbiOpStateListenersLock.RUnlock()
+	d.nbiOpStateListenersLock.Unlock()
 
 	for operationalStateEvent := range operationalStateChannel {
 		for _, nbiChan := range nbiChans {
@@ -79,8 +79,8 @@ func (d *Dispatcher) RegisterOpState(subscriber string) (chan events.Operational
 
 // UnregisterOperationalState closes the device channel and removes it from the deviceListeners
 func (d *Dispatcher) UnregisterOperationalState(subscriber string) {
-	d.nbiOpStateListenersLock.Lock()
-	defer d.nbiOpStateListenersLock.Unlock()
+	d.nbiOpStateListenersLock.RLock()
+	defer d.nbiOpStateListenersLock.RUnlock()
 	channel, ok := d.nbiOpStateListeners[subscriber]
 	if !ok {
 		log.Infof("Subscriber %s had not been registered", subscriber)

--- a/pkg/dispatcher/dispatcher.go
+++ b/pkg/dispatcher/dispatcher.go
@@ -50,10 +50,15 @@ func NewDispatcher() *Dispatcher {
 func (d *Dispatcher) ListenOperationalState(operationalStateChannel <-chan events.OperationalStateEvent) {
 	log.Info("Operational State Event listener initialized")
 
+	nbiChans := make([]chan events.OperationalStateEvent, 0)
 	d.nbiOpStateListenersLock.RLock()
-	defer d.nbiOpStateListenersLock.RUnlock()
+	for _, nbiChan := range d.nbiOpStateListeners {
+		nbiChans = append(nbiChans, nbiChan)
+	}
+	d.nbiOpStateListenersLock.RUnlock()
+
 	for operationalStateEvent := range operationalStateChannel {
-		for _, nbiChan := range d.nbiOpStateListeners {
+		for _, nbiChan := range nbiChans {
 			nbiChan <- operationalStateEvent
 		}
 	}

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -442,7 +442,6 @@ func (sync *Synchronizer) opStateSubHandler(msg proto.Message) error {
 			}
 		}
 
-		sync.operationalCacheLock.Lock()
 		for _, del := range notification.Delete {
 			if del.Elem == nil {
 				return fmt.Errorf("invalid nil path in update: %v", del)
@@ -450,9 +449,10 @@ func (sync *Synchronizer) opStateSubHandler(msg proto.Message) error {
 			pathStr := utils.StrPathElem(del.Elem)
 			log.Info("Delete path ", pathStr, " for device ", sync.ID)
 			sync.operationalStateChan <- events.NewOperationalStateEvent(string(sync.Device.ID), pathStr, nil, events.EventItemDeleted)
+			sync.operationalCacheLock.Lock()
 			delete(sync.operationalCache, pathStr)
+			sync.operationalCacheLock.Unlock()
 		}
-		sync.operationalCacheLock.Unlock()
 	}
 	return nil
 }


### PR DESCRIPTION
This fixes the subscribe integration test. A data structure was locked while a channel write was possible, causing a deadlock.