### PR TITLE
Handling Topo device UPDATE and DELETE

### DIFF
--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -38,6 +38,7 @@ const ( // For event types
 	EventTypeErrorMissingModelPlugin
 	EventTypeErrorTranslation
 	EventTypeErrorGetWithRoPaths
+	EventTypeTopoUpdate
 )
 
 // EventAction is an enumerated type
@@ -52,10 +53,12 @@ const (
 )
 
 func (et EventType) String() string {
-	return [...]string{"OperationalState", "EventTypeAchievedSetConfig",
-		"EventTypeErrorSetConfig", "EventTypeErrorParseConfig",
-		"EventTypeErrorDeviceConnect", "EventTypeErrorDeviceCapabilities", "EventTypeErrorDeviceDisconnect",
-		"EventTypeErrorSubscribe, EventTypeErrorMissingModelPlugin, EventTypeErrorTranslation"}[et]
+	return [...]string{"EventOperationalState", "EventTypeDeviceConnected",
+		"EventTypeErrorParseConfig", "EventTypeErrorDeviceConnect",
+		"EventTypeErrorDeviceCapabilities", "EventTypeErrorDeviceConnectInitialConfigSync",
+		"EventTypeErrorDeviceDisconnect",
+		"EventTypeErrorSubscribe, EventTypeErrorMissingModelPlugin, EventTypeErrorTranslation",
+		"EventTypeErrorGetWithRoPaths", "EventTypeTopoUpdate"}[et]
 }
 
 // Event is a general purpose base type of event

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -32,6 +32,7 @@ import (
 
 var synchronizers = make(map[topodevice.ID]*deviceSynchronizer)
 var connections = make(map[topodevice.ID]bool)
+var synchronizersMu = syncPrimitives.RWMutex{}
 
 const backoffInterval = 10 * time.Millisecond
 const maxBackoffTime = 5 * time.Second
@@ -54,10 +55,11 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 			}
 
 			device := topoEvent.Device
-			log.Infof("Received device event %v", device)
-			_, ok = synchronizers[device.ID]
-			if !ok {
-				synchronizer := &deviceSynchronizer{
+			synchronizersMu.Lock()
+			synchronizer, ok := synchronizers[device.ID]
+			if !ok && topoEvent.Type != topodevice.ListResponse_REMOVED {
+				log.Infof("Topo device %s %s", device.ID, topoEvent.Type)
+				synchronizer = &deviceSynchronizer{
 					opStateChan:               opStateChan,
 					southboundErrorChan:       errChan,
 					dispatcher:                dispatcher,
@@ -70,7 +72,40 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 				}
 				synchronizers[device.ID] = synchronizer
 				go synchronizer.connect()
+			} else if ok && topoEvent.Type == topodevice.ListResponse_UPDATED {
+				changed := false
+				if synchronizer.device.Address != topoEvent.Device.Address {
+					oldAddress := synchronizer.device.Address
+					synchronizer.mu.Lock()
+					synchronizer.device.Address = topoEvent.Device.Address
+					changed = true
+					synchronizer.mu.Unlock()
+					log.Infof("Topo device %s UPDATED address %s -> %s ", device.ID, oldAddress, topoEvent.Device.Address)
+					synchronizer.close()
+					time.Sleep(maxBackoffTime + time.Millisecond*10) // close might not take effect until timeout
+					synchronizer.reopen()
+					go synchronizer.connect()
+					log.Infof("Topo device %s UPDATED address %s -> %s ", device.ID, oldAddress, topoEvent.Device.Address)
+				}
+				if synchronizer.device.Timeout.String() != topoEvent.Device.Timeout.String() {
+					synchronizer.mu.Lock()
+					oldTimeout := synchronizer.device.Timeout
+					synchronizer.device.Timeout = topoEvent.Device.Timeout
+					changed = true
+					synchronizer.mu.Unlock()
+					log.Infof("Topo device %s UPDATED timeout %s -> %s ", device.ID, oldTimeout, topoEvent.Device.Timeout)
+				}
+				if !changed {
+					log.Infof("Topo device %s UPDATE not supported %v", device.ID, device)
+				}
+			} else if ok && topoEvent.Type == topodevice.ListResponse_REMOVED {
+				delete(synchronizers, device.ID)
+				synchronizer.close()
+				log.Infof("Topo device %s REMOVED", device.ID)
+			} else {
+				log.Warnf("Unhandled event from topo service %v", topoEvent)
 			}
+			synchronizersMu.Unlock()
 		case event, ok := <-errChan:
 			if !ok {
 				return
@@ -81,6 +116,7 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 			switch event.EventType() {
 			case events.EventTypeErrorDeviceConnect:
 				deviceID := topodevice.ID(event.Subject())
+				synchronizersMu.Lock()
 				synchronizer, ok := synchronizers[deviceID]
 				if ok && connections[deviceID] {
 					synchronizer.close()
@@ -100,8 +136,11 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 					log.Info("Retrying connecting to device %s ", deviceID)
 					go synchronizer.connect()
 				}
+				synchronizersMu.Unlock()
 			case events.EventTypeDeviceConnected:
+				synchronizersMu.RLock()
 				connections[deviceID] = true
+				synchronizersMu.Unlock()
 			}
 			southboundErrorChan <- event
 		}
@@ -120,7 +159,7 @@ type deviceSynchronizer struct {
 	device                    *topodevice.Device
 	target                    southbound.TargetIf
 	closed                    bool
-	mu                        syncPrimitives.Mutex
+	mu                        syncPrimitives.RWMutex
 }
 
 func (s *deviceSynchronizer) connect() {
@@ -148,6 +187,7 @@ func (s *deviceSynchronizer) connect() {
 
 // synchronize connects to the device for synchronization
 func (s *deviceSynchronizer) synchronize() error {
+	s.mu.RLock()
 	log.Infof("Connecting to device %v", s.device)
 	modelName := utils.ToModelName(devicetype.Type(s.device.Type), devicetype.Version(s.device.Version))
 	mReadOnlyPaths, ok := s.modelRegistry.ModelReadOnlyPaths[modelName]
@@ -167,6 +207,7 @@ func (s *deviceSynchronizer) synchronize() error {
 	s.operationalStateCacheLock.Lock()
 	s.operationalStateCache[s.device.ID] = valueMap
 	s.operationalStateCacheLock.Unlock()
+	s.mu.RUnlock()
 
 	ctx := context.Background()
 	sync, err := New(ctx, s.device, s.opStateChan, s.southboundErrorChan,
@@ -200,5 +241,14 @@ func (s *deviceSynchronizer) synchronize() error {
 func (s *deviceSynchronizer) close() {
 	s.mu.Lock()
 	s.closed = true
+	s.mu.Unlock()
+	s.operationalStateCacheLock.Lock()
+	delete(s.operationalStateCache, s.device.ID)
+	s.operationalStateCacheLock.Unlock()
+}
+
+func (s *deviceSynchronizer) reopen() {
+	s.mu.Lock()
+	s.closed = false
 	s.mu.Unlock()
 }

--- a/pkg/southbound/synchronizer/factory_test.go
+++ b/pkg/southbound/synchronizer/factory_test.go
@@ -89,7 +89,7 @@ func TestFactory_Revert(t *testing.T) {
 		TLS:         topodevice.TlsConfig{},
 		Type:        "TestDevice",
 		Role:        "leaf",
-		Attributes:  nil,
+		Attributes:  make(map[string]string),
 	}
 	topoEvent := topodevice.ListResponse{
 		Type:   topodevice.ListResponse_ADDED,
@@ -97,13 +97,6 @@ func TestFactory_Revert(t *testing.T) {
 	}
 
 	topoChan <- &topoEvent
-
-	time.Sleep(time.Millisecond * 100) // Give it a second for the event to take effect
-
-	//listeners := dispatcher.GetListeners()
-	//assert.Equal(t, 2, len(listeners))
-	//assert.Equal(t, listeners[0], device1NameStr) // One for DeviceListeners
-	//assert.Equal(t, listeners[1], device1NameStr) // One for OpState
 
 	// Wait for gRPC connection to timeout
 	time.Sleep(time.Millisecond * 600) // Give it a moment for the event to take effect
@@ -118,6 +111,41 @@ func TestFactory_Revert(t *testing.T) {
 			"could not create a gNMI client: Dialer(1.2.3.4:11161, 500ms): context deadline exceeded", "after gRPC timeout")
 		break
 	}
+
+	// Device removed from topo
+	//device1.Attributes["t1"] = "test"
+	device1Update := topodevice.Device{
+		ID:          topodevice.ID(device1NameStr),
+		Revision:    0,
+		Address:     "1.2.3.4:11161",
+		Target:      "",
+		Version:     "1.0.0",
+		Timeout:     &timeout,
+		Credentials: topodevice.Credentials{},
+		TLS:         topodevice.TlsConfig{},
+		Type:        "TestDevice",
+		Role:        "spine",
+		Attributes:  make(map[string]string),
+	}
+	topoEventUpdated := topodevice.ListResponse{
+		Type:   topodevice.ListResponse_UPDATED,
+		Device: &device1Update,
+	}
+	topoChan <- &topoEventUpdated
+
+	// Device removed from topo
+	topoEventRemove := topodevice.ListResponse{
+		Type:   topodevice.ListResponse_REMOVED,
+		Device: &device1,
+	}
+
+	topoChan <- &topoEventRemove
+
+	time.Sleep(time.Millisecond * 100) // Give it a moment for the event to take effect
+	opStateCacheLock.RLock()
+	_, ok = opstateCache[device1.ID]
+	opStateCacheLock.RUnlock()
+	assert.Assert(t, !ok, "Expected Op state cache entry to have been removed")
 
 	close(topoChan)
 


### PR DESCRIPTION
As it was onos-config ignored the deletion and update of devices in Topo

* Handle a device DELETE event from Topo
* Handle a device UPDATE event from Topo for **Address** and **Timeout** (others can be added)
* Ignore other UPDATEs
* Treat NONE (got at startup) in the same way as ADDED
