### PR TITLE
Avoid opening new streams for each NetworkChange watch

### DIFF
--- a/pkg/test/mocks/store/map_backed_network_changes_store_mock.go
+++ b/pkg/test/mocks/store/map_backed_network_changes_store_mock.go
@@ -75,9 +75,9 @@ func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore *MockNetworkChang
 		func(c chan<- stream.Event, o ...networkstore.WatchOption) (stream.Context, error) {
 			go func() {
 				mu.RLock()
-				defer mu.RUnlock()
 				change := networkChangesList[len(networkChangesList)-1]
 				if change == nil {
+					mu.RUnlock()
 					close(c)
 					return
 				}
@@ -91,9 +91,12 @@ func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore *MockNetworkChang
 					Type:   "",
 					Object: &change1,
 				}
+				mu.RUnlock()
 				c <- event
 
 				change2 := change1
+
+				mu.RLock()
 				refs := make([]*networkchange.DeviceChangeRef, len(change2.Changes))
 				for i, change := range change2.Changes {
 					refs[i] = &networkchange.DeviceChangeRef{
@@ -105,6 +108,7 @@ func SetUpMapBackedNetworkChangesStore(mockNetworkChangesStore *MockNetworkChang
 					Type:   "",
 					Object: &change2,
 				}
+				mu.RUnlock()
 				c <- event
 				close(c)
 			}()


### PR DESCRIPTION
This PR refactors the `NetworkChange` store to avoid opening new streams for each watch of a specific change ID. This significantly reduces the amount of interaction the northbound API has to do with stores during a write on the northbound. To ensure events are not lost since they're not replayed, this PR reorders the gNMI set logic to register the watch before adding the change.