### PR TITLE
Upping logging in Manager Deep Tests

### DIFF
--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -224,7 +224,7 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 		select {
 		case eventObj := <-nwChangeUpdates: //Blocks until event from NW change
 			event := eventObj.Object.(*networkchange.NetworkChange)
-			//t.Logf("Event received %v", event)
+			t.Logf("Event received %v", event)
 			if event.Status.State == changetypes.State_COMPLETE {
 				breakout = true
 			}
@@ -297,6 +297,7 @@ func Test_SetNetworkConfig_Deep(t *testing.T) {
 		select {
 		case eventObj := <-nwChangeUpdates: //Blocks until event from NW change
 			event := eventObj.Object.(*networkchange.NetworkChange)
+			t.Logf("Event received %v", event)
 			if event.Status.State == changetypes.State_COMPLETE {
 				breakout = true
 			}
@@ -459,7 +460,7 @@ func Test_SetNetworkConfig_Disconnected_Device(t *testing.T) {
 		select {
 		case eventObj := <-nwChangeUpdates: //Blocks until event from NW change
 			event := eventObj.Object.(*networkchange.NetworkChange)
-			//t.Logf("Event received %v", event)
+			t.Logf("Event received %v", event)
 			switch event.Status.State {
 			case changetypes.State_RUNNING:
 				wasRunning = true


### PR DESCRIPTION
The last failure was in a different place than before and was because the event never arrived from NetworkChange - in the setUp

I'm increasing the logging again for all events.

I can't reproduce on my own system