### PR TITLE
Retry device state updates to avoid inconsistent states

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e
 	github.com/atomix/atomix-go-local v0.0.0-20191108201451-9131cc896ed6
 	github.com/atomix/atomix-go-node v0.0.0-20191108201428-59c0962b63c8
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/atomix/atomix-go-client v0.0.0-20191002230120-837d618e27c5/go.mod h1:
 github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310/go.mod h1:OJHBatYnC3NkjfQl59ecAM+3UjJRN1KmjmBd5E6O4bg=
 github.com/atomix/atomix-go-client v0.0.0-20191015003555-98ae5ccbe7bd/go.mod h1:jV1V8j+zo30xhC+hufKM/1XIiJKA3ODjwuMA/rBHu8g=
 github.com/atomix/atomix-go-client v0.0.0-20191018192841-3644d110cbec/go.mod h1:bM51i8VXdxw3+vN5spPJWllkfsfpakHYo2bOkNj1xC4=
-github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef h1:RePrb4E2X3WFfgkFc2NlfoWlt8xU5y/STl6VSIvWJAk=
-github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e h1:aLn+oZd73fkB11hrCGuqpFPug7rleIT0cCxloffYzMM=
 github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -174,12 +174,12 @@ func listenOnResponseChannel(respChan chan events.DeviceResponse, m *Manager) {
 		subject := topodevice.ID(event.Subject())
 		switch event.EventType() {
 		case events.EventTypeDeviceConnected:
-			_, err := m.DeviceConnected(subject)
+			err := m.DeviceConnected(subject)
 			if err != nil {
 				log.Error("Can't notify connection", err)
 			}
 		case events.EventTypeErrorDeviceConnect:
-			_, err := m.DeviceDisconnected(subject, event.Error())
+			err := m.DeviceDisconnected(subject, event.Error())
 			if err != nil {
 				log.Error("Can't notify disconnection", err)
 			}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -600,14 +600,8 @@ func TestManager_DeviceConnected(t *testing.T) {
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(deviceDisconnected, nil)
 	mocks.MockStores.DeviceStore.EXPECT().Update(gomock.Any()).Return(device1Connected, nil)
 
-	deviceConnected, err := mgrTest.DeviceConnected(device1)
-
+	err := mgrTest.DeviceConnected(device1)
 	assert.NilError(t, err)
-	assert.Equal(t, deviceConnected.ID, device1Connected.ID)
-	assert.Equal(t, deviceConnected.Protocols[0].Protocol, topodevice.Protocol_GNMI)
-	assert.Equal(t, deviceConnected.Protocols[0].ConnectivityState, topodevice.ConnectivityState_REACHABLE)
-	assert.Equal(t, deviceConnected.Protocols[0].ChannelState, topodevice.ChannelState_CONNECTED)
-	assert.Equal(t, deviceConnected.Protocols[0].ServiceState, topodevice.ServiceState_AVAILABLE)
 }
 
 func TestManager_DeviceDisconnected(t *testing.T) {
@@ -649,14 +643,8 @@ func TestManager_DeviceDisconnected(t *testing.T) {
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(device1Connected, nil)
 	mocks.MockStores.DeviceStore.EXPECT().Update(gomock.Any()).Return(deviceDisconnected, nil)
 
-	deviceUpdated, err := mgrTest.DeviceDisconnected(device1, errors.New("device reported disconnection"))
-
+	err := mgrTest.DeviceDisconnected(device1, errors.New("device reported disconnection"))
 	assert.NilError(t, err)
-	assert.Equal(t, deviceUpdated.ID, device1Connected.ID)
-	assert.Equal(t, deviceUpdated.Protocols[0].Protocol, topodevice.Protocol_GNMI)
-	assert.Equal(t, deviceUpdated.Protocols[0].ConnectivityState, topodevice.ConnectivityState_UNREACHABLE)
-	assert.Equal(t, deviceUpdated.Protocols[0].ChannelState, topodevice.ChannelState_DISCONNECTED)
-	assert.Equal(t, deviceUpdated.Protocols[0].ServiceState, topodevice.ServiceState_UNAVAILABLE)
 }
 
 type MockModelPlugin struct{}


### PR DESCRIPTION
Updates to device states do not correctly handle write conflicts from concurrent updates. This PR is a naive fix for write conflicts. Ideally, we need to have more precise handling of specific errors from stores.