### PR TITLE
Bump timeout for linters - merge jobs occasionally time out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ deps: # @HELP ensure that the required dependencies are in place
 	bash -c "diff -u <(echo -n) <(git diff go.sum)"
 
 linters: # @HELP examines Go source code and reports coding problems
-	golangci-lint run
+	golangci-lint run --timeout 30m
 
 license_check: # @HELP examine and ensure license headers exist
 	@if [ ! -d "../build-tools" ]; then cd .. && git clone https://github.com/onosproject/build-tools.git; fi


### PR DESCRIPTION
Bumping up the timeout for the ci linters. Merge jobs are timing out fairly consistently with the default one minute setting. For Travis jobs, this is a useless timeout anyway, as the whole Travis job has an associated timeout.