### PR TITLE
Wilcard get on the NB reports all devices, also un-connected.

### DIFF
--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -19,7 +19,6 @@ import (
 	devicetype "github.com/onosproject/onos-config/api/types/device"
 	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
 	"github.com/onosproject/onos-config/pkg/utils"
-	topodevice "github.com/onosproject/onos-topo/api/device"
 )
 
 // GetTargetConfig returns a set of change values given a target, a configuration name, a path and a layer.
@@ -44,17 +43,12 @@ func (m *Manager) GetTargetConfig(deviceID devicetype.ID, version devicetype.Ver
 	return filteredValues, nil
 }
 
-// GetAllDeviceIds returns a list of just DeviceIDs from the Config store
+// GetAllDeviceIds returns a list of just DeviceIDs from the device cache
 func (m *Manager) GetAllDeviceIds() *[]string {
+
 	var deviceIds = make([]string, 0)
-	deviceChan := make(chan *topodevice.Device)
-	err := m.DeviceStore.List(deviceChan)
-	if err != nil {
-		log.Errorf("Cant get a list for devices %s", err)
-		return &deviceIds
-	}
-	for dev := range deviceChan {
-		deviceIds = append(deviceIds, string(dev.ID))
+	for _, dev := range m.DeviceCache.GetDevices() {
+		deviceIds = append(deviceIds, string(dev.DeviceID))
 	}
 
 	return &deviceIds

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -59,7 +59,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		}
 		//if target is already disconnected we don't do a get again.
 		_, ok := disconnectedDevicesMap[topodevice.ID(target)]
-		if !ok {
+		if !ok && target != "*" {
 			_, errGet := manager.GetManager().DeviceStore.Get(topodevice.ID(target))
 
 			if errGet != nil && status.Convert(errGet).Code() == codes.NotFound {
@@ -87,7 +87,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		target := prefix.GetTarget()
 		//if target is already disconnected we don't do a get again.
 		_, ok := disconnectedDevicesMap[topodevice.ID(target)]
-		if !ok {
+		if !ok && target != "*" {
 			_, errGet := manager.GetManager().DeviceStore.Get(topodevice.ID(target))
 			if errGet != nil && status.Convert(errGet).Code() == codes.NotFound {
 				log.Infof("Device is not connected %s, %s", target, errGet)

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/status"
 	"gotest.tools/assert"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -93,8 +94,7 @@ func Test_getNoPathElems(t *testing.T) {
 
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
-	server, mocks := setUpForGetSetTests(t)
-	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	server, _ := setUpForGetSetTests(t)
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
 
@@ -111,14 +111,12 @@ func Test_getAllDevices(t *testing.T) {
 	assert.Equal(t, result.Notification[0].Update[0].Path.Target, "*")
 
 	deviceListStr := utils.StrVal(result.Notification[0].Update[0].Val)
-
-	assert.Equal(t, deviceListStr, "[Device1 (1.0.0), Device2 (2.0.0), Device3]")
+	assert.Assert(t, strings.Contains(deviceListStr, "Device1, Device2, Device3"))
 }
 
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
-	server, mocks := setUpForGetSetTests(t)
-	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	server, _ := setUpForGetSetTests(t)
 
 	request := gnmi.GetRequest{
 		Prefix: &gnmi.Path{Target: "*"},
@@ -132,7 +130,7 @@ func Test_getAllDevicesInPrefix(t *testing.T) {
 
 	deviceListStr := utils.StrVal(result.Notification[0].Update[0].Val)
 
-	assert.Equal(t, deviceListStr, "[Device1 (1.0.0), Device2 (2.0.0), Device3]", "Expected value")
+	assert.Assert(t, strings.Contains(deviceListStr, "Device1, Device2, Device3"))
 }
 
 func Test_get2PathsWithPrefix(t *testing.T) {

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -270,6 +270,23 @@ func setUpBaseDevices(mockStores *mockstore.MockStores, deviceCache *mockcache.M
 			Type:     "TestDevice",
 		},
 	}).AnyTimes()
+	deviceCache.EXPECT().GetDevices().Return([]*cache.Info{
+		{
+			DeviceID: "Device1",
+			Version:  "1.0.0",
+			Type:     "TestDevice",
+		},
+		{
+			DeviceID: "Device2",
+			Version:  "2.0.0",
+			Type:     "TestDevice",
+		},
+		{
+			DeviceID: "Device3",
+			Version:  "1.0.0",
+			Type:     "TestDevice",
+		},
+	}).AnyTimes()
 
 	mockStores.DeviceStore.EXPECT().Get(topodevice.ID(device1)).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
 	mockStores.DeviceStore.EXPECT().List(gomock.Any()).DoAndReturn(


### PR DESCRIPTION
Moved the * get to the cache in order to report all devices known to onos-config