### PR TITLE
Re-queue NetworkChanges when device not found in device service

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -266,6 +266,7 @@ func (c *Controller) reconcile(id types.ID, reconciler Reconciler) bool {
 		// Otherwise, return the result.
 		succeeded, err := reconciler.Reconcile(id)
 		if err != nil {
+			log.Errorf("An error occurred during reconciliation of %s: %v", id, err)
 			time.Sleep(time.Duration(iteration*2) * time.Millisecond)
 		} else {
 			return succeeded


### PR DESCRIPTION
Fixes a bug in the `NetworkChange` controller to ensure the reconciler is not blocked when a device is unknown to the topo service. When the topo service returns a `NotFound` error, the reconciler currently returns the error and the controller retries, blocking all later requests. This is expected behavior for the controller, but the reconciler should not return an error in this case.