### PR TITLE
Remove watch stream when closed to ensure watches are reopened on device connect

### DIFF
--- a/pkg/controller/change/network/watcher.go
+++ b/pkg/controller/change/network/watcher.go
@@ -159,6 +159,7 @@ func (w *DeviceWatcher) updateWatch(topodevice *devicetopo.Device, ch chan<- typ
 		if ctx != nil {
 			log.Infof("Closing watch for device %v: device disconnected", deviceID)
 			ctx.Close()
+			delete(w.streams, deviceID)
 		}
 		return
 	}


### PR DESCRIPTION
This PR fixes a bug to ensure `NetworkChange`s are requeued when a device is reconnected. Because the device watch stream context was not removed when the device was disconnected, a new stream was never opened when it reconnected. This PR simply ensures the context is deleted.