### PR TITLE
Update ygot ver used by code-generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/onosproject/onos-topo v0.0.0-20191113170912-88eeee89f4eb
 	github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c
 	github.com/openconfig/goyang v0.0.0-20190924211109-064f9690516f
-	github.com/openconfig/ygot v0.6.0
+	github.com/openconfig/ygot v0.6.1-0.20200103195725-e3c44fa43926
 	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/openconfig/goyang v0.0.0-20190924211109-064f9690516f h1:BaekRUaWpfaRB
 github.com/openconfig/goyang v0.0.0-20190924211109-064f9690516f/go.mod h1:dhXaV0JgHJzdrHi2l+w0fZrwArtXL7jEFoiqLEdmkvU=
 github.com/openconfig/ygot v0.6.0 h1:kJJFPBrczC6TDnz/HMlFTJEdW2CuyUftV13XveIukg0=
 github.com/openconfig/ygot v0.6.0/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
+github.com/openconfig/ygot v0.6.1-0.20200103195725-e3c44fa43926 h1:58WpM0gs8tt1CbZorr4zyDsbjjbQ2Ua+Yr12ufyGHlc=
+github.com/openconfig/ygot v0.6.1-0.20200103195725-e3c44fa43926/go.mod h1:o30svNf7O0xK+R35tlx95odkDmZWS9JyWWQSmIhqwAs=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
Running ./ModelGenerator.sh Stratum-1.0.0.env was giving ...
`build command-line-arguments: cannot load github.com/openconfig/ygot/genutil: module github.com/openconfig/ygot@latest found (v0.6.0), but does not contain package github.com/openconfig/ygot/genutil`

Note: the available ygot tags are ...
```
$ go list -m -versions github.com/openconfig/ygot
github.com/openconfig/ygot v0.5.0 v0.6.0
```

Here we change to revision from Fri Jan 3 11:57:25 2020 -0800 with SHA e3c44fa439262c24ff5d3dc62b662b10f49181c3
Extra benefit is it includes fix for https://github.com/openconfig/ygot/issues/333 which is needed imminiently anyway.

Steps taken ...
```
$ go get -u github.com/openconfig/ygot
$ cd $GOPATH/src/github.com/openconfig/ygot && go get -t -d ./...


$ export GO111MODULE=on && go get github.com/openconfig/ygot@e3c44fa439262c24ff5d3dc62b662b10f49181c3
$ go list -m all| grep ygot
github.com/openconfig/ygot v0.6.1-0.20200103195725-e3c44fa43926
// previously it was v0.6.0 (from 2019-04-27)
```

Will change to an official tagged ygot version when becomes available

Note: `github.com/grpc-ecosystem/go-grpc-middleware` is also removed here
(but that is just tidyup not related to above)