### PR TITLE
Change store indexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/onosproject/onos-config
 go 1.12
 
 require (
-	github.com/atomix/atomix-go-client v0.0.0-20191219053757-bad855985f00
-	github.com/atomix/atomix-go-local v0.0.0-20200108223830-0291169cab55
-	github.com/atomix/atomix-go-node v0.0.0-20200108075738-abed9e2478db
+	github.com/atomix/atomix-go-client v0.0.0-20200109182939-90603cd4d968
+	github.com/atomix/atomix-go-local v0.0.0-20200109182851-1ee7104bf7e9
+	github.com/atomix/atomix-go-node v0.0.0-20200109182801-f5c8e3518e4a
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1
 	github.com/gogo/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e h1:aLn+oZd
 github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-client v0.0.0-20191219053757-bad855985f00 h1:ZlWT6LwOC6KD/XqaDnJMJcx7sNotRsONjwseYhcNzXY=
 github.com/atomix/atomix-go-client v0.0.0-20191219053757-bad855985f00/go.mod h1:riSQMsP+Pn2ZffC1AiPAc9HhTwcnlPRYTmW73KNM7hA=
+github.com/atomix/atomix-go-client v0.0.0-20200109182939-90603cd4d968 h1:nNKlqdW7+7jYlbleC8wCDIt2DkarljX0jfO3ZWzHfUI=
+github.com/atomix/atomix-go-client v0.0.0-20200109182939-90603cd4d968/go.mod h1:4dlu7FEq5WYaAtVG0qZ6i1MPsEIUWAfe6EvBKtNbSK8=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:lt/qUsFF29yT2ofmxOXfFzIz0poN22/Qa5SPdalgTKw=
@@ -52,6 +54,8 @@ github.com/atomix/atomix-go-local v0.0.0-20191218214123-a72c188f976e/go.mod h1:T
 github.com/atomix/atomix-go-local v0.0.0-20191219211400-d2c88ae3b162/go.mod h1:GhjFshTc1hk4dOl8KN3IjvW7C7sKgRHe16paqz16qPU=
 github.com/atomix/atomix-go-local v0.0.0-20200108223830-0291169cab55 h1:QO0J59B6sZLgA/8MJjMEEYNPNSfrU9qbsV9qOqEGKOs=
 github.com/atomix/atomix-go-local v0.0.0-20200108223830-0291169cab55/go.mod h1:wgqb4FgkCTUgqxpVI0DNPH4Rf3fF5qBm6vWkKEwshm8=
+github.com/atomix/atomix-go-local v0.0.0-20200109182851-1ee7104bf7e9 h1:4AedjylwfRnlmgtOywTVllC4jkFC1+Mn4zqQconXgbE=
+github.com/atomix/atomix-go-local v0.0.0-20200109182851-1ee7104bf7e9/go.mod h1:N8dEk+DnbmyriuqnztKPUrNTX981aU3e8XUsljROROs=
 github.com/atomix/atomix-go-node v0.0.0-20190827191929-2d3dc9c550d9/go.mod h1:PL1T5R78itch1QC1CN4JmbRL/2XQlg4R95R14822C6Q=
 github.com/atomix/atomix-go-node v0.0.0-20190828183436-fc30340cd8db/go.mod h1:dyh8Bb50qKfMlpqDE6X+dQ1tZ399WKEABa3ntDYImnA=
 github.com/atomix/atomix-go-node v0.0.0-20190830183721-649263a17223/go.mod h1:KJxB/MAgndAbyCOqTV2hatw7lExiZZs7QCOr45IfC9U=
@@ -72,6 +76,8 @@ github.com/atomix/atomix-go-node v0.0.0-20191218215657-d6b301251224/go.mod h1:Io
 github.com/atomix/atomix-go-node v0.0.0-20191219211341-c5c395d1bc60/go.mod h1:hgqxWxx0JDLYX5Ekf1Pt8esnaxCe7gyNPGke0Pc8w4E=
 github.com/atomix/atomix-go-node v0.0.0-20200108075738-abed9e2478db h1:FZNM+6XKiUSE/S/2wDzMck9r1ZcZR5lcg6nLOT1Fz/Q=
 github.com/atomix/atomix-go-node v0.0.0-20200108075738-abed9e2478db/go.mod h1:sFa3CXb7khBF2wEfk9qCY9rs7GrwsukqIGbrYkiAGz0=
+github.com/atomix/atomix-go-node v0.0.0-20200109182801-f5c8e3518e4a h1:dVo8ylWqPbAAdSgB6u2+18bBCjSLmPYrtOVpF40fkO0=
+github.com/atomix/atomix-go-node v0.0.0-20200109182801-f5c8e3518e4a/go.mod h1:sFa3CXb7khBF2wEfk9qCY9rs7GrwsukqIGbrYkiAGz0=
 github.com/atomix/atomix-k8s-controller v0.0.0-20191203231043-ae7d3a341174 h1:G54rAlp/BYJPhp80++aggUwOdo2uIhVsNpZdC9jkOus=
 github.com/atomix/atomix-k8s-controller v0.0.0-20191203231043-ae7d3a341174/go.mod h1:nfCaQUuz6VyvpXvcCjre09PLc6vR4tyJ7Vnu7/wt2ZY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/pkg/controller/change/device/computedelta_test.go
+++ b/pkg/controller/change/device/computedelta_test.go
@@ -29,11 +29,12 @@ func TestReconciler_computeRollback_singleUpdate(t *testing.T) {
 		devices: devices,
 		changes: deviceChangesStore,
 	}
-	err := setUpComputeDelta(reconciler, deviceChangesStore, 1)
+	err := setUpComputeDelta(reconciler, deviceChangesStore, 1, 1)
 	assert.NoError(t, err)
 	defer deviceChangesStore.Close()
 
 	deviceChangeIf1Change := &devicechange.DeviceChange{
+		Index: 1,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("%s-if%d-change", device1, 1)),
 			Index: types.Index(1),
@@ -67,11 +68,12 @@ func TestReconciler_computeRollback_mixedUpdate(t *testing.T) {
 		devices: devices,
 		changes: deviceChangesStore,
 	}
-	err := setUpComputeDelta(reconciler, deviceChangesStore, 1)
+	err := setUpComputeDelta(reconciler, deviceChangesStore, 1, 1)
 	assert.NoError(t, err)
 	defer deviceChangesStore.Close()
 
 	deviceChangeIf1Change := &devicechange.DeviceChange{
+		Index: 1,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("%s-if%d-change", device1, 1)),
 			Index: types.Index(1),
@@ -128,10 +130,11 @@ func TestReconciler_computeRollback_addInterface(t *testing.T) {
 		devices: devices,
 		changes: deviceChangesStore,
 	}
-	err := setUpComputeDelta(reconciler, deviceChangesStore, 1)
+	err := setUpComputeDelta(reconciler, deviceChangesStore, 1, 1)
 	assert.NoError(t, err)
 
 	deviceChangeIf2Add := &devicechange.DeviceChange{
+		Index: 1,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("%s-if%d-add", device1, 2)),
 			Index: types.Index(1),
@@ -185,13 +188,14 @@ func TestReconciler_computeRollback_removeInterface(t *testing.T) {
 		devices: devices,
 		changes: deviceChangesStore,
 	}
-	err := setUpComputeDelta(reconciler, deviceChangesStore, 1)
+	err := setUpComputeDelta(reconciler, deviceChangesStore, 1, 1)
 	assert.NoError(t, err)
 
-	err = setUpComputeDelta(reconciler, deviceChangesStore, 2)
+	err = setUpComputeDelta(reconciler, deviceChangesStore, 2, 2)
 	assert.NoError(t, err)
 
 	deviceChangeIf2Delete := &devicechange.DeviceChange{
+		Index: 1,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("%s-if%d-delete", device1, 2)),
 			Index: types.Index(1),
@@ -230,9 +234,8 @@ func TestReconciler_computeRollback_removeInterface(t *testing.T) {
 	}
 }
 
-func setUpComputeDelta(reconciler *Reconciler, deviceChangesStore devicechanges.Store, iface int) error {
-	deviceChangeIf := newChangeInterface(device1, v1, iface)
-
+func setUpComputeDelta(reconciler *Reconciler, deviceChangesStore devicechanges.Store, index devicechange.Index, iface int) error {
+	deviceChangeIf := newChangeInterface(index, device1, v1, iface)
 	err := deviceChangesStore.Create(deviceChangeIf)
 	if err != nil {
 		return err

--- a/pkg/controller/change/device/controller_test.go
+++ b/pkg/controller/change/device/controller_test.go
@@ -225,7 +225,7 @@ func TestReconcilerChangeThenRollback(t *testing.T) {
 	}
 
 	// Create a device-1 change 1
-	deviceChange1 := newChangeInterface(device1, v1, 1)
+	deviceChange1 := newChangeInterface(1, device1, v1, 1)
 	err := deviceChanges.Create(deviceChange1)
 	assert.NoError(t, err)
 
@@ -258,7 +258,7 @@ func TestReconcilerChangeThenRollback(t *testing.T) {
 	//**********************************************************
 	// Create eth2 in a second change
 	//**********************************************************
-	deviceChange2 := newChangeInterface(device1, v1, 2)
+	deviceChange2 := newChangeInterface(2, device1, v1, 2)
 	err = deviceChanges.Create(deviceChange2)
 	assert.NoError(t, err)
 
@@ -367,7 +367,7 @@ func TestReconcilerRemoveThenRollback(t *testing.T) {
 	//**********************************************
 	// First create an interface eth1
 	//**********************************************
-	deviceChange1 := newChangeInterface(device1, v1, 1)
+	deviceChange1 := newChangeInterface(1, device1, v1, 1)
 	err := deviceChanges.Create(deviceChange1)
 	assert.NoError(t, err)
 
@@ -411,7 +411,7 @@ func TestReconcilerRemoveThenRollback(t *testing.T) {
 	//**********************************************
 	// Then remove the interface eth1
 	//**********************************************
-	deviceChange2 := newChangeInterfaceRemove(device1, v1, 1)
+	deviceChange2 := newChangeInterfaceRemove(2, device1, v1, 1)
 	err = deviceChanges.Create(deviceChange2)
 	assert.NoError(t, err)
 
@@ -634,7 +634,7 @@ func newChange(index devicechange.Index, device device.ID, version device.Versio
 }
 
 // newChangeInterface creates a new interface eth<n> in the OpenConfig model style
-func newChangeInterface(device device.ID, version device.Version, iface int) *devicechange.DeviceChange {
+func newChangeInterface(index devicechange.Index, device device.ID, version device.Version, iface int) *devicechange.DeviceChange {
 	ifaceID := fmt.Sprintf("%s%d", ethPrefix, iface)
 	ifacePath := fmt.Sprintf(ifConfigNameFmt, iface)
 	healthValue := healthUp
@@ -643,6 +643,7 @@ func newChangeInterface(device device.ID, version device.Version, iface int) *de
 	}
 
 	return &devicechange.DeviceChange{
+		Index: index,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("%s-if%d-added", device, iface)),
 			Index: types.Index(iface),
@@ -673,10 +674,11 @@ func newChangeInterface(device device.ID, version device.Version, iface int) *de
 }
 
 // newChangeInterfaceRemove removes an interface eth<n> of the OpenConfig model style
-func newChangeInterfaceRemove(device device.ID, version device.Version, iface int) *devicechange.DeviceChange {
+func newChangeInterfaceRemove(index devicechange.Index, device device.ID, version device.Version, iface int) *devicechange.DeviceChange {
 	ifacePath := fmt.Sprintf(ifConfigNameFmt, iface)
 
 	return &devicechange.DeviceChange{
+		Index: index,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("%s-if%d-removed", device, iface)),
 			Index: types.Index(iface),

--- a/pkg/controller/change/device/controller_test.go
+++ b/pkg/controller/change/device/controller_test.go
@@ -87,12 +87,12 @@ func TestReconcilerChangeSuccess(t *testing.T) {
 	}
 
 	// Create a device-1 change 1
-	deviceChange1 := newChange(device1, v1)
+	deviceChange1 := newChange(1, device1, v1)
 	err := deviceChanges.Create(deviceChange1)
 	assert.NoError(t, err)
 
 	// Create a device-2 change 1
-	deviceChange2 := newChange(device2, v1)
+	deviceChange2 := newChange(2, device2, v1)
 	err = deviceChanges.Create(deviceChange2)
 	assert.NoError(t, err)
 
@@ -154,13 +154,13 @@ func TestReconcilerRollbackSuccess(t *testing.T) {
 	}
 
 	// Create a device-1 change 1
-	deviceChange1 := newChange(device1, v1)
+	deviceChange1 := newChange(1, device1, v1)
 	deviceChange1.Status.Phase = changetypes.Phase_ROLLBACK
 	err := deviceChanges.Create(deviceChange1)
 	assert.NoError(t, err)
 
 	// Create a device-2 change 1
-	deviceChange2 := newChange(device2, v1)
+	deviceChange2 := newChange(2, device2, v1)
 	deviceChange2.Status.Phase = changetypes.Phase_ROLLBACK
 	err = deviceChanges.Create(deviceChange2)
 	assert.NoError(t, err)
@@ -612,8 +612,9 @@ func mockTargetDevice(t *testing.T, name device.ID, ctrl *gomock.Controller) {
 	southbound.Targets[topodevice.ID(name)] = mockTargetDevice
 }
 
-func newChange(device device.ID, version device.Version) *devicechange.DeviceChange {
+func newChange(index devicechange.Index, device device.ID, version device.Version) *devicechange.DeviceChange {
 	return &devicechange.DeviceChange{
+		Index: index,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(device),
 			Index: 1,

--- a/pkg/controller/change/network/controller.go
+++ b/pkg/controller/change/network/controller.go
@@ -161,6 +161,7 @@ func (r *Reconciler) createDeviceChanges(networkChange *networkchange.NetworkCha
 	refs := make([]*networkchange.DeviceChangeRef, len(networkChange.Changes))
 	for i, change := range networkChange.Changes {
 		deviceChange := &devicechange.DeviceChange{
+			Index: devicechange.Index(networkChange.Index),
 			NetworkChange: devicechange.NetworkChangeRef{
 				ID:    types.ID(networkChange.ID),
 				Index: types.Index(networkChange.Index),

--- a/pkg/controller/change/network/watcher_test.go
+++ b/pkg/controller/change/network/watcher_test.go
@@ -277,6 +277,7 @@ func TestDeviceWatcher(t *testing.T) {
 	}
 
 	change2 := &devicechange.DeviceChange{
+		Index: 2,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    "network-change-2",
 			Index: 2,

--- a/pkg/controller/change/network/watcher_test.go
+++ b/pkg/controller/change/network/watcher_test.go
@@ -238,9 +238,10 @@ func TestDeviceWatcher(t *testing.T) {
 	assert.NoError(t, err)
 
 	change1 := &devicechange.DeviceChange{
+		Index: 1,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    "network-change-1",
-			Index: 2,
+			Index: 1,
 		},
 		Change: &devicechange.Change{
 			DeviceID:      "device-1",

--- a/pkg/controller/snapshot/device/controller_test.go
+++ b/pkg/controller/snapshot/device/controller_test.go
@@ -103,7 +103,7 @@ func TestReconcileDeviceSnapshotIndex(t *testing.T) {
 	// Verify the correct snapshot was taken
 	snapshot, err := snapshots.Load(deviceSnapshot.GetVersionedDeviceID())
 	assert.NoError(t, err)
-	assert.Equal(t, devicechange.Index(3), snapshot.ChangeIndex)
+	assert.Equal(t, devicechange.Index(4), snapshot.ChangeIndex)
 	assert.Len(t, snapshot.Values, 2)
 	for _, value := range snapshot.Values {
 		switch value.GetPath() {

--- a/pkg/controller/snapshot/device/controller_test.go
+++ b/pkg/controller/snapshot/device/controller_test.go
@@ -321,6 +321,7 @@ func newRemove(index networkchange.Index, device device.ID, path string, created
 
 func newChange(index networkchange.Index, created time.Time, phase changetypes.Phase, state changetypes.State, change *devicechange.Change) *devicechange.DeviceChange {
 	return &devicechange.DeviceChange{
+		Index: devicechange.Index(index),
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(fmt.Sprintf("network-change-%d", index)),
 			Index: types.Index(index),

--- a/pkg/controller/snapshot/network/controller_test.go
+++ b/pkg/controller/snapshot/network/controller_test.go
@@ -71,23 +71,23 @@ func TestReconcileNetworkSnapshotPhaseState(t *testing.T) {
 	err = networkChanges.Create(networkChange4)
 	assert.NoError(t, err)
 
-	nwChange1DevCh1 := newDeviceChange(networkChange1.GetID(), device1, v1, devicesim)
+	nwChange1DevCh1 := newDeviceChange(1, networkChange1.GetID(), device1, v1, devicesim)
 	err = deviceChanges.Create(nwChange1DevCh1)
 	assert.NoError(t, err)
 
-	nwChange2DevCh1 := newDeviceChange(networkChange2.GetID(), device1, v1, devicesim)
+	nwChange2DevCh1 := newDeviceChange(2, networkChange2.GetID(), device1, v1, devicesim)
 	err = deviceChanges.Create(nwChange2DevCh1)
 	assert.NoError(t, err)
 
-	nwChange2DevCh2 := newDeviceChange(networkChange2.GetID(), device2, v1, devicesim)
+	nwChange2DevCh2 := newDeviceChange(3, networkChange2.GetID(), device2, v1, devicesim)
 	err = deviceChanges.Create(nwChange2DevCh2)
 	assert.NoError(t, err)
 
-	nwChange3DevCh1 := newDeviceChange(networkChange3.GetID(), device2, v1, devicesim)
+	nwChange3DevCh1 := newDeviceChange(4, networkChange3.GetID(), device2, v1, devicesim)
 	err = deviceChanges.Create(nwChange3DevCh1)
 	assert.NoError(t, err)
 
-	nwChange4DevCh1 := newDeviceChange(networkChange4.GetID(), device3, v1, devicesim)
+	nwChange4DevCh1 := newDeviceChange(5, networkChange4.GetID(), device3, v1, devicesim)
 	err = deviceChanges.Create(nwChange4DevCh1)
 	assert.NoError(t, err)
 
@@ -372,11 +372,12 @@ func newNetworkChange(id networkchange.ID, phase changetypes.Phase, state change
 	}
 }
 
-func newDeviceChange(nwChangeID networkchange.ID, deviceID devicebase.ID, deviceVersion devicebase.Version, deviceType devicebase.Type) *devicechange.DeviceChange {
+func newDeviceChange(index devicechange.Index, nwChangeID networkchange.ID, deviceID devicebase.ID, deviceVersion devicebase.Version, deviceType devicebase.Type) *devicechange.DeviceChange {
 	dcID := devicechange.ID(fmt.Sprintf("%s:%s:%s", nwChangeID, deviceID, deviceVersion))
 
 	return &devicechange.DeviceChange{
-		ID: dcID,
+		Index: index,
+		ID:    dcID,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID(nwChangeID),
 			Index: 0,

--- a/pkg/store/change/device/store.go
+++ b/pkg/store/change/device/store.go
@@ -270,7 +270,7 @@ func (s *atomixStore) Update(change *devicechange.DeviceChange) error {
 		return err
 	}
 
-	entry, err := changes.Replace(ctx, string(change.ID), bytes, indexedmap.IfVersion(indexedmap.Version(change.Revision)))
+	entry, err := changes.Set(ctx, indexedmap.Index(change.Index), string(change.ID), bytes, indexedmap.IfVersion(indexedmap.Version(change.Revision)))
 	if err != nil {
 		return err
 	}

--- a/pkg/store/change/device/store_test.go
+++ b/pkg/store/change/device/store_test.go
@@ -51,6 +51,7 @@ func TestDeviceStore(t *testing.T) {
 	assert.NoError(t, err)
 
 	change1 := &devicechange.DeviceChange{
+		Index: 1,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID("network-change-1"),
 			Index: 1,
@@ -79,6 +80,7 @@ func TestDeviceStore(t *testing.T) {
 	}
 
 	change2 := &devicechange.DeviceChange{
+		Index: 2,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID("network-change-2"),
 			Index: 2,
@@ -122,6 +124,7 @@ func TestDeviceStore(t *testing.T) {
 	assert.NotEqual(t, devicechange.Revision(0), change2.Revision)
 
 	change3 := &devicechange.DeviceChange{
+		Index: 3,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID("network-change-3"),
 			Index: 3,
@@ -148,6 +151,7 @@ func TestDeviceStore(t *testing.T) {
 
 	// For two devices
 	change4 := &devicechange.DeviceChange{
+		Index: 4,
 		NetworkChange: devicechange.NetworkChangeRef{
 			ID:    types.ID("network-change-3"),
 			Index: 3,

--- a/pkg/store/change/device/store_test.go
+++ b/pkg/store/change/device/store_test.go
@@ -176,7 +176,7 @@ func TestDeviceStore(t *testing.T) {
 	err = store1.Create(change4)
 	assert.NoError(t, err)
 	assert.Equal(t, devicechange.ID("network-change-3:device-2:1.0.0"), change4.ID)
-	assert.Equal(t, devicechange.Index(1), change4.Index)
+	assert.Equal(t, devicechange.Index(4), change4.Index)
 	assert.NotEqual(t, devicechange.Revision(0), change4.Revision)
 
 	// Verify events were received for the changes

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -224,7 +224,7 @@ func (s *atomixStore) Create(change *networkchange.NetworkChange) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	entry, err := s.changes.Put(ctx, string(change.ID), bytes, indexedmap.IfNotSet())
+	entry, err := s.changes.Append(ctx, string(change.ID), bytes)
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func (s *atomixStore) Update(change *networkchange.NetworkChange) error {
 		return err
 	}
 
-	entry, err := s.changes.Put(ctx, string(change.ID), bytes, indexedmap.IfVersion(indexedmap.Version(change.Revision)))
+	entry, err := s.changes.Replace(ctx, string(change.ID), bytes, indexedmap.IfVersion(indexedmap.Version(change.Revision)))
 	if err != nil {
 		return err
 	}

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -249,7 +249,7 @@ func (s *atomixStore) Update(change *networkchange.NetworkChange) error {
 		return err
 	}
 
-	entry, err := s.changes.Replace(ctx, string(change.ID), bytes, indexedmap.IfVersion(indexedmap.Version(change.Revision)))
+	entry, err := s.changes.Set(ctx, indexedmap.Index(change.Index), string(change.ID), bytes, indexedmap.IfVersion(indexedmap.Version(change.Revision)))
 	if err != nil {
 		return err
 	}

--- a/pkg/store/snapshot/network/store.go
+++ b/pkg/store/snapshot/network/store.go
@@ -158,7 +158,7 @@ func (s *atomixStore) Create(snapshot *networksnapshot.NetworkSnapshot) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	entry, err := s.snapshots.Put(ctx, string(snapshot.ID), bytes, indexedmap.IfNotSet())
+	entry, err := s.snapshots.Append(ctx, string(snapshot.ID), bytes)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (s *atomixStore) Update(snapshot *networksnapshot.NetworkSnapshot) error {
 		return err
 	}
 
-	entry, err := s.snapshots.Put(ctx, string(snapshot.ID), bytes, indexedmap.IfVersion(indexedmap.Version(snapshot.Revision)))
+	entry, err := s.snapshots.Replace(ctx, string(snapshot.ID), bytes, indexedmap.IfVersion(indexedmap.Version(snapshot.Revision)))
 	if err != nil {
 		return err
 	}

--- a/pkg/store/snapshot/network/store.go
+++ b/pkg/store/snapshot/network/store.go
@@ -183,7 +183,7 @@ func (s *atomixStore) Update(snapshot *networksnapshot.NetworkSnapshot) error {
 		return err
 	}
 
-	entry, err := s.snapshots.Replace(ctx, string(snapshot.ID), bytes, indexedmap.IfVersion(indexedmap.Version(snapshot.Revision)))
+	entry, err := s.snapshots.Set(ctx, indexedmap.Index(snapshot.Index), string(snapshot.ID), bytes, indexedmap.IfVersion(indexedmap.Version(snapshot.Revision)))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR modifies the `DeviceChange` store and state to store device changes at the same index as the parent `NetworkChange`. This ensures device changes are stored at deterministic indexes, so the northbound API can return sooner rather than having to wait for device changes to be propagated.