### PR TITLE
Do not exit device cache watch loop when device is not found

### DIFF
--- a/pkg/controller/change/device/watcher.go
+++ b/pkg/controller/change/device/watcher.go
@@ -53,8 +53,10 @@ func (w *Watcher) Start(ch chan<- types.ID) error {
 	deviceCacheCh := make(chan stream.Event)
 	go func() {
 		for eventObj := range deviceCacheCh {
-			if eventObj.Type == stream.Created {
+			// TODO: Handle device deletes
+			if eventObj.Type == stream.None || eventObj.Type == stream.Created {
 				event := eventObj.Object.(*cache.Info)
+				log.Infof("Received device event for device %v %v", event.DeviceID, event.Version)
 				w.watchDevice(devicetype.NewVersionedID(event.DeviceID, event.Version), ch)
 			}
 		}
@@ -88,7 +90,7 @@ func (w *Watcher) watchDevice(deviceID devicetype.VersionedID, ch chan<- types.I
 	deviceChangeCh := make(chan stream.Event, queueSize)
 	ctx, err := w.ChangeStore.Watch(deviceID, deviceChangeCh, devicechangestore.WithReplay())
 	if err != nil {
-		log.Errorf("setting up Watcher stream for %s: %s", deviceID, err)
+		log.Errorf("Setting up Watcher stream for %s: %s", deviceID, err)
 		return
 	}
 	w.streams[deviceID] = ctx

--- a/pkg/controller/change/network/watcher.go
+++ b/pkg/controller/change/network/watcher.go
@@ -116,7 +116,7 @@ func (w *DeviceWatcher) Start(ch chan<- types.ID) error {
 			device, err := w.DeviceStore.Get(devicetopo.ID(event.DeviceID))
 			if err != nil {
 				log.Errorf("Could not find device %v", event.DeviceID)
-				return
+				continue
 			}
 			if device.Version == string(event.Version) {
 				w.updateWatch(device, ch)


### PR DESCRIPTION
This PR fixes a bug in the network controller's device cache watcher. If a device is not found, the watcher returns and stops processing events. This can lead to a deadlock in the device cache, which is waiting for the watcher to read the channel, while the watcher already exited. The watcher should simply skip the event if the device is not available.