### PR TITLE
Enforce manadatory check against plugins Fixes #890

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -20,6 +20,7 @@ gives a gNMI interface northbound for other systems to connect to, and an
 Admin service through gRPC
 
 Arguments
+-allowUnvalidatedConfig <allow configuration for devices without a corresponding model plugin>
 
 -modelPlugin (repeated) <the location of a shared object library that implements the Model Plugin interface>
 
@@ -70,7 +71,7 @@ func (i *arrayFlags) Set(value string) error {
 // The main entry point
 func main() {
 	var modelPlugins arrayFlags
-
+	allowUnvalidatedConfig := flag.Bool("-allowUnvalidatedConfig", false, "allow configuration for devices without a corresponding model plugin")
 	flag.Var(&modelPlugins, "modelPlugin", "names of model plugins to load (repeated)")
 	caPath := flag.String("caPath", "", "path to CA certificate")
 	keyPath := flag.String("keyPath", "", "path to client private key")
@@ -136,8 +137,9 @@ func main() {
 		log.Error("Cannot load device store ", err)
 	}
 
-	mgr, err := manager.LoadManager(leadershipStore, mastershipStore, deviceChangesStore, deviceCache,
-		networkChangesStore, networkSnapshotStore, deviceSnapshotStore, deviceStore)
+	mgr, err := manager.NewManager(leadershipStore, mastershipStore, deviceChangesStore,
+		deviceStore, deviceCache, networkChangesStore, networkSnapshotStore,
+		deviceSnapshotStore, *allowUnvalidatedConfig)
 	if err != nil {
 		log.Fatal("Unable to load onos-config ", err)
 	} else {

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -132,8 +132,8 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 	mastershipStore, err := mastership.NewLocalStore("test", cluster.NodeID("node1"))
 	assert.NilError(t, err)
 
-	mgrTest, err = LoadManager(leadershipStore, mastershipStore, deviceChangesStore, deviceCache,
-		networkChangesStore, networkSnapshotStore, deviceSnapshotStore, mockDeviceStore)
+	mgrTest, err = NewManager(leadershipStore, mastershipStore, deviceChangesStore, mockDeviceStore,
+		deviceCache, networkChangesStore, networkSnapshotStore, deviceSnapshotStore, true)
 	if err != nil {
 		t.Fatalf("could not load manager %v", err)
 	}
@@ -228,7 +228,7 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 			if event.Status.State == changetypes.State_COMPLETE {
 				breakout = true
 			}
-		case <-time.After(3 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.FailNow()
 		}
 		if breakout {
@@ -300,7 +300,7 @@ func Test_SetNetworkConfig_Deep(t *testing.T) {
 			if event.Status.State == changetypes.State_COMPLETE {
 				breakout = true
 			}
-		case <-time.After(3 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.FailNow()
 		}
 		if breakout {
@@ -364,7 +364,7 @@ func Test_SetNetworkConfig_ConfigOnly_Deep(t *testing.T) {
 			if event.Status.State == changetypes.State_COMPLETE {
 				breakout = true
 			}
-		case <-time.After(3 * time.Second):
+		case <-time.After(5 * time.Second):
 			t.FailNow()
 		}
 		if breakout {
@@ -468,7 +468,7 @@ func Test_SetNetworkConfig_Disconnected_Device(t *testing.T) {
 					breakout = true
 				}
 			}
-		case <-time.After(1 * time.Second):
+		case <-time.After(5 * time.Second):
 			breakout = true
 			t.FailNow()
 		}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -242,7 +242,7 @@ func setUp(t *testing.T) (*Manager, *AllMocks) {
 		mockNetworkChangesStore,
 		mockNetworkSnapshotStore,
 		mockDeviceSnapshotStore,
-		make(chan *topodevice.ListResponse, 10))
+		true)
 	if err != nil {
 		log.Warn(err)
 		os.Exit(-1)

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -15,6 +15,7 @@
 package manager
 
 import (
+	"fmt"
 	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
@@ -40,6 +41,9 @@ func (m *Manager) ValidateNetworkConfig(deviceName devicetype.ID, version device
 	deviceModelYgotPlugin, ok := m.ModelRegistry.ModelPlugins[modelName]
 	if !ok {
 		log.Warn("No model ", modelName, " available as a plugin")
+		if !mgr.allowUnvalidatedConfig {
+			return fmt.Errorf("no model %s available as a plugin", modelName)
+		}
 		return nil
 	}
 

--- a/pkg/northbound/admin/admin_test.go
+++ b/pkg/northbound/admin/admin_test.go
@@ -59,15 +59,16 @@ func setUpServer(t *testing.T) (*manager.Manager, *grpc.ClientConn, admin.Config
 	client := admin.CreateConfigAdminServiceClient(conn)
 
 	ctrl := gomock.NewController(t)
-	mgrTest, err := manager.LoadManager(
+	mgrTest, err := manager.NewManager(
 		mockstore.NewMockLeadershipStore(ctrl),
 		mockstore.NewMockMastershipStore(ctrl),
 		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockDeviceStore(ctrl),
 		cache.NewMockCache(ctrl),
 		mockstore.NewMockNetworkChangesStore(ctrl),
 		mockstore.NewMockNetworkSnapshotStore(ctrl),
 		mockstore.NewMockDeviceSnapshotStore(ctrl),
-		mockstore.NewMockDeviceStore(ctrl))
+		true)
 	if err != nil {
 		log.Error("Unable to load manager")
 	}

--- a/pkg/northbound/diags/diags_new_test.go
+++ b/pkg/northbound/diags/diags_new_test.go
@@ -65,15 +65,16 @@ func setUpServer(t *testing.T) (*manager.Manager, *grpc.ClientConn, diags.Change
 	client := diags.CreateChangeServiceClient(conn)
 
 	ctrl := gomock.NewController(t)
-	mgrTest, err := manager.LoadManager(
+	mgrTest, err := manager.NewManager(
 		mockstore.NewMockLeadershipStore(ctrl),
 		mockstore.NewMockMastershipStore(ctrl),
 		mockstore.NewMockDeviceChangesStore(ctrl),
+		mockstore.NewMockDeviceStore(ctrl),
 		mockcache.NewMockCache(ctrl),
 		mockstore.NewMockNetworkChangesStore(ctrl),
 		mockstore.NewMockNetworkSnapshotStore(ctrl),
 		mockstore.NewMockDeviceSnapshotStore(ctrl),
-		mockstore.NewMockDeviceStore(ctrl))
+		true)
 	if err != nil {
 		log.Error("Unable to load manager")
 	}

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -211,15 +211,16 @@ func setUp(t *testing.T) (*Server, *manager.Manager, *AllMocks) {
 	allMocks.MockStores = mockStores
 	allMocks.MockDeviceCache = deviceCache
 
-	mgr, err := manager.LoadManager(
+	mgr, err := manager.NewManager(
 		mockStores.LeadershipStore,
 		mockStores.MastershipStore,
 		mockStores.DeviceChangesStore,
+		mockStores.DeviceStore,
 		deviceCache,
 		mockStores.NetworkChangesStore,
 		mockStores.NetworkSnapshotStore,
 		mockStores.DeviceSnapshotStore,
-		mockStores.DeviceStore)
+		true)
 
 	if err != nil {
 		log.Error("Expected manager to be loaded ", err)


### PR DESCRIPTION
by default only configurations that have a model plugin will be allowed

The flag on the command line will allow this to be disabled for testing purposes or for users who want to use the system without having to create model plugins

For unit tests the flag option is set to true, but can be easliy changed

Also in this patch I have increased the timeout for tests failing, as i sometimes became a problem
