### PR TITLE
Add gNMI northbound set/get benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,19 @@ onos-config-tests-docker: # @HELP build onos-config tests Docker image
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o build/onos-config-tests/_output/bin/onos-config-tests ./cmd/onos-config-tests
 	docker build . -f build/onos-config-tests/Dockerfile -t onosproject/onos-config-tests:${ONOS_CONFIG_VERSION}
 
+onos-config-benchmarks-docker: # @HELP build onos-config benchmarks Docker image
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o build/onos-config-benchmarks/_output/bin/onos-config-benchmarks ./cmd/onos-config-benchmarks
+	docker build . -f build/onos-config-benchmarks/Dockerfile -t onosproject/onos-config-benchmarks:${ONOS_CONFIG_VERSION}
+
 images: # @HELP build all Docker images
-images: build onos-config-docker onos-config-tests-docker
+images: build onos-config-docker onos-config-tests-docker onos-config-benchmarks-docker
 
 kind: # @HELP build Docker images and add them to the currently configured kind cluster
 kind: images
 	@if [ "`kind get clusters`" = '' ]; then echo "no kind cluster found" && exit 1; fi
 	kind load docker-image onosproject/onos-config:${ONOS_CONFIG_VERSION}
 	kind load docker-image onosproject/onos-config-tests:${ONOS_CONFIG_VERSION}
+	kind load docker-image onosproject/onos-config-benchmarks:${ONOS_CONFIG_VERSION}
 
 all: build images
 

--- a/benchmark/gnmi/getbench.go
+++ b/benchmark/gnmi/getbench.go
@@ -1,4 +1,4 @@
-// Copyright 2019-present Open Networking Foundation.
+// Copyright 2020-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package gnmi
 
 import (
-	"github.com/onosproject/onos-config/benchmark/gnmi"
+	"context"
 	"github.com/onosproject/onos-test/pkg/benchmark"
+	"time"
 )
 
-func main() {
-	benchmark.Register("gnmi", &gnmi.BenchmarkSuite{})
-	benchmark.Main()
+// BenchmarkGet tests get of GNMI paths
+func (s *BenchmarkSuite) BenchmarkGet(b *benchmark.Benchmark) {
+	b.Run(func() error {
+		devicePath := getDevicePath(s.simulator.Name(), "/system/config/motd-banner")
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		_, _, err := getGNMIValue(ctx, s.client, devicePath)
+		return err
+	})
 }

--- a/benchmark/gnmi/gnmiutils.go
+++ b/benchmark/gnmi/gnmiutils.go
@@ -1,0 +1,126 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"context"
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/onosproject/onos-config/pkg/utils"
+	"github.com/openconfig/gnmi/client"
+	gclient "github.com/openconfig/gnmi/client/gnmi"
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/openconfig/gnmi/proto/gnmi_ext"
+	"strings"
+)
+
+// DevicePath describes the results of a get operation for a single path
+// It specifies the device, path, and value
+type DevicePath struct {
+	deviceName    string
+	path          string
+	pathDataType  string
+	pathDataValue string
+}
+
+var noPaths = make([]DevicePath, 0)
+var noExtensions = make([]*gnmi_ext.Extension, 0)
+
+func convertGetResults(response *gpb.GetResponse) ([]DevicePath, []*gnmi_ext.Extension, error) {
+	entryCount := len(response.Notification)
+	result := make([]DevicePath, entryCount)
+
+	for index, notification := range response.Notification {
+		value := notification.Update[0].Val
+
+		result[index].deviceName = notification.Update[0].Path.Target
+		pathString := ""
+
+		for _, elem := range notification.Update[0].Path.Elem {
+			pathString = pathString + "/" + elem.Name
+		}
+		result[index].path = pathString
+
+		result[index].pathDataType = "string_val"
+		if value != nil {
+			result[index].pathDataValue = utils.StrVal(value)
+		} else {
+			result[index].pathDataValue = ""
+		}
+	}
+
+	return result, response.Extension, nil
+}
+
+func extractSetTransactionID(response *gpb.SetResponse) string {
+	return string(response.Extension[0].GetRegisteredExt().Msg)
+}
+
+// getGNMIValue generates a GET request on the given client for a path on a device
+func getGNMIValue(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePath, []*gnmi_ext.Extension, error) {
+	protoString := ""
+	for _, devicePath := range paths {
+		protoString = protoString + MakeProtoPath(devicePath.deviceName, devicePath.path)
+	}
+
+	getTZRequest := &gpb.GetRequest{}
+	if err := proto.UnmarshalText(protoString, getTZRequest); err != nil {
+		fmt.Printf("unable to parse gnmi.GetRequest from %q : %v", protoString, err)
+		return nil, nil, err
+	}
+
+	response, err := c.(*gclient.Client).Get(ctx, getTZRequest)
+	if err != nil || response == nil {
+		return nil, nil, err
+	}
+	return convertGetResults(response)
+}
+
+// setGNMIValue generates a SET request on the given client for update and delete paths on a device
+func setGNMIValue(ctx context.Context, c client.Impl, updatePaths []DevicePath, deletePaths []DevicePath, extensions []*gnmi_ext.Extension) (string, []*gnmi_ext.Extension, error) {
+	var protoBuilder strings.Builder
+	for _, updatePath := range updatePaths {
+		protoBuilder.WriteString(MakeProtoUpdatePath(updatePath))
+	}
+	for _, deletePath := range deletePaths {
+		protoBuilder.WriteString(MakeProtoDeletePath(deletePath.deviceName, deletePath.path))
+	}
+
+	setTZRequest := &gpb.SetRequest{}
+
+	if err := proto.UnmarshalText(protoBuilder.String(), setTZRequest); err != nil {
+		return "", nil, err
+	}
+
+	setTZRequest.Extension = extensions
+	setResult, setError := c.(*gclient.Client).Set(ctx, setTZRequest)
+	if setError != nil {
+		return "", nil, setError
+	}
+	return extractSetTransactionID(setResult), setResult.Extension, nil
+}
+
+func getDevicePath(device string, path string) []DevicePath {
+	return getDevicePathWithValue(device, path, "", "")
+}
+
+func getDevicePathWithValue(device string, path string, value string, valueType string) []DevicePath {
+	devicePath := make([]DevicePath, 1)
+	devicePath[0].deviceName = device
+	devicePath[0].path = path
+	devicePath[0].pathDataValue = value
+	devicePath[0].pathDataType = valueType
+	return devicePath
+}

--- a/benchmark/gnmi/protoutils.go
+++ b/benchmark/gnmi/protoutils.go
@@ -1,0 +1,99 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"github.com/onosproject/onos-config/pkg/utils"
+	"strings"
+)
+
+const (
+	// StringVal :
+	StringVal = "string_val"
+
+	// IntVal :
+	IntVal = "int_val"
+
+	// BoolVal :
+	BoolVal = "bool_val"
+)
+
+// MakeProtoTarget returns a GNMI proto path for a given target
+func MakeProtoTarget(target string, path string) string {
+	var protoBuilder strings.Builder
+	var pathElements []string
+
+	protoBuilder.WriteString("<target: '")
+	protoBuilder.WriteString(target)
+	protoBuilder.WriteString("', ")
+
+	pathElements = utils.SplitPath(path)
+
+	for _, pathElement := range pathElements {
+		protoBuilder.WriteString("elem: <name: '")
+		protoBuilder.WriteString(pathElement)
+		protoBuilder.WriteString("'>")
+	}
+	protoBuilder.WriteString(">")
+	return protoBuilder.String()
+}
+
+// MakeProtoPath returns a path: element for a given target and path
+func MakeProtoPath(target string, path string) string {
+	var protoBuilder strings.Builder
+
+	protoBuilder.WriteString("path: ")
+	gnmiPath := MakeProtoTarget(target, path)
+	protoBuilder.WriteString(gnmiPath)
+	return protoBuilder.String()
+}
+
+func makeProtoValue(value string, valueType string) string {
+	var protoBuilder strings.Builder
+
+	var valueString string
+
+	if valueType == StringVal {
+		valueString = "'" + value + "'"
+	} else {
+		valueString = value
+	}
+	protoBuilder.WriteString(" val: <")
+	protoBuilder.WriteString(valueType)
+	protoBuilder.WriteString(":")
+	protoBuilder.WriteString(valueString)
+	protoBuilder.WriteString(">")
+	return protoBuilder.String()
+}
+
+// MakeProtoUpdatePath returns an update: element for a target, path, and new value
+func MakeProtoUpdatePath(devicePath DevicePath) string {
+	var protoBuilder strings.Builder
+
+	protoBuilder.WriteString("update: <")
+	protoBuilder.WriteString(MakeProtoPath(devicePath.deviceName, devicePath.path))
+	protoBuilder.WriteString(makeProtoValue(devicePath.pathDataValue, devicePath.pathDataType))
+	protoBuilder.WriteString(">")
+	return protoBuilder.String()
+}
+
+// MakeProtoDeletePath returns a delete: element for a given target and path
+func MakeProtoDeletePath(target string, path string) string {
+	var protoBuilder strings.Builder
+
+	protoBuilder.WriteString("delete: ")
+	protoBuilder.WriteString(MakeProtoTarget(target, path))
+	return protoBuilder.String()
+}

--- a/benchmark/gnmi/setbench.go
+++ b/benchmark/gnmi/setbench.go
@@ -1,4 +1,4 @@
-// Copyright 2019-present Open Networking Foundation.
+// Copyright 2020-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package gnmi
 
 import (
-	"github.com/onosproject/onos-config/benchmark/gnmi"
+	"context"
 	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-test/pkg/benchmark/params"
+	"time"
 )
 
-func main() {
-	benchmark.Register("gnmi", &gnmi.BenchmarkSuite{})
-	benchmark.Main()
+// BenchmarkSet tests set of GNMI paths
+func (s *BenchmarkSuite) BenchmarkSet(b *benchmark.Benchmark) {
+	b.Run(func(value string) error {
+		devicePath := getDevicePathWithValue(s.simulator.Name(), "/system/config/motd-banner", value, StringVal)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		_, _, err := setGNMIValue(ctx, s.client, devicePath, noPaths, noExtensions)
+		return err
+	}, params.RandomString(8))
 }

--- a/benchmark/gnmi/suite.go
+++ b/benchmark/gnmi/suite.go
@@ -1,0 +1,54 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/onosproject/onos-test/pkg/onit/setup"
+	"github.com/openconfig/gnmi/client/gnmi"
+)
+
+// BenchmarkSuite is an onos-config gNMI benchmark suite
+type BenchmarkSuite struct {
+	benchmark.Suite
+	simulator env.SimulatorEnv
+	client    *client.Client
+}
+
+// SetupSuite :: benchmark
+func (s *BenchmarkSuite) SetupSuite(c *benchmark.Context) {
+	setup.Atomix()
+	setup.Partitions().Raft()
+	setup.Topo().SetReplicas(2)
+	setup.Config().SetReplicas(2)
+	setup.SetupOrDie()
+}
+
+// SetupBenchmark :: benchmark
+func (s *BenchmarkSuite) SetupBenchmark(c *benchmark.Context) {
+	s.simulator = env.NewSimulator().AddOrDie()
+	client, err := env.Config().NewGNMIClient()
+	if err != nil {
+		panic(err)
+	}
+	s.client = client
+}
+
+// TearDownBenchmark :: benchmark
+func (s *BenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
+	s.simulator.RemoveOrDie()
+	s.client.Close()
+}

--- a/build/onos-config-benchmarks/Dockerfile
+++ b/build/onos-config-benchmarks/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.8
+
+RUN apk upgrade --update --no-cache && apk add libc6-compat
+
+USER nobody
+
+ADD build/onos-config-benchmarks/_output/bin/onos-config-benchmarks /usr/local/bin/onos-config-benchmarks
+
+ENTRYPOINT ["onos-config-benchmarks"]

--- a/cmd/onos-config-benchmarks/main.go
+++ b/cmd/onos-config-benchmarks/main.go
@@ -1,4 +1,4 @@
-// Copyright 2019-present Open Networking Foundation.
+// Copyright 2020-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,16 +15,11 @@
 package main
 
 import (
-	"github.com/onosproject/onos-config/test/cli"
-	"github.com/onosproject/onos-config/test/gnmi"
-	"github.com/onosproject/onos-config/test/ha"
-	"github.com/onosproject/onos-test/pkg/test"
+	"github.com/onosproject/onos-config/benchmark/gnmi"
+	"github.com/onosproject/onos-test/pkg/benchmark"
 )
 
 func main() {
-	test.Register("cli", &cli.TestSuite{})
-	test.Register("gnmi", &gnmi.TestSuite{})
-	test.Register("ha", &ha.TestSuite{})
-
-	test.Main()
+	benchmark.Register("gnmi", &gnmi.BenchmarkSuite{})
+	benchmark.Main()
 }

--- a/cmd/onos-config-benchmarks/main.go
+++ b/cmd/onos-config-benchmarks/main.go
@@ -15,11 +15,16 @@
 package main
 
 import (
-	"github.com/onosproject/onos-config/benchmark/gnmi"
-	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-config/test/cli"
+	"github.com/onosproject/onos-config/test/gnmi"
+	"github.com/onosproject/onos-config/test/ha"
+	"github.com/onosproject/onos-test/pkg/test"
 )
 
 func main() {
-	benchmark.Register("gnmi", &gnmi.BenchmarkSuite{})
-	benchmark.Main()
+	test.Register("cli", &cli.TestSuite{})
+	test.Register("gnmi", &gnmi.TestSuite{})
+	test.Register("ha", &ha.TestSuite{})
+
+	test.Main()
 }

--- a/cmd/onos-config-tests/main.go
+++ b/cmd/onos-config-tests/main.go
@@ -15,11 +15,16 @@
 package main
 
 import (
-	"github.com/onosproject/onos-config/benchmark/gnmi"
-	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-config/test/cli"
+	"github.com/onosproject/onos-config/test/gnmi"
+	"github.com/onosproject/onos-config/test/ha"
+	"github.com/onosproject/onos-test/pkg/test"
 )
 
 func main() {
-	benchmark.Register("gnmi", &gnmi.BenchmarkSuite{})
-	benchmark.Main()
+	test.Register("cli", &cli.TestSuite{})
+	test.Register("gnmi", &gnmi.TestSuite{})
+	test.Register("ha", &ha.TestSuite{})
+
+	test.Main()
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/onosproject/onos-test v0.0.0-20200110210314-9e9ce2c945d0
+	github.com/onosproject/onos-test v0.0.0-20200114235320-ec5e1c74a5d2
 	github.com/onosproject/onos-topo v0.0.0-20191113170912-88eeee89f4eb
 	github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c
 	github.com/openconfig/goyang v0.0.0-20190924211109-064f9690516f

--- a/go.sum
+++ b/go.sum
@@ -270,6 +270,10 @@ github.com/onosproject/onos-test v0.0.0-20200109235108-1f3ea4829a88 h1:gL8Kh+Vxh
 github.com/onosproject/onos-test v0.0.0-20200109235108-1f3ea4829a88/go.mod h1:MuqvLb93cywFHf5jU+UzmTke214TqKQsHeHrGYctAa0=
 github.com/onosproject/onos-test v0.0.0-20200110210314-9e9ce2c945d0 h1:9VufguVtGU7jsroIZalsbOg7DNb97KWq+ZNkkBfk8KA=
 github.com/onosproject/onos-test v0.0.0-20200110210314-9e9ce2c945d0/go.mod h1:MuqvLb93cywFHf5jU+UzmTke214TqKQsHeHrGYctAa0=
+github.com/onosproject/onos-test v0.0.0-20200111150630-8da14688e9e4 h1:AxYw0CHThV+APsw90Zof8Lttk9yUJ8G9nMoDNelsciU=
+github.com/onosproject/onos-test v0.0.0-20200111150630-8da14688e9e4/go.mod h1:MuqvLb93cywFHf5jU+UzmTke214TqKQsHeHrGYctAa0=
+github.com/onosproject/onos-test v0.0.0-20200114235320-ec5e1c74a5d2 h1:w0Dz/z3W8y40LwRxKJDleW1R8RieJJKQSpFJ+lAcg4Q=
+github.com/onosproject/onos-test v0.0.0-20200114235320-ec5e1c74a5d2/go.mod h1:upJkuL2a0RgSf/zw93AVORMxxChYof0VUMac4mLY8dE=
 github.com/onosproject/onos-topo v0.0.0-20191107000708-af85b82cfca3 h1:J0qw6ZRZiLvWm94Yu1HI7K/hNG/52aRdnBErYmLJL3M=
 github.com/onosproject/onos-topo v0.0.0-20191107000708-af85b82cfca3/go.mod h1:oPGdJnMHy5UGx4slrbf84DEFqcKXuGMv36N+EBc3QwM=
 github.com/onosproject/onos-topo v0.0.0-20191113170912-88eeee89f4eb h1:jcQhZMMGue2jeAs0A2HVTGpybxywHjyRoyd+b0R96B8=


### PR DESCRIPTION
This PR adds a new `onos-config-benchmarks` image with basic gNMI _set_ and _get_ benchmarks.