### PR TITLE
Adding inital configuration set on the device

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -32,6 +32,7 @@ const ( // For event types
 	EventTypeErrorParseConfig
 	EventTypeErrorDeviceConnect
 	EventTypeErrorDeviceCapabilities
+	EventTypeErrorDeviceConnectInitialConfigSync
 	EventTypeErrorDeviceDisconnect
 	EventTypeErrorSubscribe
 	EventTypeErrorMissingModelPlugin

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -145,7 +145,7 @@ func (m *Manager) Run() {
 	go listenOnResponseChannel(m.SouthboundErrorChan, m)
 	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
 	go synchronizer.Factory(m.TopoChannel, m.OperationalStateChannel, m.SouthboundErrorChan,
-		m.Dispatcher, m.ModelRegistry, m.OperationalStateCache, southbound.TargetGenerator, m.OperationalStateCacheLock)
+		m.Dispatcher, m.ModelRegistry, m.OperationalStateCache, southbound.TargetGenerator, m.OperationalStateCacheLock, m.DeviceChangesStore)
 	log.Debug("Device factory started")
 
 	err := m.DeviceStore.Watch(m.TopoChannel)

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -22,6 +22,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/events"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"github.com/onosproject/onos-config/pkg/southbound"
+	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	topodevice "github.com/onosproject/onos-topo/api/device"
 	syncPrimitives "sync"
@@ -34,7 +35,7 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 	southboundErrorChan chan<- events.DeviceResponse, dispatcher *dispatcher.Dispatcher,
 	modelRegistry *modelregistry.ModelRegistry, operationalStateCache map[topodevice.ID]devicechange.TypedValueMap,
 	newTargetFn func() southbound.TargetIf,
-	operationalStateCacheLock *syncPrimitives.RWMutex) {
+	operationalStateCacheLock *syncPrimitives.RWMutex, deviceChangeStore device.Store) {
 
 	for topoEvent := range topoChannel {
 		notifiedDevice := topoEvent.Device
@@ -62,7 +63,7 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 			operationalStateCacheLock.Unlock()
 			target := newTargetFn()
 			sync, err := New(ctx, notifiedDevice, opStateChan, southboundErrorChan,
-				valueMap, mReadOnlyPaths, target, mStateGetMode, operationalStateCacheLock)
+				valueMap, mReadOnlyPaths, target, mStateGetMode, operationalStateCacheLock, deviceChangeStore)
 			if err != nil {
 				log.Errorf("Error connecting to device %v: %v", notifiedDevice, err)
 				southboundErrorChan <- events.NewErrorEventNoChangeID(events.EventTypeErrorDeviceConnect,

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -126,7 +126,7 @@ func New(context context.Context,
 
 func initialSet(context context.Context, onosExistingConfig []*devicechange.PathValue, device *topodevice.Device, target southbound.TargetIf) error {
 	setRequest, errExtract := values.PathValuesToGnmiChange(onosExistingConfig)
-	log.Info("Setting initial configuration for device %s : %s", device.ID, setRequest)
+	log.Infof("Setting initial configuration for device %s : %s", device.ID, setRequest)
 	if errExtract != nil {
 		return errExtract
 	}


### PR DESCRIPTION
Provides initial facilities to do a set of pre-existing configuration on the device. 
Partially fixes #917 