### PR TITLE
Serve gnmi northbound gets from device state cache

### DIFF
--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -119,9 +119,8 @@ func getUpdate(version devicetype.Version, prefix *gnmi.Path, path *gnmi.Path) (
 	if prefix != nil && prefix.Elem != nil {
 		pathAsString = utils.StrPath(prefix) + pathAsString
 	}
-	//TODO the following can be optimized by looking if the path is in the read only
-	configValues, errGetTargetCfg := manager.GetManager().GetTargetConfig(
-		devicetype.ID(target), version, pathAsString, 0)
+	// TODO: Use index extension to provide read-your-own-writes consistency via the 'index' argument
+	configValues, errGetTargetCfg := manager.GetManager().DeviceStateStore.Get(devicetype.NewVersionedID(devicetype.ID(target), version), 0)
 	if errGetTargetCfg != nil {
 		log.Error("Error while extracting config", errGetTargetCfg)
 		return nil, errGetTargetCfg

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -17,6 +17,7 @@ package gnmi
 import (
 	"context"
 	"github.com/golang/mock/gomock"
+	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
 	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/utils"
@@ -72,6 +73,7 @@ func Test_getNoPathElems(t *testing.T) {
 		},
 	}).AnyTimes()
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	mocks.MockStores.DeviceStateStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]*devicechange.PathValue{}, nil).AnyTimes()
 	setUpListMock(mocks)
 
 	noPath1 := gnmi.Path{Target: "Device1"}
@@ -223,6 +225,7 @@ func Test_targetDoesNotExist(t *testing.T) {
 		},
 	}).AnyTimes()
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).AnyTimes()
+	mocks.MockStores.DeviceStateStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]*devicechange.PathValue{}, nil).AnyTimes()
 	setUpListMock(mocks)
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})
@@ -251,6 +254,7 @@ func Test_pathDoesNotExist(t *testing.T) {
 		},
 	}).AnyTimes()
 	mocks.MockStores.DeviceStore.EXPECT().Get(gomock.Any()).Return(nil, status.Error(codes.NotFound, "device not found")).Times(2)
+	mocks.MockStores.DeviceStateStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]*devicechange.PathValue{}, nil).AnyTimes()
 	setUpListMock(mocks)
 
 	prefixPath, err := utils.ParseGNMIElements([]string{"cont1a", "cont2a"})

--- a/pkg/northbound/gnmi/gnmi_test.go
+++ b/pkg/northbound/gnmi/gnmi_test.go
@@ -189,6 +189,12 @@ func setUpChangesMock(mocks *AllMocks) {
 			Message: "",
 		},
 	}
+	mocks.MockStores.DeviceStateStore.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]*devicechange.PathValue{
+		{
+			Path:  configValue01.Path,
+			Value: configValue01.Value,
+		},
+	}, nil).AnyTimes()
 	mocks.MockStores.DeviceChangesStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(device devicetype.VersionedID, c chan<- *devicechange.DeviceChange) (stream.Context, error) {
 			go func() {
@@ -209,6 +215,7 @@ func setUp(t *testing.T) (*Server, *manager.Manager, *AllMocks) {
 	ctrl := gomock.NewController(t)
 	mockStores := &mockstore.MockStores{
 		DeviceStore:          mockstore.NewMockDeviceStore(ctrl),
+		DeviceStateStore:     mockstore.NewMockDeviceStateStore(ctrl),
 		NetworkChangesStore:  mockstore.NewMockNetworkChangesStore(ctrl),
 		DeviceChangesStore:   mockstore.NewMockDeviceChangesStore(ctrl),
 		NetworkSnapshotStore: mockstore.NewMockNetworkSnapshotStore(ctrl),


### PR DESCRIPTION
This PR serves gNMI _get_ requests using the device state cache (a state machine) rather than building the state dynamically. This represents a significant performance improvement. Listing device state over the network can add hundreds of milliseconds of latency to a _get_.

Note that this pull request introduces a consistency issue for gets. A client that reads following a write may not see its own write. This will be addressed in a separate pull request.