### PR TITLE
Fix indentation in partitionset.yaml

### DIFF
--- a/deployments/helm/onos-config/templates/partitionset.yaml
+++ b/deployments/helm/onos-config/templates/partitionset.yaml
@@ -14,6 +14,6 @@ spec:
     spec:
       size: {{ .Values.store.raft.partitionSize }}
       raft:
-         electionTimeoutMillis: 5000
-         heartbeatPeriodMillis: 1000
+        electionTimeoutMillis: 5000
+        heartbeatPeriodMillis: 1000
 {{- end }}


### PR DESCRIPTION
The characters used to indent the Raft configuration were not parsed correctly.