### PR TITLE
Test for setting to an offline device followed by setting to an online device

### DIFF
--- a/test/gnmi/gnmiutils.go
+++ b/test/gnmi/gnmiutils.go
@@ -225,3 +225,24 @@ func setGNMIValueOrFail(t *testing.T, gnmiClient client.Impl,
 	networkChangeID := network.ID(extensionBefore.Msg)
 	return networkChangeID
 }
+
+func getSimulatorExtensions() []*gnmi_ext.Extension {
+	const (
+		deviceVersion = "1.0.0"
+		deviceType    = "Devicesim"
+	)
+
+	extDeviceType := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  gnmi.GnmiExtensionDeviceType,
+			Msg: []byte(deviceType),
+		},
+	}
+	extDeviceVersion := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  gnmi.GnmiExtensionVersion,
+			Msg: []byte(deviceVersion),
+		},
+	}
+	return []*gnmi_ext.Extension{{Ext: &extDeviceType}, {Ext: &extDeviceVersion}}
+}

--- a/test/gnmi/oneliveonedeadtest.go
+++ b/test/gnmi/oneliveonedeadtest.go
@@ -16,59 +16,41 @@
 package gnmi
 
 import (
-	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
 	"github.com/onosproject/onos-test/pkg/onit/env"
-	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"testing"
-)
-
-const (
-	oneLiveOneDeadDeviceModPath          = "/system/clock/config/timezone-name"
-	oneLiveOneDeadDeviceModValue         = "Europe/Rome"
-	oneLiveOneDeadDeviceName    = "dead-dev-1"
-	oneLiveOneDeadDeviceVersion = "1.0.0"
-	oneLiveOneDeadDeviceType    = "Devicesim"
-	oneLiveOneDeadDeviceAddress          = "198.18.0.1:4"
 )
 
 // TestOneLiveOneDeadDevice tests GNMI operations to an offline device followed by operations to a connected device
 func (s *TestSuite) TestOneLiveOneDeadDevice(t *testing.T) {
 
+	const (
+		modPath  = "/system/clock/config/timezone-name"
+		modValue = "Europe/Rome"
+	)
+
 	// Make a GNMI client to use for requests
 	gnmiClient := getGNMIClientOrFail(t)
 
 	// Set a value using gNMI client to the offline device
-	extNameDeviceType := gnmi_ext.Extension_RegisteredExt{
-		RegisteredExt: &gnmi_ext.RegisteredExtension{
-			Id:  gnmi.GnmiExtensionDeviceType,
-			Msg: []byte(oneLiveOneDeadDeviceType),
-		},
-	}
-	extNameDeviceVersion := gnmi_ext.Extension_RegisteredExt{
-		RegisteredExt: &gnmi_ext.RegisteredExtension{
-			Id:  gnmi.GnmiExtensionVersion,
-			Msg: []byte(oneLiveOneDeadDeviceVersion),
-		},
-	}
-	extensions := []*gnmi_ext.Extension{{Ext: &extNameDeviceType}, {Ext: &extNameDeviceVersion}}
-
-	offlineDevicePath := getDevicePathWithValue("offline-device", oneLiveOneDeadDeviceModPath, oneLiveOneDeadDeviceModValue, StringVal)
+	offlineDevicePath := getDevicePathWithValue("offline-device", modPath, modValue, StringVal)
 
 	// Set the value - should return a pending change
-	setGNMIValueOrFail(t, gnmiClient, offlineDevicePath, noPaths, extensions)
+	setGNMIValueOrFail(t, gnmiClient, offlineDevicePath, noPaths, getSimulatorExtensions())
 
 	// Check that the value was set correctly in the cache
-	checkGNMIValue(t, gnmiClient, offlineDevicePath, oneLiveOneDeadDeviceModValue, 0, "Query after set returned the wrong value")
+	checkGNMIValue(t, gnmiClient, offlineDevicePath, modValue, 0, "Query after set returned the wrong value")
 
 	// Create an online device
-	simulator := env.NewSimulator().AddOrDie()
+	onlineSimulator := env.NewSimulator().AddOrDie()
 
 	// Set a value to the online device
-	onlineDevicePath := getDevicePathWithValue(simulator.Name(), oneLiveOneDeadDeviceModPath, oneLiveOneDeadDeviceModValue, StringVal)
-
-	// Set a value using gNMI client
+	onlineDevicePath := getDevicePathWithValue(onlineSimulator.Name(), modPath, modValue, StringVal)
 	setGNMIValueOrFail(t, gnmiClient, onlineDevicePath, noPaths, noExtensions)
 
-	// Check that the value was set correctly
-	checkGNMIValue(t, gnmiClient, onlineDevicePath, oneLiveOneDeadDeviceModValue, 0, "Query after set returned the wrong value")
+	// Check that the value was set correctly in the cache
+	checkGNMIValue(t, gnmiClient, onlineDevicePath, modValue, 0, "Query after set returned the wrong value")
+
+	// Check that the value was set correctly on the device
+	deviceGnmiClient := getDeviceGNMIClientOrFail(t, onlineSimulator)
+	checkDeviceValue(t, deviceGnmiClient, onlineDevicePath, modValue)
 }

--- a/test/gnmi/oneliveonedeadtest.go
+++ b/test/gnmi/oneliveonedeadtest.go
@@ -1,0 +1,74 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gnmi
+
+import (
+	"github.com/onosproject/onos-config/pkg/northbound/gnmi"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/openconfig/gnmi/proto/gnmi_ext"
+	"testing"
+)
+
+const (
+	oneLiveOneDeadDeviceModPath          = "/system/clock/config/timezone-name"
+	oneLiveOneDeadDeviceModValue         = "Europe/Rome"
+	oneLiveOneDeadDeviceName    = "dead-dev-1"
+	oneLiveOneDeadDeviceVersion = "1.0.0"
+	oneLiveOneDeadDeviceType    = "Devicesim"
+	oneLiveOneDeadDeviceAddress          = "198.18.0.1:4"
+)
+
+// TestOneLiveOneDeadDevice tests GNMI operations to an offline device followed by operations to a connected device
+func (s *TestSuite) TestOneLiveOneDeadDevice(t *testing.T) {
+
+	// Make a GNMI client to use for requests
+	gnmiClient := getGNMIClientOrFail(t)
+
+	// Set a value using gNMI client to the offline device
+	extNameDeviceType := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  gnmi.GnmiExtensionDeviceType,
+			Msg: []byte(oneLiveOneDeadDeviceType),
+		},
+	}
+	extNameDeviceVersion := gnmi_ext.Extension_RegisteredExt{
+		RegisteredExt: &gnmi_ext.RegisteredExtension{
+			Id:  gnmi.GnmiExtensionVersion,
+			Msg: []byte(oneLiveOneDeadDeviceVersion),
+		},
+	}
+	extensions := []*gnmi_ext.Extension{{Ext: &extNameDeviceType}, {Ext: &extNameDeviceVersion}}
+
+	offlineDevicePath := getDevicePathWithValue("offline-device", oneLiveOneDeadDeviceModPath, oneLiveOneDeadDeviceModValue, StringVal)
+
+	// Set the value - should return a pending change
+	setGNMIValueOrFail(t, gnmiClient, offlineDevicePath, noPaths, extensions)
+
+	// Check that the value was set correctly in the cache
+	checkGNMIValue(t, gnmiClient, offlineDevicePath, oneLiveOneDeadDeviceModValue, 0, "Query after set returned the wrong value")
+
+	// Create an online device
+	simulator := env.NewSimulator().AddOrDie()
+
+	// Set a value to the online device
+	onlineDevicePath := getDevicePathWithValue(simulator.Name(), oneLiveOneDeadDeviceModPath, oneLiveOneDeadDeviceModValue, StringVal)
+
+	// Set a value using gNMI client
+	setGNMIValueOrFail(t, gnmiClient, onlineDevicePath, noPaths, noExtensions)
+
+	// Check that the value was set correctly
+	checkGNMIValue(t, gnmiClient, onlineDevicePath, oneLiveOneDeadDeviceModValue, 0, "Query after set returned the wrong value")
+}

--- a/test/gnmi/oneliveonedeadtest.go
+++ b/test/gnmi/oneliveonedeadtest.go
@@ -16,6 +16,7 @@
 package gnmi
 
 import (
+	"github.com/onosproject/onos-config/test/utils"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"testing"
 )
@@ -45,7 +46,8 @@ func (s *TestSuite) TestOneLiveOneDeadDevice(t *testing.T) {
 
 	// Set a value to the online device
 	onlineDevicePath := getDevicePathWithValue(onlineSimulator.Name(), modPath, modValue, StringVal)
-	setGNMIValueOrFail(t, gnmiClient, onlineDevicePath, noPaths, noExtensions)
+	nid := setGNMIValueOrFail(t, gnmiClient, onlineDevicePath, noPaths, noExtensions)
+	utils.WaitForNetworkChangeComplete(t, nid)
 
 	// Check that the value was set correctly in the cache
 	checkGNMIValue(t, gnmiClient, onlineDevicePath, modValue, 0, "Query after set returned the wrong value")


### PR DESCRIPTION
This PR implements an integration test to reproduce what is happening in issue #1014 

Do a set operation to a non-existent device followed by a set to an online device and the second set will get stuck.
