### PR TITLE
Add a func to wait for a network change to complete

### DIFF
--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -138,20 +138,20 @@ func IsNetworkChangeComplete(t *testing.T, networkChangeID network.ID) bool {
 	assert.Nil(t, changeServiceClientErr)
 	assert.True(t, changeServiceClient != nil)
 
-	for i := 1; i < 5; i++ {
-		// Check if the network change has completed
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-		listNetworkChangesClient, listNetworkChangesClientErr := changeServiceClient.ListNetworkChanges(context.Background(), listNetworkChangeRequest)
-		assert.Nil(t, listNetworkChangesClientErr)
-		assert.True(t, listNetworkChangesClient != nil)
+	listNetworkChangesClient, listNetworkChangesClientErr := changeServiceClient.ListNetworkChanges(ctx, listNetworkChangeRequest)
+	assert.Nil(t, listNetworkChangesClientErr)
+	assert.True(t, listNetworkChangesClient != nil)
+
+	for {
+		// Check if the network change has completed
 		networkChangeResponse, networkChangeResponseErr := listNetworkChangesClient.Recv()
 		assert.Nil(t, networkChangeResponseErr)
 		assert.True(t, networkChangeResponse != nil)
 		if change.State_COMPLETE == networkChangeResponse.Change.Status.State {
 			return true
 		}
-
-		time.Sleep(2 * time.Second)
 	}
-	return false
 }

--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -126,8 +126,8 @@ func MakeContext() context.Context {
 	return ctx
 }
 
-// IsNetworkChangeComplete checks for a COMPLETED status on the given change, retying for 15 seconds
-func IsNetworkChangeComplete(t *testing.T, networkChangeID network.ID) bool {
+// WaitForNetworkChangeComplete waits for a COMPLETED status on the given change
+func WaitForNetworkChangeComplete(t *testing.T, networkChangeID network.ID) bool {
 	listNetworkChangeRequest := &diags.ListNetworkChangeRequest{
 		Subscribe:     false,
 		ChangeID:      networkChangeID,

--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -151,7 +151,7 @@ func IsNetworkChangeComplete(t *testing.T, networkChangeID network.ID) bool {
 			return true
 		}
 
-		time.Sleep(2*time.Second)
+		time.Sleep(2 * time.Second)
 	}
 	return false
 }

--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -18,12 +18,19 @@ import (
 	"context"
 	"fmt"
 	"github.com/golang/protobuf/proto"
+	"github.com/onosproject/onos-config/api/diags"
+	"github.com/onosproject/onos-config/api/types/change"
+	"github.com/onosproject/onos-config/api/types/change/network"
 	"github.com/onosproject/onos-config/pkg/utils"
+	"github.com/onosproject/onos-test/pkg/onit/env"
 	"github.com/openconfig/gnmi/client"
 	gclient "github.com/openconfig/gnmi/client/gnmi"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
+	"github.com/stretchr/testify/assert"
 	"strings"
+	"testing"
+	"time"
 )
 
 // DevicePath describes the results of a get operation for a single path
@@ -117,4 +124,34 @@ func MakeContext() context.Context {
 	// TODO: Investigate using context.WithCancel() here
 	ctx := context.Background()
 	return ctx
+}
+
+// IsNetworkChangeComplete checks for a COMPLETED status on the given change, retying for 15 seconds
+func IsNetworkChangeComplete(t *testing.T, networkChangeID network.ID) bool {
+	listNetworkChangeRequest := &diags.ListNetworkChangeRequest{
+		Subscribe:     false,
+		ChangeID:      networkChangeID,
+		WithoutReplay: false,
+	}
+
+	changeServiceClient, changeServiceClientErr := env.Config().NewChangeServiceClient()
+	assert.Nil(t, changeServiceClientErr)
+	assert.True(t, changeServiceClient != nil)
+
+	for i := 1; i < 5; i++ {
+		// Check if the network change has completed
+
+		listNetworkChangesClient, listNetworkChangesClientErr := changeServiceClient.ListNetworkChanges(context.Background(), listNetworkChangeRequest)
+		assert.Nil(t, listNetworkChangesClientErr)
+		assert.True(t, listNetworkChangesClient != nil)
+		networkChangeResponse, networkChangeResponseErr := listNetworkChangesClient.Recv()
+		assert.Nil(t, networkChangeResponseErr)
+		assert.True(t, networkChangeResponse != nil)
+		if change.State_COMPLETE == networkChangeResponse.Change.Status.State {
+			return true
+		}
+
+		time.Sleep(2*time.Second)
+	}
+	return false
 }

--- a/test/gnmi/transactiontest.go
+++ b/test/gnmi/transactiontest.go
@@ -112,7 +112,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	assert.Equal(t, 0, len(extensions))
 
 	// Wait for the network change to complete
-	complete := IsNetworkChangeComplete(t, networkChangeID)
+	complete := WaitForNetworkChangeComplete(t, networkChangeID)
 	assert.True(t, complete, "Set never completed")
 
 	// Check that the values are set on the devices

--- a/test/gnmi/transactiontest.go
+++ b/test/gnmi/transactiontest.go
@@ -17,6 +17,7 @@ package gnmi
 import (
 	"context"
 	"github.com/onosproject/onos-config/api/admin"
+	"github.com/onosproject/onos-config/api/types/change/network"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"strconv"
 	"testing"
@@ -99,6 +100,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	assert.Equal(t, 1, len(extensions))
 	extension := extensions[0].GetRegisteredExt()
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
+	networkChangeID := network.ID(extension.Msg)
 
 	// Check that the values were set correctly
 	var devicePathsForGet = getDevicePaths(devices, paths)
@@ -108,6 +110,10 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	assert.Equal(t, value1, getValuesAfterSet[0].pathDataValue, "Query after set returned the wrong value: %s\n", getValuesAfterSet)
 	assert.Equal(t, value2, getValuesAfterSet[1].pathDataValue, "Query after set 2 returned the wrong value: %s\n", getValuesAfterSet)
 	assert.Equal(t, 0, len(extensions))
+
+	// Wait for the network change to complete
+	complete := IsNetworkChangeComplete(t, networkChangeID)
+	assert.True(t, complete, "Set never completed")
 
 	// Check that the values are set on the devices
 	device1GnmiClient := getDeviceGNMIClient(t, device1)


### PR DESCRIPTION
Adds a function to wait for a network change to reach the COMPLETE state. This is needed for tests that interrogate device simulators to check values.