### PR TITLE
Added new param '-en PROTO' to gnmi_cli examples

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -354,11 +354,7 @@ service and port:
 > gnmi_cli -set \
     -address config.onosproject.org:443 \
     -proto "update: <path: <target: 'device-1-device-simulator', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Dublin'>>" \
-    -timeout 5s \
-    -client_crt deployments/helm/onos-config/files/certs/tls.crt \
-    -client_key deployments/helm/onos-config/files/certs/tls.key \
-    -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt \
-    -alsologtostderr
+    -timeout 5s -en PROTO -client_crt deployments/helm/onos-config/files/certs/tls.crt -client_key deployments/helm/onos-config/files/certs/tls.key -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt -alsologtostderr
 response: <
   path: <
     elem: <
@@ -395,11 +391,7 @@ through the northbound API:
 > gnmi_cli -get \
     -address config.onosproject.org:443 \
     -proto "path: <target: 'device-1-device-simulator', elem: <name: 'system'> elem: <name: 'clock' > elem:<name:'config'> elem: <name: 'timezone-name'>>" \
-    -timeout 5s \
-    -client_crt deployments/helm/onos-config/files/certs/tls.crt \
-    -client_key deployments/helm/onos-config/files/certs/tls.key \
-    -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt \
-    -alsologtostderr
+    -timeout 5s -en PROTO -alsologtostderr -client_crt deployments/helm/onos-config/files/certs/tls.crt -client_key deployments/helm/onos-config/files/certs/tls.key -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt
 notification: <
   timestamp: 1557856109
   update: <

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -354,7 +354,8 @@ service and port:
 > gnmi_cli -set \
     -address config.onosproject.org:443 \
     -proto "update: <path: <target: 'device-1-device-simulator', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Dublin'>>" \
-    -timeout 5s -en PROTO -client_crt deployments/helm/onos-config/files/certs/tls.crt -client_key deployments/helm/onos-config/files/certs/tls.key -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt -alsologtostderr
+    -timeout 5s -en PROTO \
+    -client_crt deployments/helm/onos-config/files/certs/tls.crt -client_key deployments/helm/onos-config/files/certs/tls.key -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt -alsologtostderr
 response: <
   path: <
     elem: <
@@ -391,7 +392,8 @@ through the northbound API:
 > gnmi_cli -get \
     -address config.onosproject.org:443 \
     -proto "path: <target: 'device-1-device-simulator', elem: <name: 'system'> elem: <name: 'clock' > elem:<name:'config'> elem: <name: 'timezone-name'>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt deployments/helm/onos-config/files/certs/tls.crt -client_key deployments/helm/onos-config/files/certs/tls.key -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt deployments/helm/onos-config/files/certs/tls.crt -client_key deployments/helm/onos-config/files/certs/tls.key -ca_crt deployments/helm/onos-config/files/certs/tls.cacrt
 notification: <
   timestamp: 1557856109
   update: <

--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -41,11 +41,8 @@ Use `gnmi_cli -get` to get configuration for a particular device (target) from t
 > If config from several devices are required, several paths can be added
 ```bash
 gnmi_cli -get -address onos-config:5150 \
-    -proto "path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt /etc/ssl/certs/client1.crt \
-    -client_key /etc/ssl/certs/client1.key \
-    -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 ### List all device names (targets)
@@ -53,10 +50,7 @@ A useful way to retrieve all stored device names is with the command:
 ```bash
 gnmi_cli -get -address onos-config:5150 \
     -proto "path: <target: '*'>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt /etc/ssl/certs/client1.crt \
-    -client_key /etc/ssl/certs/client1.key \
-    -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > The value in the response can be an individual value or a tree of values depending
@@ -64,11 +58,11 @@ gnmi_cli -get -address onos-config:5150 \
 
 ### List complete configuration for a device (target)
 >Use the following value for proto to get all configuration and operational state on a particular device
->    -proto "path: <target: 'localhost-1'>"
+>    -proto "path: <target: 'devicesim-1'>"
 
 ### Get a keyed index in a list
 Use a proto value like:
->    -proto "path: <target: 'localhost-1',
+>    -proto "path: <target: 'devicesim-1',
 >         elem: <name: 'system'>
 >         elem: <name: 'openflow'> elem: <name: 'controllers'>
 >         elem: <name: 'controller' key: <key: 'name' value: 'main'>>
@@ -83,11 +77,8 @@ one item of match all items respectively as defined in the gNMI
 For instance to retrieve all instances of an interface use `*` as the key: 
 ```bash
 gnmi_cli -get -address onos-config:5150 \
-    -proto "path:<target: 'localhost-1', elem:<name:'interfaces' > elem:<name:'interface' key:<key:'name' value:'*' > > elem:<name:'config'> elem:<name:'enabled' >>" \
-        -timeout 5s -alsologtostderr \
-        -client_crt /etc/ssl/certs/client1.crt \
-        -client_key /etc/ssl/certs/client1.key \
-        -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "path:<target: 'devicesim-1', elem:<name:'interfaces' > elem:<name:'interface' key:<key:'name' value:'*' > > elem:<name:'config'> elem:<name:'enabled' >>" \
+        -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 > This returns the `enabled` config attribute of both interfaces 'eth1' and 'admin'
 
@@ -95,11 +86,8 @@ To retrieve both the config and state values of both then additionally the use
 `*` in place of `config`:
 ```bash
 gnmi_cli -get -address onos-config:5150 \
-    -proto "path:<target: 'localhost-1', elem:<name:'interfaces' > elem:<name:'interface' key:<key:'name' value:'*' > > elem:<name:'*'> elem:<name:'enabled' >>" \
-        -timeout 5s -alsologtostderr \
-        -client_crt /etc/ssl/certs/client1.crt \
-        -client_key /etc/ssl/certs/client1.key \
-        -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "path:<target: 'devicesim-1', elem:<name:'interfaces' > elem:<name:'interface' key:<key:'name' value:'*' > > elem:<name:'*'> elem:<name:'enabled' >>" \
+        -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 > If the device is connected and the OperationState cache is populated this returns
 > 4 values - `eth1` config and state enabled values and `admin` config and
@@ -110,22 +98,16 @@ To retrieve state, non-configurable values, there is no difference with a normal
 An example follows:
 ```bash
 gnmi_cli -get -address onos-config:5150 \
-   -proto "path: <target: 'localhost-1',elem:<name:'system' > elem:<name:'openflow' > elem:<name:'controllers' > elem:<name:'controller' key:<key:'name' value:'main' > > elem:<name:'connections' > elem:<name:'connection' key:<key:'aux-id' value:'0' > > elem:<name:'state' > elem:<name:'address'>>" \
-   -timeout 5s -alsologtostderr \
-   -client_crt /etc/ssl/certs/client1.crt \
-   -client_key /etc/ssl/certs/client1.key \
-   -ca_crt /etc/ssl/certs/onfca.crt
+   -proto "path: <target: 'devicesim-1',elem:<name:'system' > elem:<name:'openflow' > elem:<name:'controllers' > elem:<name:'controller' key:<key:'name' value:'main' > > elem:<name:'connections' > elem:<name:'connection' key:<key:'aux-id' value:'0' > > elem:<name:'state' > elem:<name:'address'>>" \
+   -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 ## Northbound Set Request via gNMI
 Similarly, to make a gNMI Set request, use the `gnmi_cli -set` command as in the example below:
 
 ```bash
 gnmi_cli -address onos-config:5150 -set \
-    -proto "update: <path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt /etc/ssl/certs/client1.crt \
-    -client_key /etc/ssl/certs/client1.key \
-    -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "update: <path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 giving a response like
 ```bash
@@ -143,7 +125,7 @@ response: <
     elem: <
       name: "timezone-name"
     >
-    target: "localhost-1"
+    target: "devicesim-1"
   >
   op: UPDATE
 >
@@ -166,9 +148,9 @@ SetRequest() with the 100 extension at the end of the -proto section like:
 > See [gnmi_extensions.md](./gnmi_extensions.md) for more on gNMI extensions supported.
 
 > The corresponding -get for this require using the -proto
-> `path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>`
+> `path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>`
 
-> Currently (Jul '19) checking of the contents done only when a Model Plugin is
+> Currently (Nov '19) checking of the contents done only when a Model Plugin is
 > loaded for the device type. 2 checks are done
 >
 >   1. that a attempt is not being made to change a readonly attribute and
@@ -177,11 +159,31 @@ SetRequest() with the 100 extension at the end of the -proto section like:
 > The config is only forwarded down to the southbound layer only if the config is
 > correct and the device is registered in the topocache (currently in the deviceStore)
 
+### Target device not known/creating a new device target
 If the `target` device is not currently known to `onos-config` the system will store the configuration internally and apply
 it to the `target` device when/if it becomes available.
 
 When the `target` becomes available `onos-config` will compute the latest configuration for it based on the set of 
 applied changes and push it to the `target` with a standard `set` operation.
+
+In the case where the `target` device is not known, a special feature of onos-config
+has to be invoked to tell the system the type and version to use as a model plugin
+for validation - these are given in extensions 101 and 102.
+> This can be used to pre-provision new devices or new versions of devices before
+> they are available in the `onos-topo` topology.  
+
+For example using the
+gnmi_cli:
+```bash
+gnmi_cli -address onos-config:5150 -set \
+    -proto "update: <path: <target: 'new-device', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>, extension: <registered_ext: <id: 100, msg: 'my2ndchange'>>  , extension <registered_ext: <id: 101, msg: 'Devicesim'>>, extension: <registered_ext: <id: 102, msg: '1.0.0'>>" \
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+```
+
+> There are restrictions on the use of these extensions in this context:
+> * All targets specified in this `set` command will have to be of the same type
+> and version as given in extension 101 and 102, even if they already exist on
+> the system
 
 ## Northbound Delete Request via gNMI
 A delete request in gNMI is done using the set request with `delete` paths instead of `update` or `replace`.
@@ -189,11 +191,8 @@ To make a gNMI Set request do delete a path, use the `gnmi_cli -set` command as 
 
 ```bash
 gnmi_cli -address onos-config:5150 -set \
-    -proto "delete: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt /etc/ssl/certs/client1.crt \
-    -client_key /etc/ssl/certs/client1.key \
-    -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "delete: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 ## Northbound Subscribe Request for Stream Notifications via gNMI
@@ -202,11 +201,8 @@ please note the `0` as subscription mode to indicate streaming:
 
 ```bash
 gnmi_cli -address onos-config:5150 \
-    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt /etc/ssl/certs/client1.crt \
-    -client_key /etc/ssl/certs/client1.key \
-    -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > This command will block until there is a change at the requested value that gets
@@ -218,11 +214,8 @@ please note the `1` as subscription mode to indicate to send the response once:
 
 ```bash
 gnmi_cli -address onos-config:5150 \
-    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt /etc/ssl/certs/client1.crt \
-    -client_key /etc/ssl/certs/client1.key \
-    -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > This command will fail if no value is set at that specific path. This is due to limitations of the gnmi_cli.
@@ -232,12 +225,8 @@ Similarly, to make a gNMI Subscribe POLL request, use the `gnmi_cli` command as 
 please note the `2` as subscription mode to indicate to send the response in a polling way every `polling_interval` specified seconds:
 
 ```bash
-gnmi_cli -address onos-config:5150 \
-     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
-     -timeout 5s \
-     -polling_interval 5s \
-     -client_crt /etc/ssl/certs/client1.crt \
-     -client_key /etc/ssl/certs/client1.key \
-     -ca_crt /etc/ssl/certs/onfca.crt
+gnmi_cli -address onos-config:5150 -polling_interval 5s \
+     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+     -timeout 5s -en PROTO -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 > This command will fail if no value is set at that specific path. This is due to limitations of the gnmi_cli.

--- a/docs/gnmi.md
+++ b/docs/gnmi.md
@@ -42,7 +42,8 @@ Use `gnmi_cli -get` to get configuration for a particular device (target) from t
 ```bash
 gnmi_cli -get -address onos-config:5150 \
     -proto "path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 ### List all device names (targets)
@@ -50,7 +51,8 @@ A useful way to retrieve all stored device names is with the command:
 ```bash
 gnmi_cli -get -address onos-config:5150 \
     -proto "path: <target: '*'>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > The value in the response can be an individual value or a tree of values depending
@@ -78,7 +80,8 @@ For instance to retrieve all instances of an interface use `*` as the key:
 ```bash
 gnmi_cli -get -address onos-config:5150 \
     -proto "path:<target: 'devicesim-1', elem:<name:'interfaces' > elem:<name:'interface' key:<key:'name' value:'*' > > elem:<name:'config'> elem:<name:'enabled' >>" \
-        -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 > This returns the `enabled` config attribute of both interfaces 'eth1' and 'admin'
 
@@ -87,7 +90,8 @@ To retrieve both the config and state values of both then additionally the use
 ```bash
 gnmi_cli -get -address onos-config:5150 \
     -proto "path:<target: 'devicesim-1', elem:<name:'interfaces' > elem:<name:'interface' key:<key:'name' value:'*' > > elem:<name:'*'> elem:<name:'enabled' >>" \
-        -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 > If the device is connected and the OperationState cache is populated this returns
 > 4 values - `eth1` config and state enabled values and `admin` config and
@@ -98,8 +102,9 @@ To retrieve state, non-configurable values, there is no difference with a normal
 An example follows:
 ```bash
 gnmi_cli -get -address onos-config:5150 \
-   -proto "path: <target: 'devicesim-1',elem:<name:'system' > elem:<name:'openflow' > elem:<name:'controllers' > elem:<name:'controller' key:<key:'name' value:'main' > > elem:<name:'connections' > elem:<name:'connection' key:<key:'aux-id' value:'0' > > elem:<name:'state' > elem:<name:'address'>>" \
-   -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "path: <target: 'devicesim-1',elem:<name:'system' > elem:<name:'openflow' > elem:<name:'controllers' > elem:<name:'controller' key:<key:'name' value:'main' > > elem:<name:'connections' > elem:<name:'connection' key:<key:'aux-id' value:'0' > > elem:<name:'state' > elem:<name:'address'>>" \
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 ## Northbound Set Request via gNMI
 Similarly, to make a gNMI Set request, use the `gnmi_cli -set` command as in the example below:
@@ -107,7 +112,8 @@ Similarly, to make a gNMI Set request, use the `gnmi_cli -set` command as in the
 ```bash
 gnmi_cli -address onos-config:5150 -set \
     -proto "update: <path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 giving a response like
 ```bash
@@ -168,7 +174,8 @@ applied changes and push it to the `target` with a standard `set` operation.
 
 In the case where the `target` device is not known, a special feature of onos-config
 has to be invoked to tell the system the type and version to use as a model plugin
-for validation - these are given in extensions 101 and 102.
+for validation - these are given in extensions [101](./gnmi_extensions.md) (version)
+and [102](./gnmi_extensions.md) (type).
 > This can be used to pre-provision new devices or new versions of devices before
 > they are available in the `onos-topo` topology.  
 
@@ -176,14 +183,15 @@ For example using the
 gnmi_cli:
 ```bash
 gnmi_cli -address onos-config:5150 -set \
-    -proto "update: <path: <target: 'new-device', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>, extension: <registered_ext: <id: 100, msg: 'my2ndchange'>>  , extension <registered_ext: <id: 101, msg: 'Devicesim'>>, extension: <registered_ext: <id: 102, msg: '1.0.0'>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "update: <path: <target: 'new-device', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>> val: <string_val: 'Europe/Paris'>>, extension: <registered_ext: <id: 100, msg: 'my2ndchange'>>  , extension <registered_ext: <id: 101, msg: '1.0.0'>>, extension: <registered_ext: <id: 102, msg: 'Devicesim'>>" \
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > There are restrictions on the use of these extensions in this context:
 > * All targets specified in this `set` command will have to be of the same type
 > and version as given in extension 101 and 102, even if they already exist on
-> the system
+> the system.
 
 ## Northbound Delete Request via gNMI
 A delete request in gNMI is done using the set request with `delete` paths instead of `update` or `replace`.
@@ -192,7 +200,8 @@ To make a gNMI Set request do delete a path, use the `gnmi_cli -set` command as 
 ```bash
 gnmi_cli -address onos-config:5150 -set \
     -proto "delete: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 ## Northbound Subscribe Request for Stream Notifications via gNMI
@@ -202,7 +211,8 @@ please note the `0` as subscription mode to indicate streaming:
 ```bash
 gnmi_cli -address onos-config:5150 \
     -proto "subscribe:<mode: 0, prefix:<>, subscription:<path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > This command will block until there is a change at the requested value that gets
@@ -215,7 +225,8 @@ please note the `1` as subscription mode to indicate to send the response once:
 ```bash
 gnmi_cli -address onos-config:5150 \
     -proto "subscribe:<mode: 1, prefix:<>, subscription:<path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 
 > This command will fail if no value is set at that specific path. This is due to limitations of the gnmi_cli.
@@ -226,7 +237,8 @@ please note the `2` as subscription mode to indicate to send the response in a p
 
 ```bash
 gnmi_cli -address onos-config:5150 -polling_interval 5s \
-     -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
-     -timeout 5s -en PROTO -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
+    -proto "subscribe:<mode: 2, prefix:<>, subscription:<sample_interval: 5, path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'clock' > elem: <name: 'config'> elem: <name: 'timezone-name'>>>>" \
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 > This command will fail if no value is set at that specific path. This is due to limitations of the gnmi_cli.

--- a/docs/gnmi_extensions.md
+++ b/docs/gnmi_extensions.md
@@ -42,7 +42,7 @@ The following rules apply when a _prefix_ is present in the request:
 When doing a GetRequest if `*` is given as a `target` then the request returns a simple listing of all device names present in the system (with their version). Any path elements are ignored in this special case.
 
 
-# Managing configuration objects
+## Managing configuration objects
 The diagram shows the internal storage structures of onos-config (in orange). The
 Configuration object represents the complete configuration for a particular
 version of a device.
@@ -55,23 +55,23 @@ the ability to be rolled back (by the name of the Network Change).
 3 different extensions have been chosen in the project to make dealing with Network
 Changes and Configurations through gNMI possible.
 
-## Use of Extension 100 (network change name) in SetRequest and SetResponse
+### Use of Extension 100 (network change name) in SetRequest and SetResponse
 In onos-config the gNMI extension number 100 has been reserved for the
 `network change name`.
 
-### SetRequest
+#### SetRequest
 In the SetRequest extension 100 can be used to define a name for the Network
 change. If it is not specified then a name is picked automatically.
 > There is an example of setting this extension when using gnmi_cli in
 [gnmi.md](gnmi.md) (Northbound Set Request via gNMI)
 
-### SetResponse
+#### SetResponse
 In the SetResponse the name of the Network Change will always be given in
 extension 100 (either the given name or the generated one).
 >There is an example of the return of this extension through `gnmi_cli` in
 [gnmi.md](gnmi.md) (Northbound Set Request via gNMI)
 
-## Use of Extension 101 (device version) in SetRequest
+### Use of Extension 101 (device version) in SetRequest
 Extension 101 is used to set the Model version for a Configuration (as part of a
 Network Change). There may be multiple different configurations for a device based
 on version number. This extension allows the correct version of the configuration
@@ -84,7 +84,7 @@ specified.
 If no extension 101 (version) is given, and only one Configuration already exists
 for that device (target), then the change is applied to that Configuration.
 
-## Use of Extension 102 (device type) in SetRequest
+### Use of Extension 102 (device type) in SetRequest
 The target in the SetRequest contains the device name, but this is not enough to
 create a new Configuration if one does not exist - 3 pieces of information are
 required - the device name, the device type and the version (see diagram above).
@@ -93,17 +93,17 @@ Extension 102 is used to set the `device type`. If a Configuration already exist
 for this device name and version and its device type is different to what's
 given in extension 101, then an error is returned.
 
-## Use of Extension 103 (list of devices disconnected) in GetResponse, SetResponse, SubscribeResponse
+### Use of Extension 103 (list of devices disconnected) in GetResponse, SetResponse, SubscribeResponse
 In onos-config the gNMI extension number 103 has been reserved for the
 `list of devices disconnected`. The changes and device configuration is still valid and held 
 by onos-config until the device arrives in the network. 
 
-### GetResponse and SetResponse
+#### GetResponse and SetResponse
 In the GetResponse and GetRequest the `103` extension has an attached message containing a comma separated
 list of devices, e.g `device1,device2,device3` signaling which devices in the request are not
 yet connected to onos-config. 
 
-### SubscribeResponse
+#### SubscribeResponse
 In the SubscribeResponse the `103` extension has an attached message containing a single device, 
 e.g `device1` signaling that the device in the request is not yet connected to onos-config but 
 a configuration object has been changed. in Subscribe there is one device per response since it's

--- a/docs/modelplugin.md
+++ b/docs/modelplugin.md
@@ -282,10 +282,7 @@ should give an appropriate error
 ```bash
 > gnmi_cli -address localhost:5150 -set \
     -proto "update: <path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'openflow'> elem: <name: 'controllers'> elem: <name: 'controller' key: <key: 'name' value: 'main'>> elem: <name: 'connections'> elem: <name: 'connection' key: <key: 'aux-id' value: '0'>> elem: <name: 'state'> elem: <name: 'address'>> val: <string_val: '192.0.2.11'>>" \
-    -timeout 5s -alsologtostderr \
-    -client_crt pkg/southbound/testdata/client1.crt \
-    -client_key pkg/southbound/testdata/client1.key \
-    -ca_crt pkg/southbound/testdata/onfca.crt
+    -timeout 5s -en PROTO -alsologtostderr -client_crt pkg/southbound/testdata/client1.crt -client_key pkg/southbound/testdata/client1.key -ca_crt pkg/southbound/testdata/onfca.crt
 ```
 gives the error:
 ```bash

--- a/docs/modelplugin.md
+++ b/docs/modelplugin.md
@@ -280,9 +280,10 @@ When the Model Plugin is loaded, setting of an attribute like `state/address`
 should give an appropriate error
 
 ```bash
-> gnmi_cli -address localhost:5150 -set \
-    -proto "update: <path: <target: 'localhost-1', elem: <name: 'system'> elem: <name: 'openflow'> elem: <name: 'controllers'> elem: <name: 'controller' key: <key: 'name' value: 'main'>> elem: <name: 'connections'> elem: <name: 'connection' key: <key: 'aux-id' value: '0'>> elem: <name: 'state'> elem: <name: 'address'>> val: <string_val: '192.0.2.11'>>" \
-    -timeout 5s -en PROTO -alsologtostderr -client_crt pkg/southbound/testdata/client1.crt -client_key pkg/southbound/testdata/client1.key -ca_crt pkg/southbound/testdata/onfca.crt
+> gnmi_cli -address onos-config:5150 -set \
+    -proto "update: <path: <target: 'devicesim-1', elem: <name: 'system'> elem: <name: 'openflow'> elem: <name: 'controllers'> elem: <name: 'controller' key: <key: 'name' value: 'main'>> elem: <name: 'connections'> elem: <name: 'connection' key: <key: 'aux-id' value: '0'>> elem: <name: 'state'> elem: <name: 'address'>> val: <string_val: '192.0.2.11'>>" \
+    -timeout 5s -en PROTO -alsologtostderr \
+    -client_crt /etc/ssl/certs/client1.crt -client_key /etc/ssl/certs/client1.key -ca_crt /etc/ssl/certs/onfca.crt
 ```
 gives the error:
 ```bash

--- a/docs/run.md
+++ b/docs/run.md
@@ -35,7 +35,7 @@ Here is an example on how to use `gnmi_cli -get` to get configuration for a part
 ```bash
 > gnmi_cli -get -address onos-config:5150 \
     -proto "path: <target: 'localhost-1', elem: <name: 'system'> elem:<name:'config'> elem: <name: 'motd-banner'>>" \
-    -timeout 5s -alsologtostderr \
+    -timeout 5s -en PROTO -alsologtostderr \
     -client_crt /etc/ssl/certs/client1.crt \
     -client_key /etc/ssl/certs/client1.key \
     -ca_crt /etc/ssl/certs/onfca.crt


### PR DESCRIPTION
Updating only documentation.

- Added in an explaintaion of how to use Extension 101 and 102 together
- Brought additional CLI params on to same line
- Also changed example target to "devicesim-1" as this is more useful than "localhost-1" which is an unlikely name in a K8s installation