### PR TITLE
Fixing logs for device errors in factory.

### DIFF
--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -76,7 +76,7 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 				return
 			}
 
-			log.Infof("Received error event %v", event)
+			log.Infof("Received event %v", event)
 			deviceID := topodevice.ID(event.Subject())
 			switch event.EventType() {
 			case events.EventTypeErrorDeviceConnect:
@@ -97,6 +97,7 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 					}
 					synchronizers[deviceID] = synchronizer
 					connections[deviceID] = false
+					log.Info("Retrying connecting to device %s ", deviceID)
 					go synchronizer.connect()
 				}
 			case events.EventTypeDeviceConnected:


### PR DESCRIPTION
Removes `error` in a log statement that also allows for non error events to happen.
Adds in a retry to device log.