### PR TITLE
Remove go module cache for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ branches:
   only:
     - master
 
-cache:
-  directories:
-    - $HOME/gopath/pkg/mod         # Cache the Go modules
-
 before_script:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ branches:
   only:
     - master
 
-#cache:
-#  directories:
-#    - $HOME/gopath/pkg/mod         # Cache the Go modules
+cache:
+  directories:
+    - $HOME/gopath/pkg/mod         # Cache the Go modules
 
 before_script:
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest


### PR DESCRIPTION
The go modules cache on Travis no longer works, so remove the commented out cache directive.