### PR TITLE
Increment incarnation number on rollback to avoid deadlock

### DIFF
--- a/pkg/manager/rollbackconfig.go
+++ b/pkg/manager/rollbackconfig.go
@@ -47,7 +47,7 @@ func (m *Manager) RollbackTargetConfig(networkChangeID networkchange.ID) error {
 		return errLast
 	}
 
-	changeRollback.Status.Incarnation = 0
+	changeRollback.Status.Incarnation++
 	changeRollback.Status.Phase = changetypes.Phase_ROLLBACK
 	changeRollback.Status.State = changetypes.State_PENDING
 	changeRollback.Status.Reason = changetypes.Reason_NONE


### PR DESCRIPTION
This PR fixes a bug in rollbacks. When the `NetworkChange` controller is already rolling back incarnation 1, if the rollback resets the incarnation to 0 then the `NetworkChange` controller deadlocks since `DeviceChange`s are already in incarnation 1 and rolling back. This results in events not being published and the rollback never being retried.