### PR TITLE
Fix index out of bounds error when typeOpts is not specified properly

### DIFF
--- a/api/types/change/device/typedvalue.go
+++ b/api/types/change/device/typedvalue.go
@@ -225,6 +225,9 @@ func caseValueTypeLeafListBYTES(bytes []byte, typeOpts []int32) (*TypedValue, er
 			byteArrays = append(byteArrays, buf)
 			buf = make([]byte, 0)
 			idx = idx + 1
+			if idx >= len(byteArrays) {
+				return nil, fmt.Errorf("not enough typeOpts provided - found %d need at least %d", len(byteArrays), idx+1)
+			}
 			startAt = startAt + int(valueLen)
 		}
 		buf = append(buf, b)

--- a/api/types/change/device/values_test.go
+++ b/api/types/change/device/values_test.go
@@ -36,3 +36,11 @@ func Test_NewChangedValue(t *testing.T) {
 	assert.Assert(t, changeValue.Path == path)
 	assert.Assert(t, changeValue.Value.ValueToString() == "64")
 }
+
+func TestLeafListBytesCrash(t *testing.T) {
+	bytes := []byte("12345678")
+	typeOpts := []int32{4}
+	value, err := NewTypedValue(bytes, ValueType_LEAFLIST_BYTES, typeOpts)
+	assert.Assert(t, value == nil)
+	assert.Assert(t, err != nil)
+}


### PR DESCRIPTION
This fixes issue #913 