### PR TITLE
Remove build docs from onos-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,3 @@ jobs:
       if: type != pull_request
       script:
         - sh build/bin/trigger-cli-travis $TRAVIS_ACCESS_TOKEN
-    - stage: docs build
-      if: type != pull_request
-      script:
-        - sh build/bin/trigger-docs-travis $TRAVIS_ACCESS_TOKEN


### PR DESCRIPTION
since Integration tests will be called after we merge a PR, we don't need to build docs again since it is already taken care of in onos-test travis job. 