### PR TITLE
Add snaphots to the Device Cache too

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -130,7 +130,7 @@ func main() {
 
 	log.Info("Network Configuration store connected")
 
-	deviceCache, err := cache.NewCache(networkChangesStore)
+	deviceCache, err := cache.NewCache(networkChangesStore, deviceSnapshotStore)
 	if err != nil {
 		log.Error("Cannot load device cache", err)
 	}

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -124,7 +124,7 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 	deviceSnapshotStore, err := devicesnapstore.NewLocalStore()
 	assert.NilError(t, err)
 
-	deviceCache, err := cache.NewCache(networkChangesStore)
+	deviceCache, err := cache.NewCache(networkChangesStore, deviceSnapshotStore)
 	assert.NilError(t, err)
 
 	leadershipStore, err := leadership.NewLocalStore("test", cluster.NodeID("node1"))

--- a/pkg/store/device/cache/cache.go
+++ b/pkg/store/device/cache/cache.go
@@ -138,8 +138,8 @@ func (c *networkChangeStoreCache) listen() error {
 				key := device.NewVersionedID(ssChange.DeviceID, ssChange.DeviceVersion)
 				info := Info{
 					DeviceID: ssChange.DeviceID,
-					//Type:     ssChange.DeviceType - todo add the device type to device snapshot
-					Version: ssChange.DeviceVersion,
+					Type:     ssChange.DeviceType,
+					Version:  ssChange.DeviceVersion,
 				}
 				c.mu.Lock()
 				if _, ok := c.devices[key]; !ok {

--- a/pkg/store/device/cache/cache.go
+++ b/pkg/store/device/cache/cache.go
@@ -18,7 +18,9 @@ import (
 	"fmt"
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	"github.com/onosproject/onos-config/api/types/device"
+	devicesnapshot "github.com/onosproject/onos-config/api/types/snapshot/device"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
+	devicesnapshotstore "github.com/onosproject/onos-config/pkg/store/snapshot/device"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-config/pkg/utils/logging"
 	"io"
@@ -55,11 +57,13 @@ type Cache interface {
 }
 
 // NewCache returns a new cache based on the NetworkChange store
-func NewCache(networkChangeStore networkchangestore.Store) (Cache, error) {
+func NewCache(networkChangeStore networkchangestore.Store,
+	deviceSnapshotStore devicesnapshotstore.Store) (Cache, error) {
 	cache := &networkChangeStoreCache{
-		networkChangeStore: networkChangeStore,
-		devices:            make(map[device.VersionedID]*Info),
-		listeners:          make(map[chan<- stream.Event]struct{}),
+		networkChangeStore:  networkChangeStore,
+		deviceSnapshotStore: deviceSnapshotStore,
+		devices:             make(map[device.VersionedID]*Info),
+		listeners:           make(map[chan<- stream.Event]struct{}),
 	}
 
 	if err := cache.listen(); err != nil {
@@ -70,16 +74,23 @@ func NewCache(networkChangeStore networkchangestore.Store) (Cache, error) {
 
 // networkChangeStoreCache is a device cache based on the NetworkChange store
 type networkChangeStoreCache struct {
-	networkChangeStore networkchangestore.Store
-	devices            map[device.VersionedID]*Info
-	mu                 sync.RWMutex
-	listeners          map[chan<- stream.Event]struct{}
+	networkChangeStore  networkchangestore.Store
+	deviceSnapshotStore devicesnapshotstore.Store
+	devices             map[device.VersionedID]*Info
+	mu                  sync.RWMutex
+	listeners           map[chan<- stream.Event]struct{}
 }
 
 // listen starts listening for network changes
 func (c *networkChangeStoreCache) listen() error {
 	ch := make(chan stream.Event)
 	ctx, err := c.networkChangeStore.Watch(ch, networkchangestore.WithReplay())
+	if err != nil {
+		return err
+	}
+
+	// Also check the snapshots
+	ssCtx, err := c.deviceSnapshotStore.Watch(ch)
 	if err != nil {
 		return err
 	}
@@ -97,16 +108,41 @@ func (c *networkChangeStoreCache) listen() error {
 				//  this check
 				continue
 			}
-			netChange := event.Object.(*networkchange.NetworkChange)
-			for _, devChange := range netChange.Changes {
-				key := device.NewVersionedID(devChange.DeviceID, devChange.DeviceVersion)
+			netChange, ok := event.Object.(*networkchange.NetworkChange)
+			if ok {
+				for _, devChange := range netChange.Changes {
+					key := device.NewVersionedID(devChange.DeviceID, devChange.DeviceVersion)
+					c.mu.Lock()
+					if _, ok := c.devices[key]; !ok {
+						info := Info{
+							DeviceID: devChange.DeviceID,
+							Type:     devChange.DeviceType,
+							Version:  devChange.DeviceVersion,
+						}
+						c.devices[key] = &info
+						log.Infof("Updating cache with %v. Size %d Listeners %d", info, len(c.devices), len(c.listeners))
+						for l := range c.listeners {
+							if l != nil {
+								l <- stream.Event{
+									Type:   stream.Created,
+									Object: &info,
+								}
+							}
+						}
+					}
+					c.mu.Unlock()
+				}
+			}
+			ssChange, ok := event.Object.(*devicesnapshot.DeviceSnapshot)
+			if ok {
+				key := device.NewVersionedID(ssChange.DeviceID, ssChange.DeviceVersion)
+				info := Info{
+					DeviceID: ssChange.DeviceID,
+					//Type:     ssChange.DeviceType - todo add the device type to device snapshot
+					Version: ssChange.DeviceVersion,
+				}
 				c.mu.Lock()
 				if _, ok := c.devices[key]; !ok {
-					info := Info{
-						DeviceID: devChange.DeviceID,
-						Type:     devChange.DeviceType,
-						Version:  devChange.DeviceVersion,
-					}
 					c.devices[key] = &info
 					log.Infof("Updating cache with %v. Size %d Listeners %d", info, len(c.devices), len(c.listeners))
 					for l := range c.listeners {
@@ -122,6 +158,7 @@ func (c *networkChangeStoreCache) listen() error {
 			}
 		}
 		ctx.Close()
+		ssCtx.Close()
 	}()
 	return nil
 }


### PR DESCRIPTION
The Device cache should know about every device in the system. 
* From Topo store
* From network changes (of devices that might not be or never have been in topo store)
* And snaphsots (of devices that might not be or never have been in topo store and whose network changes have been compacted down)

This change adds the last type