### PR TITLE
Refactor gnmi get and set operations

### DIFF
--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -191,3 +191,21 @@ func getGNMIClientOrFail(t *testing.T) client.Impl {
 	assert.True(t, gnmiClient != nil, "Fetching GNMI client returned nil")
 	return gnmiClient
 }
+
+func checkGnmiValue(t *testing.T, gnmiClient client.Impl, paths []DevicePath, expectedValue string, expectedExtensions int, failMessage string) {
+	t.Helper()
+	value, extensions, err := gNMIGet(testutils.MakeContext(), gnmiClient, paths)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExtensions, len(extensions))
+	assert.Equal(t, expectedValue, value[0].pathDataValue, "%s: %s", failMessage, value)
+}
+
+func checkGnmiValues(t *testing.T, gnmiClient client.Impl, paths []DevicePath, expectedValues []string, expectedExtensions int, failMessage string) {
+	t.Helper()
+	value, extensions, err := gNMIGet(testutils.MakeContext(), gnmiClient, paths)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedExtensions, len(extensions))
+	for index, expectedValue := range expectedValues {
+		assert.Equal(t, expectedValue, value[index].pathDataValue, "%s: %s", failMessage, value)
+	}
+}

--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -45,13 +45,6 @@ type DevicePath struct {
 var noPaths = make([]DevicePath, 0)
 var noExtensions = make([]*gnmi_ext.Extension, 0)
 
-func makeDevicePath(device string, path string) []DevicePath {
-	devicePath := make([]DevicePath, 1)
-	devicePath[0].deviceName = device
-	devicePath[0].path = path
-	return devicePath
-}
-
 func convertGetResults(response *gpb.GetResponse) ([]DevicePath, []*gnmi_ext.Extension, error) {
 	entryCount := len(response.Notification)
 	result := make([]DevicePath, entryCount)
@@ -124,6 +117,19 @@ func gNMISet(ctx context.Context, c client.Impl, updatePaths []DevicePath, delet
 		return "", nil, setError
 	}
 	return extractSetTransactionID(setResult), setResult.Extension, nil
+}
+
+func getDevicePath(device string, path string) []DevicePath {
+	return getDevicePathWithValue(device, path, "", "")
+}
+
+func getDevicePathWithValue(device string, path string, value string, valueType string) []DevicePath {
+	devicePath := make([]DevicePath, 1)
+	devicePath[0].deviceName = device
+	devicePath[0].path = path
+	devicePath[0].pathDataValue = value
+	devicePath[0].pathDataType = valueType
+	return devicePath
 }
 
 func getDevicePaths(devices []string, paths []string) []DevicePath {

--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"github.com/golang/protobuf/proto"
+	"github.com/onosproject/onos-config/api/types/change/network"
+	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
 	"github.com/onosproject/onos-config/pkg/utils"
 	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
@@ -28,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -75,8 +78,8 @@ func extractSetTransactionID(response *gpb.SetResponse) string {
 	return string(response.Extension[0].GetRegisteredExt().Msg)
 }
 
-// gNMIGet generates a GET request on the given client for a path on a device
-func gNMIGet(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePath, []*gnmi_ext.Extension, error) {
+// getGNMIValue generates a GET request on the given client for a path on a device
+func getGNMIValue(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePath, []*gnmi_ext.Extension, error) {
 	protoString := ""
 	for _, devicePath := range paths {
 		protoString = protoString + MakeProtoPath(devicePath.deviceName, devicePath.path)
@@ -95,8 +98,8 @@ func gNMIGet(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePa
 	return convertGetResults(response)
 }
 
-// gNMISet generates a SET request on the given client for update and delete paths on a device
-func gNMISet(ctx context.Context, c client.Impl, updatePaths []DevicePath, deletePaths []DevicePath, extensions []*gnmi_ext.Extension) (string, []*gnmi_ext.Extension, error) {
+// setGNMIValue generates a SET request on the given client for update and delete paths on a device
+func setGNMIValue(ctx context.Context, c client.Impl, updatePaths []DevicePath, deletePaths []DevicePath, extensions []*gnmi_ext.Extension) (string, []*gnmi_ext.Extension, error) {
 	var protoBuilder strings.Builder
 	for _, updatePath := range updatePaths {
 		protoBuilder.WriteString(MakeProtoUpdatePath(updatePath))
@@ -160,7 +163,7 @@ func getDevicePathsWithValues(devices []string, paths []string, values []string)
 
 func checkDeviceValue(t *testing.T, deviceGnmiClient client.Impl, devicePaths []DevicePath, expectedValue string) {
 	for i := 0; i < 30; i++ {
-		deviceValues, extensions, deviceValuesError := gNMIGet(testutils.MakeContext(), deviceGnmiClient, devicePaths)
+		deviceValues, extensions, deviceValuesError := getGNMIValue(testutils.MakeContext(), deviceGnmiClient, devicePaths)
 		if deviceValuesError == nil {
 			assert.NoError(t, deviceValuesError, "GNMI get operation to device returned an error")
 			assert.Equal(t, expectedValue, deviceValues[0].pathDataValue, "Query after set returned the wrong value: %s\n", expectedValue)
@@ -192,20 +195,33 @@ func getGNMIClientOrFail(t *testing.T) client.Impl {
 	return gnmiClient
 }
 
-func checkGnmiValue(t *testing.T, gnmiClient client.Impl, paths []DevicePath, expectedValue string, expectedExtensions int, failMessage string) {
+func checkGNMIValue(t *testing.T, gnmiClient client.Impl, paths []DevicePath, expectedValue string, expectedExtensions int, failMessage string) {
 	t.Helper()
-	value, extensions, err := gNMIGet(testutils.MakeContext(), gnmiClient, paths)
+	value, extensions, err := getGNMIValue(testutils.MakeContext(), gnmiClient, paths)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedExtensions, len(extensions))
 	assert.Equal(t, expectedValue, value[0].pathDataValue, "%s: %s", failMessage, value)
 }
 
-func checkGnmiValues(t *testing.T, gnmiClient client.Impl, paths []DevicePath, expectedValues []string, expectedExtensions int, failMessage string) {
+func checkGNMIValues(t *testing.T, gnmiClient client.Impl, paths []DevicePath, expectedValues []string, expectedExtensions int, failMessage string) {
 	t.Helper()
-	value, extensions, err := gNMIGet(testutils.MakeContext(), gnmiClient, paths)
+	value, extensions, err := getGNMIValue(testutils.MakeContext(), gnmiClient, paths)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedExtensions, len(extensions))
 	for index, expectedValue := range expectedValues {
 		assert.Equal(t, expectedValue, value[index].pathDataValue, "%s: %s", failMessage, value)
 	}
+}
+
+func setGNMIValueOrFail(t *testing.T, gnmiClient client.Impl,
+	updatePaths []DevicePath, deletePaths []DevicePath,
+	extensions []*gnmi_ext.Extension) network.ID {
+	t.Helper()
+	_, extensionsSet, errorSet := setGNMIValue(testutils.MakeContext(), gnmiClient, updatePaths, deletePaths, extensions)
+	assert.NoError(t, errorSet)
+	assert.Equal(t, 1, len(extensionsSet))
+	extensionBefore := extensionsSet[0].GetRegisteredExt()
+	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
+	networkChangeID := network.ID(extensionBefore.Msg)
+	return networkChangeID
 }

--- a/test/gnmi/modelstest.go
+++ b/test/gnmi/modelstest.go
@@ -65,7 +65,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 				t.Logf("testing %q", description)
 
 				setResult := getDevicePathWithValue(simulator.Name(), path, value, valueType)
-				msg, _, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setResult, noPaths, noExtensions)
+				msg, _, errorSet := setGNMIValue(testutils.MakeContext(), gnmiClient, setResult, noPaths, noExtensions)
 				assert.NotNil(t, errorSet, "Set operation for %s does not generate an error", description)
 				assert.Contains(t, status.Convert(errorSet).Message(), expectedError,
 					"set operation for %s generates wrong error %s", description, msg)

--- a/test/gnmi/modelstest.go
+++ b/test/gnmi/modelstest.go
@@ -64,9 +64,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 
 				t.Logf("testing %q", description)
 
-				setResult := makeDevicePath(simulator.Name(), path)
-				setResult[0].pathDataValue = value
-				setResult[0].pathDataType = valueType
+				setResult := getDevicePathWithValue(simulator.Name(), path, value, valueType)
 				msg, _, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setResult, noPaths, noExtensions)
 				assert.NotNil(t, errorSet, "Set operation for %s does not generate an error", description)
 				assert.Contains(t, status.Convert(errorSet).Message(), expectedError,

--- a/test/gnmi/offlinedevicetest.go
+++ b/test/gnmi/offlinedevicetest.go
@@ -56,12 +56,9 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 	}
 	extensions := []*gnmi_ext.Extension{{Ext: &extNameDeviceType}, {Ext: &extNameDeviceVersion}}
 
-	getPath := makeDevicePath(offlineDeviceName, modPath)
-	setPath := makeDevicePath(offlineDeviceName, modPath)
-	setPath[0].pathDataValue = modValue
-	setPath[0].pathDataType = StringVal
+	devicePath := getDevicePathWithValue(offlineDeviceName, modPath, modValue, StringVal)
 
-	_, extensions, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setPath, noPaths, extensions)
+	_, extensions, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, extensions)
 	assert.NoError(t, errorSet)
 	assert.Equal(t, 1, len(extensions))
 	extensionBefore := extensions[0].GetRegisteredExt()
@@ -72,7 +69,7 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 	simulatorEnv := simulator.AddOrDie()
 	time.Sleep(2 * time.Second)
 
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
+	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
 	assert.NoError(t, errorAfter)
 	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
@@ -81,5 +78,5 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 	testutils.WaitForNetworkChangeComplete(t, networkChangeID)
 
 	deviceGnmiClient := getDeviceGNMIClientOrFail(t, simulatorEnv)
-	checkDeviceValue(t, deviceGnmiClient, getPath, modValue)
+	checkDeviceValue(t, deviceGnmiClient, devicePath, modValue)
 }

--- a/test/gnmi/offlinedevicetest.go
+++ b/test/gnmi/offlinedevicetest.go
@@ -68,15 +68,10 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 	// Check that the value was set correctly
 	simulatorEnv := simulator.AddOrDie()
 	time.Sleep(2 * time.Second)
+	checkGnmiValue(t, gnmiClient, devicePath, modValue, 0, "Query after set returned the wrong value")
 
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, modValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
-
+	// Check that the value was set properly on the device
 	testutils.WaitForNetworkChangeComplete(t, networkChangeID)
-
 	deviceGnmiClient := getDeviceGNMIClientOrFail(t, simulatorEnv)
 	checkDeviceValue(t, deviceGnmiClient, devicePath, modValue)
 }

--- a/test/gnmi/offlinedevicetest.go
+++ b/test/gnmi/offlinedevicetest.go
@@ -16,16 +16,12 @@
 package gnmi
 
 import (
-	"github.com/onosproject/onos-config/api/types/change/network"
 	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
 	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
-	"strconv"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -55,20 +51,13 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 		},
 	}
 	extensions := []*gnmi_ext.Extension{{Ext: &extNameDeviceType}, {Ext: &extNameDeviceVersion}}
-
 	devicePath := getDevicePathWithValue(offlineDeviceName, modPath, modValue, StringVal)
-
-	_, extensions, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, extensions)
-	assert.NoError(t, errorSet)
-	assert.Equal(t, 1, len(extensions))
-	extensionBefore := extensions[0].GetRegisteredExt()
-	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
-	networkChangeID := network.ID(extensionBefore.Msg)
+	networkChangeID := setGNMIValueOrFail(t, gnmiClient, devicePath, noPaths, extensions)
 
 	// Check that the value was set correctly
 	simulatorEnv := simulator.AddOrDie()
 	time.Sleep(2 * time.Second)
-	checkGnmiValue(t, gnmiClient, devicePath, modValue, 0, "Query after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, devicePath, modValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value was set properly on the device
 	testutils.WaitForNetworkChangeComplete(t, networkChangeID)

--- a/test/gnmi/offlineintopotest.go
+++ b/test/gnmi/offlineintopotest.go
@@ -63,12 +63,9 @@ func (s *TestSuite) TestOfflineDeviceInTopo(t *testing.T) {
 	gnmiClient := getGNMIClientOrFail(t)
 
 	// Set a value using gNMI client to the offline device
-	getPath := makeDevicePath(offlineInTopoModDeviceName, offlineInTopoModPath)
-	setPath := makeDevicePath(offlineInTopoModDeviceName, offlineInTopoModPath)
-	setPath[0].pathDataValue = offlineInTopoModValue
-	setPath[0].pathDataType = StringVal
+	devicePath := getDevicePathWithValue(offlineInTopoModDeviceName, offlineInTopoModPath, offlineInTopoModValue, StringVal)
 
-	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setPath, noPaths, noExtensions)
+	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, noExtensions)
 	assert.NoError(t, errorSet)
 	assert.Equal(t, 1, len(extensionsSet))
 	extensionBefore := extensionsSet[0].GetRegisteredExt()
@@ -76,7 +73,7 @@ func (s *TestSuite) TestOfflineDeviceInTopo(t *testing.T) {
 	networkChangeID := network.ID(extensionBefore.Msg)
 
 	// Check that the value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
+	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
 	assert.NoError(t, errorAfter)
 	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
@@ -111,5 +108,5 @@ func (s *TestSuite) TestOfflineDeviceInTopo(t *testing.T) {
 
 	// Interrogate the device to check that the value was set properly
 	deviceGnmiClient := getDeviceGNMIClientOrFail(t, simulatorEnv)
-	checkDeviceValue(t, deviceGnmiClient, getPath, offlineInTopoModValue)
+	checkDeviceValue(t, deviceGnmiClient, devicePath, offlineInTopoModValue)
 }

--- a/test/gnmi/offlineintopotest.go
+++ b/test/gnmi/offlineintopotest.go
@@ -19,13 +19,10 @@ import (
 	"context"
 	"github.com/onosproject/onos-config/api/diags"
 	"github.com/onosproject/onos-config/api/types/change"
-	"github.com/onosproject/onos-config/api/types/change/network"
-	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
 	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"github.com/onosproject/onos-topo/api/device"
 	"github.com/stretchr/testify/assert"
-	"strconv"
 	"testing"
 	"time"
 )
@@ -64,16 +61,10 @@ func (s *TestSuite) TestOfflineDeviceInTopo(t *testing.T) {
 
 	// Set a value using gNMI client to the offline device
 	devicePath := getDevicePathWithValue(offlineInTopoModDeviceName, offlineInTopoModPath, offlineInTopoModValue, StringVal)
-
-	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, noExtensions)
-	assert.NoError(t, errorSet)
-	assert.Equal(t, 1, len(extensionsSet))
-	extensionBefore := extensionsSet[0].GetRegisteredExt()
-	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
-	networkChangeID := network.ID(extensionBefore.Msg)
+	networkChangeID := setGNMIValueOrFail(t, gnmiClient, devicePath, noPaths, noExtensions)
 
 	// Check that the value was set correctly
-	checkGnmiValue(t, gnmiClient, devicePath, offlineInTopoModValue, 0, "Query after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, devicePath, offlineInTopoModValue, 0, "Query after set returned the wrong value")
 
 	// Check for pending state on the network change
 	changeServiceClient, changeServiceClientErr := env.Config().NewChangeServiceClient()

--- a/test/gnmi/offlineintopotest.go
+++ b/test/gnmi/offlineintopotest.go
@@ -73,11 +73,7 @@ func (s *TestSuite) TestOfflineDeviceInTopo(t *testing.T) {
 	networkChangeID := network.ID(extensionBefore.Msg)
 
 	// Check that the value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, offlineInTopoModValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
+	checkGnmiValue(t, gnmiClient, devicePath, offlineInTopoModValue, 0, "Query after set returned the wrong value")
 
 	// Check for pending state on the network change
 	changeServiceClient, changeServiceClientErr := env.Config().NewChangeServiceClient()

--- a/test/gnmi/singlepathtest.go
+++ b/test/gnmi/singlepathtest.go
@@ -35,32 +35,30 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	gnmiClient := getGNMIClientOrFail(t)
 
 	// Set a value using gNMI client
-	getPath := makeDevicePath(simulator.Name(), tzPath)
-	setPath := makeDevicePath(simulator.Name(), tzPath)
-	setPath[0].pathDataValue = tzValue
-	setPath[0].pathDataType = StringVal
-	_, extensions, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setPath, noPaths, noExtensions)
+	devicePath := getDevicePathWithValue(simulator.Name(), tzPath, tzValue, StringVal)
+
+	_, extensions, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, noExtensions)
 	assert.NoError(t, errorSet)
 	assert.Equal(t, 1, len(extensions))
 	extension := extensions[0].GetRegisteredExt()
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	// Check that the value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
+	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
 	assert.NoError(t, errorAfter)
 	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, tzValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
 
 	// Remove the path we added
-	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, getPath, noExtensions)
+	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, devicePath, noExtensions)
 	assert.NoError(t, errorDelete)
 	assert.Equal(t, 1, len(extensions))
 	extension = extensions[0].GetRegisteredExt()
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	//  Make sure it got removed
-	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
+	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
 	assert.NoError(t, errorAfterDelete)
 	assert.Equal(t, 0, len(extensions))
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",

--- a/test/gnmi/singlepathtest.go
+++ b/test/gnmi/singlepathtest.go
@@ -44,11 +44,7 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	// Check that the value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, tzValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
+	checkGnmiValue(t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
 
 	// Remove the path we added
 	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, devicePath, noExtensions)
@@ -58,9 +54,5 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	//  Make sure it got removed
-	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfterDelete)
-	assert.Equal(t, 0, len(extensions))
-	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",
-		"incorrect value found for path /system/clock/config/timezone-name after delete")
+	checkGnmiValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
 }

--- a/test/gnmi/singlepathtest.go
+++ b/test/gnmi/singlepathtest.go
@@ -15,10 +15,7 @@
 package gnmi
 
 import (
-	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
-	"github.com/stretchr/testify/assert"
-	"strconv"
 	"testing"
 )
 
@@ -34,25 +31,17 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	// Make a GNMI client to use for requests
 	gnmiClient := getGNMIClientOrFail(t)
 
-	// Set a value using gNMI client
 	devicePath := getDevicePathWithValue(simulator.Name(), tzPath, tzValue, StringVal)
 
-	_, extensions, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, noExtensions)
-	assert.NoError(t, errorSet)
-	assert.Equal(t, 1, len(extensions))
-	extension := extensions[0].GetRegisteredExt()
-	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
+	// Set a value using gNMI client
+	setGNMIValueOrFail(t, gnmiClient, devicePath, noPaths, noExtensions)
 
 	// Check that the value was set correctly
-	checkGnmiValue(t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
 
 	// Remove the path we added
-	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, devicePath, noExtensions)
-	assert.NoError(t, errorDelete)
-	assert.Equal(t, 1, len(extensions))
-	extension = extensions[0].GetRegisteredExt()
-	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
+	setGNMIValueOrFail(t, gnmiClient, noPaths, devicePath, noExtensions)
 
 	//  Make sure it got removed
-	checkGnmiValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
+	checkGNMIValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
 }

--- a/test/gnmi/singlestatetest.go
+++ b/test/gnmi/singlestatetest.go
@@ -46,7 +46,7 @@ func (s *TestSuite) TestSingleState(t *testing.T) {
 	for attempt := 1; attempt <= 10; attempt++ {
 		// If the device cache has not been completely initialized, we can hit a race here where the value
 		// will be returned as null. Needs further investigation.
-		valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, makeDevicePath(simulator.Name(), stateControllersPath))
+		valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, getDevicePath(simulator.Name(), stateControllersPath))
 		assert.NoError(t, errorAfter)
 		assert.NotEqual(t, nil, valueAfter, "Query after state returned nil")
 		address := valueAfter[0].pathDataValue

--- a/test/gnmi/singlestatetest.go
+++ b/test/gnmi/singlestatetest.go
@@ -46,7 +46,7 @@ func (s *TestSuite) TestSingleState(t *testing.T) {
 	for attempt := 1; attempt <= 10; attempt++ {
 		// If the device cache has not been completely initialized, we can hit a race here where the value
 		// will be returned as null. Needs further investigation.
-		valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, getDevicePath(simulator.Name(), stateControllersPath))
+		valueAfter, extensions, errorAfter := getGNMIValue(testutils.MakeContext(), gnmiClient, getDevicePath(simulator.Name(), stateControllersPath))
 		assert.NoError(t, errorAfter)
 		assert.NotEqual(t, nil, valueAfter, "Query after state returned nil")
 		address := valueAfter[0].pathDataValue

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -113,12 +113,7 @@ func (s *TestSuite) TestSubscribe(t *testing.T) {
 	}
 
 	// Check that the value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, subValue, valueAfter[0].pathDataValue,
-		"Query after set returned the wrong value: %s\n", valueAfter)
+	checkGnmiValue(t, gnmiClient, devicePath, subValue, 0, "Query after set returned the wrong value")
 
 	// Remove the path we added
 	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, devicePath, noExtensions)
@@ -144,11 +139,7 @@ func (s *TestSuite) TestSubscribe(t *testing.T) {
 	}
 
 	//  Make sure it got removed
-	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfterDelete)
-	assert.Equal(t, 0, len(extensions))
-	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",
-		"incorrect value found for path /system/clock/config/timezone-name after delete")
+	checkGnmiValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
 }
 
 func buildRequest(path *gnmi.Path, mode gnmi.SubscriptionList_Mode) (*gnmi.SubscribeRequest, error) {

--- a/test/gnmi/transactiontest.go
+++ b/test/gnmi/transactiontest.go
@@ -65,14 +65,11 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 	networkChangeID := network.ID(extension.Msg)
 
+	devicePathsForGet := getDevicePaths(devices, paths)
+
 	// Check that the values were set correctly
-	var devicePathsForGet = getDevicePaths(devices, paths)
-	getValuesAfterSet, extensions, getValueAfterSetError := gNMIGet(testutils.MakeContext(), gnmiClient, devicePathsForGet)
-	assert.NoError(t, getValueAfterSetError, "GNMI get operation returned an error")
-	assert.NotEqual(t, "", getValuesAfterSet, "Query after set returned an error: %s\n", getValueAfterSetError)
-	assert.Equal(t, value1, getValuesAfterSet[0].pathDataValue, "Query after set returned the wrong value: %s\n", getValuesAfterSet)
-	assert.Equal(t, value2, getValuesAfterSet[1].pathDataValue, "Query after set 2 returned the wrong value: %s\n", getValuesAfterSet)
-	assert.Equal(t, 0, len(extensions))
+	expectedValues := []string{value1, value2}
+	checkGnmiValues(t, gnmiClient, devicePathsForGet, expectedValues, 0, "Query after set returned the wrong value")
 
 	// Wait for the network change to complete
 	complete := testutils.WaitForNetworkChangeComplete(t, networkChangeID)
@@ -98,10 +95,6 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	assert.Contains(t, rollbackResponse.Message, changeID, "rollbackResponse message does not contain change ID")
 
 	// Check that the values were really rolled back
-	getValuesAfterRollback, extensions, errorGetAfterRollback := gNMIGet(testutils.MakeContext(), gnmiClient, devicePathsForGet)
-	assert.NoError(t, errorGetAfterRollback, "Get after rollback returned an error")
-	assert.NotNil(t, rollbackResponse, "Response for get after rollback is nil")
-	assert.Equal(t, "", getValuesAfterRollback[0].pathDataValue, "Query after rollback returned the wrong value: %s\n", getValuesAfterRollback)
-	assert.Equal(t, "", getValuesAfterRollback[1].pathDataValue, "Query after rollback returned the wrong value: %s\n", getValuesAfterRollback)
-	assert.Equal(t, 0, len(extensions))
+	expectedValuesAfterRollback := []string{"", ""}
+	checkGnmiValues(t, gnmiClient, devicePathsForGet, expectedValuesAfterRollback, 0, "Query after rollback returned the wrong value")
 }

--- a/test/gnmi/treepathtest.go
+++ b/test/gnmi/treepathtest.go
@@ -39,7 +39,7 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	// Make a GNMI client to use for requests
 	gnmiClient := getGNMIClientOrFail(t)
 
-	getPath := makeDevicePath(device.Name(), newRootEnabledPath)
+	getPath := getDevicePath(device.Name(), newRootEnabledPath)
 
 	// Set name of new root using gNMI client
 	setNamePath := []DevicePath{

--- a/test/gnmi/treepathtest.go
+++ b/test/gnmi/treepathtest.go
@@ -15,10 +15,7 @@
 package gnmi
 
 import (
-	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
-	"github.com/stretchr/testify/assert"
-	"strconv"
 	"testing"
 )
 
@@ -45,33 +42,27 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	setNamePath := []DevicePath{
 		{deviceName: device.Name(), path: newRootConfigNamePath, pathDataValue: newRootName, pathDataType: StringVal},
 	}
-	_, _, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setNamePath, noPaths, noExtensions)
-	assert.NoError(t, errorSet)
+	setGNMIValueOrFail(t, gnmiClient, setNamePath, noPaths, noExtensions)
 
 	// Set values using gNMI client
 	setPath := []DevicePath{
 		{deviceName: device.Name(), path: newRootDescriptionPath, pathDataValue: newDescription, pathDataType: StringVal},
 		{deviceName: device.Name(), path: newRootEnabledPath, pathDataValue: "false", pathDataType: BoolVal},
 	}
-	_, _, errorSet = gNMISet(testutils.MakeContext(), gnmiClient, setPath, noPaths, noExtensions)
-	assert.NoError(t, errorSet)
+	setGNMIValueOrFail(t, gnmiClient, setPath, noPaths, noExtensions)
 
 	// Check that the name value was set correctly
-	checkGnmiValue(t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
 
 	// Check that the enabled value was set correctly
-	checkGnmiValue(t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
 
 	// Remove the root path we added
-	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, getPath, noExtensions)
-	assert.NoError(t, errorDelete)
-	assert.Equal(t, 1, len(extensions))
-	extension := extensions[0].GetRegisteredExt()
-	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
+	setGNMIValueOrFail(t, gnmiClient, noPaths, getPath, noExtensions)
 
 	//  Make sure child got removed
-	checkGnmiValue(t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
+	checkGNMIValue(t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
 
 	//  Make sure new root got removed
-	checkGnmiValue(t, gnmiClient, getPath, "", 0, "New root was not removed")
+	checkGNMIValue(t, gnmiClient, getPath, "", 0, "New root was not removed")
 }

--- a/test/gnmi/treepathtest.go
+++ b/test/gnmi/treepathtest.go
@@ -57,18 +57,10 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	assert.NoError(t, errorSet)
 
 	// Check that the name value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, setNamePath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query name after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, newRootName, valueAfter[0].pathDataValue, "Query name after set returned the wrong value: %s\n", valueAfter)
+	checkGnmiValue(t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
 
 	// Check that the enabled value was set correctly
-	valueAfter, extensions, errorAfter = gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
-	assert.NoError(t, errorAfter)
-	assert.NotEqual(t, "", valueAfter, "Query enabled after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, "false", valueAfter[0].pathDataValue, "Query enabled after set returned the wrong value: %s\n", valueAfter)
-	assert.Equal(t, 0, len(extensions))
+	checkGnmiValue(t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
 
 	// Remove the root path we added
 	_, extensions, errorDelete := gNMISet(testutils.MakeContext(), gnmiClient, noPaths, getPath, noExtensions)
@@ -78,15 +70,8 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	//  Make sure child got removed
-	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
-	assert.NoError(t, errorAfterDelete)
-	assert.Equal(t, valueAfterDelete[0].pathDataValue, "", "New child was not removed")
-	assert.Equal(t, 0, len(extensions))
+	checkGnmiValue(t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
 
 	//  Make sure new root got removed
-	valueAfterRootDelete, extensions, errorAfterRootDelete := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
-	assert.NoError(t, errorAfterRootDelete)
-	assert.Equal(t, valueAfterRootDelete[0].pathDataValue, "",
-		"New root was not removed")
-	assert.Equal(t, 0, len(extensions))
+	checkGnmiValue(t, gnmiClient, getPath, "", 0, "New root was not removed")
 }

--- a/test/gnmi/unreachabledevicetest.go
+++ b/test/gnmi/unreachabledevicetest.go
@@ -88,9 +88,5 @@ func (s *TestSuite) TestUnreachableDevice(t *testing.T) {
 	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
 
 	// Check that the value was set correctly in the cache
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, unreachableDeviceModValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
+	checkGnmiValue(t, gnmiClient, devicePath, unreachableDeviceModValue, 0, "Query after set returned the wrong value")
 }

--- a/test/gnmi/unreachabledevicetest.go
+++ b/test/gnmi/unreachabledevicetest.go
@@ -78,20 +78,17 @@ func (s *TestSuite) TestUnreachableDevice(t *testing.T) {
 	}
 	extensions := []*gnmi_ext.Extension{{Ext: &extNameDeviceType}, {Ext: &extNameDeviceVersion}}
 
-	getPath := makeDevicePath(unreachableDeviceModDeviceName, unreachableDeviceModPath)
-	setPath := makeDevicePath(unreachableDeviceModDeviceName, unreachableDeviceModPath)
-	setPath[0].pathDataValue = unreachableDeviceModValue
-	setPath[0].pathDataType = StringVal
+	devicePath := getDevicePathWithValue(unreachableDeviceModDeviceName, unreachableDeviceModPath, unreachableDeviceModValue, StringVal)
 
 	// Set the value - should return a pending change
-	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setPath, noPaths, extensions)
+	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, extensions)
 	assert.NoError(t, errorSet)
 	assert.Equal(t, 1, len(extensionsSet))
 	extensionBefore := extensionsSet[0].GetRegisteredExt()
 	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
 
 	// Check that the value was set correctly in the cache
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, getPath)
+	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, devicePath)
 	assert.NoError(t, errorAfter)
 	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)

--- a/test/gnmi/unreachabledevicetest.go
+++ b/test/gnmi/unreachabledevicetest.go
@@ -18,12 +18,10 @@ package gnmi
 import (
 	"context"
 	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
-	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"github.com/onosproject/onos-topo/api/device"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"github.com/stretchr/testify/assert"
-	"strconv"
 	"testing"
 )
 
@@ -81,12 +79,8 @@ func (s *TestSuite) TestUnreachableDevice(t *testing.T) {
 	devicePath := getDevicePathWithValue(unreachableDeviceModDeviceName, unreachableDeviceModPath, unreachableDeviceModValue, StringVal)
 
 	// Set the value - should return a pending change
-	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, devicePath, noPaths, extensions)
-	assert.NoError(t, errorSet)
-	assert.Equal(t, 1, len(extensionsSet))
-	extensionBefore := extensionsSet[0].GetRegisteredExt()
-	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
+	setGNMIValueOrFail(t, gnmiClient, devicePath, noPaths, extensions)
 
 	// Check that the value was set correctly in the cache
-	checkGnmiValue(t, gnmiClient, devicePath, unreachableDeviceModValue, 0, "Query after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, devicePath, unreachableDeviceModValue, 0, "Query after set returned the wrong value")
 }

--- a/test/gnmi/updatedeletetest.go
+++ b/test/gnmi/updatedeletetest.go
@@ -71,7 +71,7 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	assert.Equal(t, "false", valueAfter[0].pathDataValue, "Query name after set returned the wrong value: %s\n", valueAfter)
 
 	//  Make sure Description got removed
-	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, makeDevicePath(device.Name(), udtestDescriptionPath))
+	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, getDevicePath(device.Name(), udtestDescriptionPath))
 	assert.NoError(t, errorAfterDelete)
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "", "New child was not removed")
 	assert.Equal(t, 0, len(extensions))

--- a/test/gnmi/updatedeletetest.go
+++ b/test/gnmi/updatedeletetest.go
@@ -15,9 +15,7 @@
 package gnmi
 
 import (
-	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
-	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -42,16 +40,14 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	setNamePath := []DevicePath{
 		{deviceName: device.Name(), path: udtestNamePath, pathDataValue: udtestNameValue, pathDataType: StringVal},
 	}
-	_, _, errorSet := gNMISet(testutils.MakeContext(), gnmiClient, setNamePath, noPaths, noExtensions)
-	assert.NoError(t, errorSet)
+	setGNMIValueOrFail(t, gnmiClient, setNamePath, noPaths, noExtensions)
 
 	// Set initial values for Enabled and Description using gNMI client
 	setInitialValuesPath := []DevicePath{
 		{deviceName: device.Name(), path: udtestEnabledPath, pathDataValue: "true", pathDataType: BoolVal},
 		{deviceName: device.Name(), path: udtestDescriptionPath, pathDataValue: udtestDescriptionValue, pathDataType: StringVal},
 	}
-	_, _, errorSet = gNMISet(testutils.MakeContext(), gnmiClient, setInitialValuesPath, noPaths, noExtensions)
-	assert.NoError(t, errorSet)
+	setGNMIValueOrFail(t, gnmiClient, setInitialValuesPath, noPaths, noExtensions)
 
 	// Update Enabled, delete Description using gNMI client
 	updateEnabledPath := []DevicePath{
@@ -60,12 +56,11 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	deleteDescriptionPath := []DevicePath{
 		{deviceName: device.Name(), path: udtestDescriptionPath},
 	}
-	_, _, errorSet = gNMISet(testutils.MakeContext(), gnmiClient, updateEnabledPath, deleteDescriptionPath, noExtensions)
-	assert.NoError(t, errorSet)
+	setGNMIValueOrFail(t, gnmiClient, updateEnabledPath, deleteDescriptionPath, noExtensions)
 
 	// Check that the Enabled value is set correctly
-	checkGnmiValue(t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
 
 	//  Make sure Description got removed
-	checkGnmiValue(t, gnmiClient, getDevicePath(device.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
+	checkGNMIValue(t, gnmiClient, getDevicePath(device.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
 }

--- a/test/gnmi/updatedeletetest.go
+++ b/test/gnmi/updatedeletetest.go
@@ -64,15 +64,8 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	assert.NoError(t, errorSet)
 
 	// Check that the Enabled value is set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), gnmiClient, updateEnabledPath)
-	assert.NoError(t, errorAfter)
-	assert.Equal(t, 0, len(extensions))
-	assert.NotEqual(t, "", valueAfter, "Query name after set returned an error: %s\n", errorAfter)
-	assert.Equal(t, "false", valueAfter[0].pathDataValue, "Query name after set returned the wrong value: %s\n", valueAfter)
+	checkGnmiValue(t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
 
 	//  Make sure Description got removed
-	valueAfterDelete, extensions, errorAfterDelete := gNMIGet(testutils.MakeContext(), gnmiClient, getDevicePath(device.Name(), udtestDescriptionPath))
-	assert.NoError(t, errorAfterDelete)
-	assert.Equal(t, valueAfterDelete[0].pathDataValue, "", "New child was not removed")
-	assert.Equal(t, 0, len(extensions))
+	checkGnmiValue(t, gnmiClient, getDevicePath(device.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
 }


### PR DESCRIPTION
This PR refactors the GNMI get and set operations to use utility functions to cut down on boilerplate code.