### PR TITLE
Test create remove device

### DIFF
--- a/test/gnmi/createremovedevicetest.go
+++ b/test/gnmi/createremovedevicetest.go
@@ -1,0 +1,101 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gnmi
+
+import (
+	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	createRemoveDeviceModPath          = "/system/clock/config/timezone-name"
+	createRemoveDeviceModValue1         = "Europe/Paris"
+	createRemoveDeviceModValue2         = "Europe/London"
+	createRemoveDeviceModValue3         = "Europe/Munich"
+	createRemoveDeviceModDeviceName    = "offline-dev-1"
+	createRemoveDeviceModDeviceVersion = "1.0.0"
+	createRemoveDeviceModDeviceType    = "Devicesim"
+)
+
+// TestOfflineDeviceInTopo tests set/query of a single GNMI path to a single device that is in the config but offline
+func (s *TestSuite) TestCreateRemovedDevice(t *testing.T) {
+
+	//  Start a new simulated device
+	simulator := env.NewSimulator().SetName(createRemoveDeviceModDeviceName)
+	simulatorEnv := simulator.AddOrDie()
+	time.Sleep(2 * time.Second)
+
+	// Make a GNMI client to use for requests
+	c, err := env.Config().NewGNMIClient()
+	assert.NoError(t, err)
+	assert.True(t, c != nil, "Fetching client returned nil")
+
+	// Set a value using gNMI client - device is up
+	setPath := makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath)
+	setPath[0].pathDataValue = createRemoveDeviceModValue1
+	setPath[0].pathDataType = StringVal
+
+	_, extensionsSet, errorSet := gNMISet(MakeContext(), c, setPath, noPaths, noExtensions)
+	assert.NoError(t, errorSet)
+	assert.Equal(t, 1, len(extensionsSet))
+	extensionBefore := extensionsSet[0].GetRegisteredExt()
+	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
+
+	// Check that the value was set correctly
+	valueAfter, extensions, errorAfter := gNMIGet(MakeContext(), c, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath))
+	assert.NoError(t, errorAfter)
+	assert.Equal(t, 0, len(extensions))
+	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
+	assert.Equal(t, createRemoveDeviceModValue1, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
+
+	// interrogate the device to check that the value was set properly
+	deviceGnmiClient := getDeviceGNMIClient(t, simulatorEnv)
+	checkDeviceValue(t, deviceGnmiClient, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath), createRemoveDeviceModValue1)
+
+	//  Shut down the simulator
+	simulatorEnv.KillOrDie()
+	time.Sleep(2 * time.Second)
+
+	// Set a value using gNMI client - device is down
+	setPath2 := makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath)
+	setPath2[0].pathDataValue = createRemoveDeviceModValue2
+	setPath2[0].pathDataType = StringVal
+	_, extensionsSet2, errorSet2 := gNMISet(MakeContext(), c, setPath, noPaths, noExtensions)
+	assert.NoError(t, errorSet2)
+	assert.Equal(t, 1, len(extensionsSet2))
+	extensionBefore2 := extensionsSet2[0].GetRegisteredExt()
+	assert.Equal(t, extensionBefore2.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
+
+	//  Restart simulated device
+	simulatorEnv2 := simulator.
+	time.Sleep(2 * time.Second)
+
+	// Check that the value was set correctly
+	valueAfter2, extensions2, errorAfter2 := gNMIGet(MakeContext(), c, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath))
+	assert.NoError(t, errorAfter2)
+	assert.Equal(t, 0, len(extensions2))
+	assert.NotEqual(t, "", valueAfter2, "Query after set returned an error: %s\n", errorAfter)
+	assert.Equal(t, createRemoveDeviceModValue2, valueAfter2[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter2)
+
+	// interrogate the device to check that the value was set properly
+	deviceGnmiClient2 := getDeviceGNMIClient(t, simulatorEnv2)
+	checkDeviceValue(t, deviceGnmiClient2, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath), createRemoveDeviceModValue2)
+}

--- a/test/gnmi/createremovedevicetest.go
+++ b/test/gnmi/createremovedevicetest.go
@@ -29,7 +29,7 @@ const (
 	createRemoveDeviceModPath          = "/system/clock/config/timezone-name"
 	createRemoveDeviceModValue1        = "Europe/Paris"
 	createRemoveDeviceModValue2        = "Europe/London"
-	createRemoveDeviceModDeviceName    = "offline-dev-1"
+	createRemoveDeviceModDeviceName    = "offline-sim-crd"
 	createRemoveDeviceModDeviceVersion = "1.0.0"
 	createRemoveDeviceModDeviceType    = "Devicesim"
 )
@@ -110,4 +110,8 @@ func (s *TestSuite) TestCreatedRemovedDevice(t *testing.T) {
 	// interrogate the device to check that the value was set properly
 	deviceGnmiClient2 := getDeviceGNMIClientOrFail(t, simulatorEnv2)
 	checkDeviceValue(t, deviceGnmiClient2, devicePath, createRemoveDeviceModValue2)
+
+	// Clean up the simulator, as it isn't under onit control
+	simulatorEnv.KillOrDie()
+	simulatorEnv.RemoveOrDie()
 }

--- a/test/gnmi/createremovedevicetest.go
+++ b/test/gnmi/createremovedevicetest.go
@@ -87,7 +87,7 @@ func (s *TestSuite) TestCreatedRemovedDevice(t *testing.T) {
 	//  Shut down the simulator
 	simulatorEnv.KillOrDie()
 	simulatorEnv.RemoveOrDie()
-	time.Sleep(60 * time.Second)
+	testutils.WaitForDeviceUnavailable(t, createRemoveDeviceModDeviceName, 1*time.Minute)
 
 	// Set a value using gNMI client - device is down
 	setPath2 := getDevicePathWithValue(createRemoveDeviceModDeviceName, createRemoveDeviceModPath, createRemoveDeviceModValue2, StringVal)
@@ -95,6 +95,7 @@ func (s *TestSuite) TestCreatedRemovedDevice(t *testing.T) {
 	assert.True(t, networkChangeID2 != "")
 
 	//  Restart simulated device
+	time.Sleep(45 * time.Second) // Wait for simulator to shut down. Is there a better way to do this?
 	simulatorEnv2 := simulator.AddOrDie()
 
 	// Wait for config to connect to the device
@@ -104,7 +105,6 @@ func (s *TestSuite) TestCreatedRemovedDevice(t *testing.T) {
 	checkGNMIValue(t, c, devicePath, createRemoveDeviceModValue2, 0, "Query after set 2 returns wrong value")
 
 	// Check that the network change has completed
-	// Test currently fails here
 	testutils.WaitForNetworkChangeComplete(t, networkChangeID2)
 
 	// interrogate the device to check that the value was set properly

--- a/test/gnmi/createremovedevicetest.go
+++ b/test/gnmi/createremovedevicetest.go
@@ -16,30 +16,51 @@
 package gnmi
 
 import (
+	"context"
+	"github.com/onosproject/onos-config/api/types/change/network"
 	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
+	testutils "github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/onosproject/onos-topo/api/device"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 const (
 	createRemoveDeviceModPath          = "/system/clock/config/timezone-name"
-	createRemoveDeviceModValue1         = "Europe/Paris"
-	createRemoveDeviceModValue2         = "Europe/London"
-	createRemoveDeviceModValue3         = "Europe/Munich"
+	createRemoveDeviceModValue1        = "Europe/Paris"
+	createRemoveDeviceModValue2        = "Europe/London"
+	createRemoveDeviceModValue3        = "Europe/Munich"
 	createRemoveDeviceModDeviceName    = "offline-dev-1"
 	createRemoveDeviceModDeviceVersion = "1.0.0"
 	createRemoveDeviceModDeviceType    = "Devicesim"
 )
 
-// TestOfflineDeviceInTopo tests set/query of a single GNMI path to a single device that is in the config but offline
+// TestCreateRemovedDevice tests set/query of a single GNMI path to a single device that is created, removed, then created again
 func (s *TestSuite) TestCreateRemovedDevice(t *testing.T) {
+	deviceClient, deviceClientError := env.Topo().NewDeviceServiceClient()
+	assert.NotNil(t, deviceClient)
+	assert.Nil(t, deviceClientError)
+	timeout := 10 * time.Second
+	newDevice := &device.Device{
+		ID:      createRemoveDeviceModDeviceName,
+		Address: createRemoveDeviceModDeviceName + ":11161",
+		Type:    createRemoveDeviceModDeviceType,
+		Version: createRemoveDeviceModDeviceVersion,
+		Timeout: &timeout,
+		TLS: device.TlsConfig{
+			Plain: true,
+		},
+	}
+	addRequest := &device.AddRequest{Device: newDevice}
+	addResponse, addResponseError := deviceClient.Add(context.Background(), addRequest)
+	assert.NotNil(t, addResponse)
+	assert.Nil(t, addResponseError)
 
 	//  Start a new simulated device
-	simulator := env.NewSimulator().SetName(createRemoveDeviceModDeviceName)
+	simulator := env.NewSimulator().SetName(createRemoveDeviceModDeviceName).SetAddDevice(false)
 	simulatorEnv := simulator.AddOrDie()
 	time.Sleep(2 * time.Second)
 
@@ -53,18 +74,25 @@ func (s *TestSuite) TestCreateRemovedDevice(t *testing.T) {
 	setPath[0].pathDataValue = createRemoveDeviceModValue1
 	setPath[0].pathDataType = StringVal
 
-	_, extensionsSet, errorSet := gNMISet(MakeContext(), c, setPath, noPaths, noExtensions)
+	_, extensionsSet, errorSet := gNMISet(testutils.MakeContext(), c, setPath, noPaths, noExtensions)
 	assert.NoError(t, errorSet)
 	assert.Equal(t, 1, len(extensionsSet))
 	extensionBefore := extensionsSet[0].GetRegisteredExt()
 	assert.Equal(t, extensionBefore.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
+	networkChangeID := network.ID(extensionBefore.Msg)
 
 	// Check that the value was set correctly
-	valueAfter, extensions, errorAfter := gNMIGet(MakeContext(), c, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath))
+	valueAfter, extensions, errorAfter := gNMIGet(testutils.MakeContext(), c, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath))
 	assert.NoError(t, errorAfter)
 	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, createRemoveDeviceModValue1, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
+
+	// Wait for config to connect to the device
+	testutils.WaitForDeviceAvailable(t, createRemoveDeviceModDeviceName, 1*time.Minute)
+
+	// Check that the network change has completed
+	testutils.WaitForNetworkChangeComplete(t, networkChangeID)
 
 	// interrogate the device to check that the value was set properly
 	deviceGnmiClient := getDeviceGNMIClient(t, simulatorEnv)
@@ -72,28 +100,38 @@ func (s *TestSuite) TestCreateRemovedDevice(t *testing.T) {
 
 	//  Shut down the simulator
 	simulatorEnv.KillOrDie()
-	time.Sleep(2 * time.Second)
+	simulatorEnv.RemoveOrDie()
+	time.Sleep(60 * time.Second)
 
 	// Set a value using gNMI client - device is down
 	setPath2 := makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath)
 	setPath2[0].pathDataValue = createRemoveDeviceModValue2
 	setPath2[0].pathDataType = StringVal
-	_, extensionsSet2, errorSet2 := gNMISet(MakeContext(), c, setPath, noPaths, noExtensions)
+	_, extensionsSet2, errorSet2 := gNMISet(testutils.MakeContext(), c, setPath, noPaths, noExtensions)
 	assert.NoError(t, errorSet2)
 	assert.Equal(t, 1, len(extensionsSet2))
 	extensionBefore2 := extensionsSet2[0].GetRegisteredExt()
 	assert.Equal(t, extensionBefore2.Id.String(), strconv.Itoa(gnmi.GnmiExtensionNetwkChangeID))
+	//networkChangeID2 := network.ID(extensionBefore2.Msg)
 
 	//  Restart simulated device
-	simulatorEnv2 := simulator.
-	time.Sleep(2 * time.Second)
+	simulatorEnv2 := simulator.AddOrDie()
+
+	// Wait for config to connect to the device
+	testutils.WaitForDeviceAvailable(t, createRemoveDeviceModDeviceName, 2*time.Minute)
+
+	// Check that the network change has completed
+	//testutils.WaitForNetworkChangeComplete(t, networkChangeID2)
+	time.Sleep(30 * time.Second)
 
 	// Check that the value was set correctly
-	valueAfter2, extensions2, errorAfter2 := gNMIGet(MakeContext(), c, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath))
+	valueAfter2, extensions2, errorAfter2 := gNMIGet(testutils.MakeContext(), c, makeDevicePath(createRemoveDeviceModDeviceName, createRemoveDeviceModPath))
 	assert.NoError(t, errorAfter2)
 	assert.Equal(t, 0, len(extensions2))
 	assert.NotEqual(t, "", valueAfter2, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, createRemoveDeviceModValue2, valueAfter2[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter2)
+
+	//time.Sleep(5 * time.Minute)
 
 	// interrogate the device to check that the value was set properly
 	deviceGnmiClient2 := getDeviceGNMIClient(t, simulatorEnv2)

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -75,6 +75,22 @@ func WaitForDeviceAvailable(t *testing.T, deviceID device.ID, timeout time.Durat
 	}, timeout)
 }
 
+// WaitForDeviceUnavailable waits for a device to become available
+func WaitForDeviceUnavailable(t *testing.T, deviceID device.ID, timeout time.Duration) bool {
+	return WaitForDevice(t, func(dev *device.Device) bool {
+		if dev.ID != deviceID {
+			return false
+		}
+
+		for _, protocol := range dev.Protocols {
+			if protocol.Protocol == device.Protocol_GNMI && protocol.ServiceState == device.ServiceState_UNAVAILABLE {
+				return true
+			}
+		}
+		return false
+	}, timeout)
+}
+
 // WaitForNetworkChangeComplete waits for a COMPLETED status on the given change
 func WaitForNetworkChangeComplete(t *testing.T, networkChangeID network.ID) bool {
 	listNetworkChangeRequest := &diags.ListNetworkChangeRequest{


### PR DESCRIPTION
Adds a test to make sure that if a device becomes unavailable and then comes back online, onos-config can still properly cache GNMI set operations and set them when the device is back.

Scenario:
Add a new device to topo
Start up a simulator for the device
Set a value via GNMI and query to be sure it is set
Query the device to be sure the value is set
Shut down the simulator
Set a new value, and check that the cached value is correct
Restart the simulator
Query the device to be sure the new value is set
