### PR TITLE
Fix race condition where error variable was accessed in multiple goroutines

### DIFF
--- a/pkg/northbound/gnmi/subscribe_test.go
+++ b/pkg/northbound/gnmi/subscribe_test.go
@@ -114,7 +114,6 @@ func Test_SubscribeLeafOnce(t *testing.T) {
 	}()
 
 	serverFake.Signal <- struct{}{}
-	assert.NilError(t, err, "Unexpected error doing Subscribe")
 
 	device1 := "Device1"
 	path1Once := "cont1a"


### PR DESCRIPTION
An error variable was set in a goroutine and tested in the main goroutine of the test. The variable value was checked before the routine had a chance to set it, and this was flagged as an error by the race detector.  The goroutine actually does set an error eventually because the device store is not mocked out for the given device, so the logic of the test is looking for something that shouldn't happen.