### PR TITLE
Refactor device cache to be in its own package

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -45,6 +45,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/store/change/network"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/leadership"
 	"github.com/onosproject/onos-config/pkg/store/mastership"
 	devicesnap "github.com/onosproject/onos-config/pkg/store/snapshot/device"
@@ -123,7 +124,7 @@ func main() {
 	}
 	log.Info("Network Configuration store connected")
 
-	deviceCache, err := devicestore.NewCache(networkChangesStore)
+	deviceCache, err := cache.NewCache(networkChangesStore)
 	if err != nil {
 		log.Error("Cannot load device cache", err)
 	}

--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -24,6 +24,7 @@ import (
 	changestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	mastershipstore "github.com/onosproject/onos-config/pkg/store/mastership"
 	"github.com/onosproject/onos-config/pkg/utils/values"
 	topodevice "github.com/onosproject/onos-topo/api/device"
@@ -33,7 +34,7 @@ import (
 
 // NewController returns a new network controller
 func NewController(mastership mastershipstore.Store, devices devicestore.Store,
-	cache devicestore.Cache, changes changestore.Store) *controller.Controller {
+	cache cache.Cache, changes changestore.Store) *controller.Controller {
 
 	c := controller.NewController("DeviceChange")
 	c.Filter(&controller.MastershipFilter{

--- a/pkg/controller/change/device/watcher.go
+++ b/pkg/controller/change/device/watcher.go
@@ -20,7 +20,7 @@ import (
 	devicetype "github.com/onosproject/onos-config/api/types/device"
 	"github.com/onosproject/onos-config/pkg/controller"
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	log "k8s.io/klog"
 	"sync"
@@ -30,7 +30,7 @@ const queueSize = 100
 
 // Watcher is a device change watcher
 type Watcher struct {
-	DeviceCache devicestore.Cache
+	DeviceCache cache.Cache
 	ChangeStore devicechangestore.Store
 	ch          chan<- types.ID
 	streams     map[devicetype.VersionedID]stream.Context
@@ -55,7 +55,7 @@ func (w *Watcher) Start(ch chan<- types.ID) error {
 	go func() {
 		for eventObj := range deviceCacheCh {
 			if eventObj.Type == stream.Created {
-				event := eventObj.Object.(*devicestore.Info)
+				event := eventObj.Object.(*cache.Info)
 				w.watchDevice(devicetype.NewVersionedID(event.DeviceID, event.Version), ch)
 			}
 		}

--- a/pkg/controller/change/network/controller.go
+++ b/pkg/controller/change/network/controller.go
@@ -22,13 +22,13 @@ import (
 	"github.com/onosproject/onos-config/pkg/controller"
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	leadershipstore "github.com/onosproject/onos-config/pkg/store/leadership"
 	log "k8s.io/klog"
 )
 
 // NewController returns a new config controller
-func NewController(leadership leadershipstore.Store, deviceCache devicestore.Cache, networkChanges networkchangestore.Store, deviceChanges devicechangestore.Store) *controller.Controller {
+func NewController(leadership leadershipstore.Store, deviceCache cache.Cache, networkChanges networkchangestore.Store, deviceChanges devicechangestore.Store) *controller.Controller {
 	c := controller.NewController("NetworkChange")
 	c.Activate(&controller.LeadershipActivator{
 		Store: leadership,

--- a/pkg/controller/change/network/watcher.go
+++ b/pkg/controller/change/network/watcher.go
@@ -22,7 +22,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/controller"
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	log "k8s.io/klog"
 	"sync"
@@ -74,7 +74,7 @@ var _ controller.Watcher = &Watcher{}
 
 // DeviceWatcher is a device change watcher
 type DeviceWatcher struct {
-	DeviceCache devicestore.Cache
+	DeviceCache cache.Cache
 	ChangeStore devicechangestore.Store
 	ch          chan<- types.ID
 	streams     map[device.VersionedID]stream.Context
@@ -99,7 +99,7 @@ func (w *DeviceWatcher) Start(ch chan<- types.ID) error {
 	go func() {
 		for eventObj := range deviceCacheCh {
 			if eventObj.Type == stream.Created {
-				event := eventObj.Object.(*devicestore.Info)
+				event := eventObj.Object.(*cache.Info)
 				w.watchDevice(device.NewVersionedID(event.DeviceID, event.Version), ch)
 			}
 		}

--- a/pkg/controller/change/network/watcher_test.go
+++ b/pkg/controller/change/network/watcher_test.go
@@ -22,8 +22,9 @@ import (
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/stream"
+	mockcache "github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
 	"github.com/stretchr/testify/assert"
 	log "k8s.io/klog"
 	"os"
@@ -139,7 +140,7 @@ func TestDeviceWatcher(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	t.Log("Testing")
-	cachedDevices := []*devicestore.Info{
+	cachedDevices := []*cache.Info{
 		{
 			DeviceID: "device-1",
 			Type:     "DeviceSim",
@@ -151,7 +152,7 @@ func TestDeviceWatcher(t *testing.T) {
 			Version:  "1.0.0",
 		},
 	}
-	deviceCache := devicestore.NewMockCache(ctrl)
+	deviceCache := mockcache.NewMockCache(ctrl)
 	deviceCache.EXPECT().Watch(gomock.Any(), true).DoAndReturn(
 		func(ch chan<- stream.Event, replay bool) (stream.Context, error) {
 			go func() {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/store/change/network"
 	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/leadership"
 	"github.com/onosproject/onos-config/pkg/store/mastership"
 	devicesnap "github.com/onosproject/onos-config/pkg/store/snapshot/device"
@@ -52,7 +53,7 @@ type Manager struct {
 	MastershipStore           mastership.Store
 	DeviceChangesStore        device.Store
 	DeviceStore               devicestore.Store
-	DeviceCache               devicestore.Cache
+	DeviceCache               cache.Cache
 	NetworkChangesStore       network.Store
 	NetworkSnapshotStore      networksnap.Store
 	DeviceSnapshotStore       devicesnap.Store
@@ -71,7 +72,7 @@ type Manager struct {
 
 // NewManager initializes the network config manager subsystem.
 func NewManager(leadershipStore leadership.Store, mastershipStore mastership.Store,
-	deviceChangesStore device.Store, deviceStore devicestore.Store, deviceCache devicestore.Cache,
+	deviceChangesStore device.Store, deviceStore devicestore.Store, deviceCache cache.Cache,
 	networkChangesStore network.Store, networkSnapshotStore networksnap.Store,
 	deviceSnapshotStore devicesnap.Store, topoCh chan *topodevice.ListResponse) (*Manager, error) {
 	log.Info("Creating Manager")
@@ -106,7 +107,7 @@ func NewManager(leadershipStore leadership.Store, mastershipStore mastership.Sto
 
 // LoadManager creates a configuration subsystem manager primed with stores loaded from the specified files.
 func LoadManager(leadershipStore leadership.Store, mastershipStore mastership.Store, deviceChangesStore device.Store,
-	deviceCache devicestore.Cache, networkChangesStore network.Store,
+	deviceCache cache.Cache, networkChangesStore network.Store,
 	networkSnapshotStore networksnap.Store, deviceSnapshotStore devicesnap.Store, deviceStore devicestore.Store) (*Manager, error) {
 	topoChannel := make(chan *topodevice.ListResponse, 10)
 

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -25,7 +25,7 @@ import (
 	devicechanges "github.com/onosproject/onos-config/pkg/store/change/device"
 	networkstore "github.com/onosproject/onos-config/pkg/store/change/network"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/leadership"
 	"github.com/onosproject/onos-config/pkg/store/mastership"
 	devicesnapstore "github.com/onosproject/onos-config/pkg/store/snapshot/device"
@@ -127,7 +127,7 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 	deviceSnapshotStore, err := devicesnapstore.NewLocalStore()
 	assert.NilError(t, err)
 
-	deviceCache, err := devicestore.NewCache(networkChangesStore)
+	deviceCache, err := cache.NewCache(networkChangesStore)
 	assert.NilError(t, err)
 
 	leadershipStore, err := leadership.NewLocalStore("test", cluster.NodeID("node1"))

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -20,7 +20,7 @@ import (
 	devicetype "github.com/onosproject/onos-config/api/types/device"
 	"github.com/onosproject/onos-config/pkg/store"
 	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/utils"
 	log "k8s.io/klog"
 )
@@ -71,7 +71,7 @@ func (m *Manager) ValidateNetworkConfig(deviceName devicetype.ID, version device
 
 // SetNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
 func (m *Manager) SetNetworkConfig(targetUpdates map[string]devicechange.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]devicestore.Info, netcfgchangename string) error {
+	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info, netcfgchangename string) error {
 	//TODO evaluate need of user and add it back if need be.
 	allDeviceChanges, errChanges := m.computeNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 	if errChanges != nil {
@@ -91,7 +91,7 @@ func (m *Manager) SetNetworkConfig(targetUpdates map[string]devicechange.TypedVa
 
 //computeNetworkConfig computes each device change
 func (m *Manager) computeNetworkConfig(targetUpdates map[string]devicechange.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]devicestore.Info,
+	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info,
 	description string) ([]*devicechange.Change, error) {
 
 	deviceChanges := make([]*devicechange.Change, 0)

--- a/pkg/northbound/admin/admin_test.go
+++ b/pkg/northbound/admin/admin_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-config/api/admin"
 	"github.com/onosproject/onos-config/pkg/manager"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
+	"github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 	"gotest.tools/assert"
@@ -65,7 +65,7 @@ func setUpServer(t *testing.T) (*manager.Manager, *grpc.ClientConn, admin.Config
 		mockstore.NewMockLeadershipStore(ctrl),
 		mockstore.NewMockMastershipStore(ctrl),
 		mockstore.NewMockDeviceChangesStore(ctrl),
-		devicestore.NewMockCache(ctrl),
+		cache.NewMockCache(ctrl),
 		mockstore.NewMockNetworkChangesStore(ctrl),
 		mockstore.NewMockNetworkSnapshotStore(ctrl),
 		mockstore.NewMockDeviceSnapshotStore(ctrl),

--- a/pkg/northbound/diags/diags_new_test.go
+++ b/pkg/northbound/diags/diags_new_test.go
@@ -24,9 +24,10 @@ import (
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	devicetypes "github.com/onosproject/onos-config/api/types/device"
 	"github.com/onosproject/onos-config/pkg/manager"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
+	mockcache "github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
 	topodevice "github.com/onosproject/onos-topo/api/device"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
@@ -69,7 +70,7 @@ func setUpServer(t *testing.T) (*manager.Manager, *grpc.ClientConn, diags.Change
 		mockstore.NewMockLeadershipStore(ctrl),
 		mockstore.NewMockMastershipStore(ctrl),
 		mockstore.NewMockDeviceChangesStore(ctrl),
-		devicestore.NewMockCache(ctrl),
+		mockcache.NewMockCache(ctrl),
 		mockstore.NewMockNetworkChangesStore(ctrl),
 		mockstore.NewMockNetworkSnapshotStore(ctrl),
 		mockstore.NewMockDeviceSnapshotStore(ctrl),
@@ -168,9 +169,9 @@ func Test_ListDeviceChanges(t *testing.T) {
 		}, nil,
 	)
 
-	mockDeviceCache, ok := mgrTest.DeviceCache.(*devicestore.MockCache)
+	mockDeviceCache, ok := mgrTest.DeviceCache.(*mockcache.MockCache)
 	assert.Assert(t, ok, "casting mock cache")
-	mockDeviceCache.EXPECT().GetDevicesByID(devicetypes.ID("device-1")).Return([]*devicestore.Info{
+	mockDeviceCache.EXPECT().GetDevicesByID(devicetypes.ID("device-1")).Return([]*cache.Info{
 		{
 			DeviceID: "device-1",
 			Type:     "Devicesim",
@@ -216,9 +217,9 @@ func Test_ListDeviceChangesNoVersionManyPresent(t *testing.T) {
 		nil, nil,
 	)
 
-	mockDeviceCache, ok := mgrTest.DeviceCache.(*devicestore.MockCache)
+	mockDeviceCache, ok := mgrTest.DeviceCache.(*mockcache.MockCache)
 	assert.Assert(t, ok, "casting mock cache")
-	mockDeviceCache.EXPECT().GetDevicesByID(devicetypes.ID("device-1")).Return([]*devicestore.Info{
+	mockDeviceCache.EXPECT().GetDevicesByID(devicetypes.ID("device-1")).Return([]*cache.Info{
 		{
 			DeviceID: "device-1",
 			Type:     "Devicesim",

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"github.com/golang/mock/gomock"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
-	"github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc/codes"
@@ -64,7 +64,7 @@ func Test_getWithPrefixNoOtherPathsNoTarget(t *testing.T) {
 // Test_getNoPathElems tests for  Paths with no elements - should treat it like /
 func Test_getNoPathElems(t *testing.T) {
 	server, _, mocks := setUp(t)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
@@ -138,7 +138,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 func Test_get2PathsWithPrefix(t *testing.T) {
 	server, _, mocks := setUp(t)
 	setUpChangesMock(mocks)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Type:     "Devicesim",
@@ -186,7 +186,7 @@ func Test_get2PathsWithPrefix(t *testing.T) {
 func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 	server, _, mocks := setUp(t)
 	setUpChangesMock(mocks)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Type:     "Devicesim",
@@ -221,7 +221,7 @@ func Test_getWithPrefixNoOtherPaths(t *testing.T) {
 
 func Test_targetDoesNotExist(t *testing.T) {
 	server, _, mocks := setUp(t)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device3")).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device3")).Return([]*cache.Info{
 		{
 			DeviceID: "Device3",
 			Type:     "Devicesim",
@@ -251,7 +251,7 @@ func Test_targetDoesNotExist(t *testing.T) {
 // No error - just an empty value
 func Test_pathDoesNotExist(t *testing.T) {
 	server, _, mocks := setUp(t)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Type:     "Devicesim",

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/onosproject/onos-config/pkg/dispatcher"
 	"github.com/onosproject/onos-config/pkg/manager"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
+	mockcache "github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
 	topodevice "github.com/onosproject/onos-topo/api/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
@@ -43,7 +44,7 @@ import (
 // because of circular dependencies.
 type AllMocks struct {
 	MockStores      *mockstore.MockStores
-	MockDeviceCache *devicestore.MockCache
+	MockDeviceCache *mockcache.MockCache
 }
 
 // TestMain should only contain static data.
@@ -208,7 +209,7 @@ func setUp(t *testing.T) (*Server, *manager.Manager, *AllMocks) {
 		LeadershipStore:      mockstore.NewMockLeadershipStore(ctrl),
 		MastershipStore:      mockstore.NewMockMastershipStore(ctrl),
 	}
-	deviceCache := devicestore.NewMockCache(ctrl)
+	deviceCache := mockcache.NewMockCache(ctrl)
 	allMocks.MockStores = mockStores
 	allMocks.MockDeviceCache = deviceCache
 
@@ -262,8 +263,8 @@ func setUpBaseNetworkStore(store *mockstore.MockNetworkChangesStore) {
 	_ = store.Create(networkChange1)
 }
 
-func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *devicestore.MockCache) {
-	deviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*devicestore.Info{
+func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *mockcache.MockCache) {
+	deviceCache.EXPECT().GetDevicesByID(devicetype.ID("Device1")).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -27,7 +27,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/modelregistry/jsonvalues"
 	"github.com/onosproject/onos-config/pkg/store"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
@@ -106,14 +106,14 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	}
 
 	mgr := manager.GetManager()
-	deviceInfo := make(map[devicetype.ID]devicestore.Info)
+	deviceInfo := make(map[devicetype.ID]cache.Info)
 	//Checking for wrong configuration against the device models for updates
 	for target, updates := range targetUpdates {
 		deviceType, version, err = mgr.CheckCacheForDevice(devicetype.ID(target), deviceType, version)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		deviceInfo[devicetype.ID(target)] = devicestore.Info{
+		deviceInfo[devicetype.ID(target)] = cache.Info{
 			DeviceID: devicetype.ID(target),
 			Type:     deviceType,
 			Version:  version,
@@ -144,7 +144,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		deviceInfo[devicetype.ID(target)] = devicestore.Info{
+		deviceInfo[devicetype.ID(target)] = cache.Info{
 			DeviceID: devicetype.ID(target),
 			Type:     deviceType,
 			Version:  version,

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -22,8 +22,7 @@ import (
 	td1 "github.com/onosproject/onos-config/modelplugin/TestDevice-1.0.0/testdevice_1_0_0"
 	td2 "github.com/onosproject/onos-config/modelplugin/TestDevice-2.0.0/testdevice_2_0_0"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
-	"github.com/onosproject/onos-config/pkg/store/device"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/utils"
 	topodevice "github.com/onosproject/onos-topo/api/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
@@ -50,14 +49,14 @@ func setUpLocalhostDeviceCache(mocks *AllMocks) {
 	const localhost1 = "localhost-1"
 	const localhost2 = "localhost-2"
 	// Setting up device cache
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("localhost-1")).Return([]*devicestore.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("localhost-1")).Return([]*cache.Info{
 		{
 			DeviceID: localhost1,
 			Version:  "1.0.0",
 			Type:     "TestDevice",
 		},
 	}).AnyTimes()
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("localhost-2")).Return([]*devicestore.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("localhost-2")).Return([]*cache.Info{
 		{
 			DeviceID: localhost2,
 			Version:  "1.0.0",
@@ -69,7 +68,7 @@ func setUpLocalhostDeviceCache(mocks *AllMocks) {
 
 func setUpDeviceWithMultipleVersions(mocks *AllMocks, deviceName string) {
 	// Setting up mocks
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID(deviceName)).Return([]*devicestore.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID(deviceName)).Return([]*cache.Info{
 		{
 			DeviceID: devicetype.ID(deviceName),
 			Version:  "1.0.0",
@@ -506,26 +505,26 @@ func TestSet_checkForReadOnly(t *testing.T) {
 	readOnlyPathsTd2, _ := modelregistry.ExtractPaths(td2Schema["Device"], yang.TSUnset, "", "")
 	mgr.ModelRegistry.ModelReadOnlyPaths["TestDevice-2.0.0"] = readOnlyPathsTd2
 
-	cacheInfo1v1 := device.Info{
+	cacheInfo1v1 := cache.Info{
 		DeviceID: "device-1",
 		Type:     "TestDevice",
 		Version:  "1.0.0",
 	}
 
-	cacheInfo1v2 := device.Info{
+	cacheInfo1v2 := cache.Info{
 		DeviceID: "device-1",
 		Type:     "TestDevice",
 		Version:  "2.0.0",
 	}
 
-	cacheInfo2v1 := device.Info{
+	cacheInfo2v1 := cache.Info{
 		DeviceID: "device-2",
 		Type:     "TestDevice",
 		Version:  "1.0.0",
 	}
 
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-1")).Return([]*device.Info{&cacheInfo1v1, &cacheInfo1v2})
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-2")).Return([]*device.Info{&cacheInfo2v1})
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-1")).Return([]*cache.Info{&cacheInfo1v1, &cacheInfo1v2})
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(devicetype.ID("device-2")).Return([]*cache.Info{&cacheInfo2v1})
 
 	updateT1 := make(map[string]*devicechange.TypedValue)
 	updateT1[cont1aCont2aLeaf2a] = devicechange.NewTypedValueUint64(10)
@@ -552,7 +551,7 @@ func TestSet_MissingDeviceType(t *testing.T) {
 	deletePaths, replacedPaths, updatedPaths := setUpPathsForGetSetTests()
 
 	// Setting up mocks
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*devicestore.Info, 0))
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*cache.Info, 0))
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 
 	// Making change

--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -17,7 +17,7 @@ package gnmi
 import (
 	"context"
 	"github.com/golang/mock/gomock"
-	"github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/utils"
 	topodevice "github.com/onosproject/onos-topo/api/device"
 	"github.com/openconfig/gnmi/proto/gnmi"
@@ -82,8 +82,8 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 	server, mgr, mocks := setUp(t)
 
 	setUpChangesMock(mocks)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*device.Info, 0)).Times(1)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return(make([]*cache.Info, 0)).Times(1)
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
@@ -130,7 +130,7 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with updates for that path
 func Test_SubscribeLeafStream(t *testing.T) {
 	server, mgr, mocks := setUp(t)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
@@ -325,7 +325,7 @@ func Test_ErrorDoubleSubscription(t *testing.T) {
 
 func Test_Poll(t *testing.T) {
 	server, mgr, mocks := setUp(t)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
@@ -394,7 +394,7 @@ func Test_Poll(t *testing.T) {
 // Test_SubscribeLeafDelete tests subscribing with mode STREAM and then issuing a set request with delete paths
 func Test_SubscribeLeafStreamDelete(t *testing.T) {
 	server, mgr, mocks := setUp(t)
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",
@@ -472,7 +472,7 @@ func Test_SubscribeLeafStreamWithDeviceLoaded(t *testing.T) {
 		ID: target,
 	}
 
-	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*device.Info{
+	mocks.MockDeviceCache.EXPECT().GetDevicesByID(gomock.Any()).Return([]*cache.Info{
 		{
 			DeviceID: "Device1",
 			Version:  "1.0.0",

--- a/pkg/store/device/cache/cache.go
+++ b/pkg/store/device/cache/cache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package device
+package cache
 
 import (
 	"fmt"

--- a/pkg/store/device/cache/cache_test.go
+++ b/pkg/store/device/cache/cache_test.go
@@ -11,8 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
 
-package device
+package cache
 
 import (
 	"github.com/golang/mock/gomock"

--- a/pkg/test/mocks/store/cache/cache_mock.go
+++ b/pkg/test/mocks/store/cache/cache_mock.go
@@ -2,11 +2,12 @@
 // Source: pkg/store/device/cache.go
 
 // Package device is a generated GoMock package.
-package device
+package cache
 
 import (
 	gomock "github.com/golang/mock/gomock"
 	device "github.com/onosproject/onos-config/api/types/device"
+	cache "github.com/onosproject/onos-config/pkg/store/device/cache"
 	stream "github.com/onosproject/onos-config/pkg/store/stream"
 	reflect "reflect"
 )
@@ -49,10 +50,10 @@ func (mr *MockCacheMockRecorder) Close() *gomock.Call {
 }
 
 // GetDevicesByID mocks base method
-func (m *MockCache) GetDevicesByID(id device.ID) []*Info {
+func (m *MockCache) GetDevicesByID(id device.ID) []*cache.Info {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDevicesByID", id)
-	ret0, _ := ret[0].([]*Info)
+	ret0, _ := ret[0].([]*cache.Info)
 	return ret0
 }
 
@@ -63,10 +64,10 @@ func (mr *MockCacheMockRecorder) GetDevicesByID(id interface{}) *gomock.Call {
 }
 
 // GetDevicesByType mocks base method
-func (m *MockCache) GetDevicesByType(deviceType device.Type) []*Info {
+func (m *MockCache) GetDevicesByType(deviceType device.Type) []*cache.Info {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDevicesByType", deviceType)
-	ret0, _ := ret[0].([]*Info)
+	ret0, _ := ret[0].([]*cache.Info)
 	return ret0
 }
 
@@ -77,10 +78,10 @@ func (mr *MockCacheMockRecorder) GetDevicesByType(deviceType interface{}) *gomoc
 }
 
 // GetDevicesByVersion mocks base method
-func (m *MockCache) GetDevicesByVersion(deviceType device.Type, deviceVersion device.Version) []*Info {
+func (m *MockCache) GetDevicesByVersion(deviceType device.Type, deviceVersion device.Version) []*cache.Info {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDevicesByVersion", deviceType, deviceVersion)
-	ret0, _ := ret[0].([]*Info)
+	ret0, _ := ret[0].([]*cache.Info)
 	return ret0
 }
 
@@ -91,10 +92,10 @@ func (mr *MockCacheMockRecorder) GetDevicesByVersion(deviceType, deviceVersion i
 }
 
 // GetDevices mocks base method
-func (m *MockCache) GetDevices() []*Info {
+func (m *MockCache) GetDevices() []*cache.Info {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDevices")
-	ret0, _ := ret[0].([]*Info)
+	ret0, _ := ret[0].([]*cache.Info)
 	return ret0
 }
 


### PR DESCRIPTION
Doing mocks for the device cache for testing was difficult because the cache was in the same package as the device store. This PR separates the device cache into its own package so that it can be mocked separately.

