### PR TITLE
Use change revisions to provide consistency for northbound sets/gets

### DIFF
--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -129,7 +129,7 @@ func main() {
 		log.Error("Cannot load network atomix store ", err)
 	}
 
-	deviceStateStore, err := state.NewStore(deviceChangesStore, deviceSnapshotStore)
+	deviceStateStore, err := state.NewStore(networkChangesStore, deviceSnapshotStore)
 	if err != nil {
 		log.Errorf("Cannot load device store with address %s:", *topoEndpoint, err)
 	}

--- a/pkg/manager/getconfig.go
+++ b/pkg/manager/getconfig.go
@@ -16,18 +16,19 @@ package manager
 
 import (
 	devicechange "github.com/onosproject/onos-config/api/types/change/device"
+	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
-	devicechangeutils "github.com/onosproject/onos-config/pkg/store/change/device/utils"
 	"github.com/onosproject/onos-config/pkg/utils"
 )
 
 // GetTargetConfig returns a set of change values given a target, a configuration name, a path and a layer.
 // The layer is the numbers of config changes we want to go back in time for. 0 is the latest (Atomix based)
-func (m *Manager) GetTargetConfig(deviceID devicetype.ID, version devicetype.Version, path string, layer int) ([]*devicechange.PathValue, error) {
+func (m *Manager) GetTargetConfig(deviceID devicetype.ID, version devicetype.Version, path string, revision networkchange.Revision) ([]*devicechange.PathValue, error) {
 	log.Infof("Getting config for %s at %s", deviceID, path)
-	configValues, errExtract := devicechangeutils.ExtractFullConfig(devicetype.NewVersionedID(deviceID, version), nil, m.DeviceChangesStore, layer)
-	if errExtract != nil {
-		return nil, errExtract
+	configValues, errGetTargetCfg := m.DeviceStateStore.Get(devicetype.NewVersionedID(deviceID, version), revision)
+	if errGetTargetCfg != nil {
+		log.Error("Error while extracting config", errGetTargetCfg)
+		return nil, errGetTargetCfg
 	}
 	if len(configValues) == 0 {
 		return configValues, nil

--- a/pkg/manager/getstate.go
+++ b/pkg/manager/getstate.go
@@ -26,6 +26,7 @@ func (m *Manager) GetTargetState(target string, path string) []*devicechange.Pat
 	configValues := make([]*devicechange.PathValue, 0)
 	//First check the cache, if it's not empty for this path we read that and return,
 	pathRegexp := utils.MatchWildcardRegexp(path)
+	m.OperationalStateCacheLock.RLock()
 	for pathCache, value := range m.OperationalStateCache[topodevice.ID(target)] {
 		if pathRegexp.MatchString(pathCache) {
 			configValues = append(configValues, &devicechange.PathValue{
@@ -34,6 +35,7 @@ func (m *Manager) GetTargetState(target string, path string) []*devicechange.Pat
 			})
 		}
 	}
+	m.OperationalStateCacheLock.RUnlock()
 	if len(configValues) == 0 {
 		log.Warnf("Path %s is not in the operational state cache of device %s", path, target)
 	}

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -124,7 +124,7 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 	assert.NilError(t, err)
 	deviceSnapshotStore, err := devicesnapstore.NewLocalStore()
 	assert.NilError(t, err)
-	deviceStateStore, err := state.NewStore(deviceChangesStore, deviceSnapshotStore)
+	deviceStateStore, err := state.NewStore(networkChangesStore, deviceSnapshotStore)
 	assert.NilError(t, err)
 
 	deviceCache, err := cache.NewCache(networkChangesStore, deviceSnapshotStore)
@@ -285,7 +285,7 @@ func Test_SetNetworkConfig_Deep(t *testing.T) {
 	updatesForDevice1, deletesForDevice1, deviceInfo := makeDeviceChanges(device1, updates, deletes)
 
 	// Verify the change
-	validationError := mgrTest.ValidateNetworkConfig(device1, deviceVersion1, deviceTypeTd, updates, deletes)
+	validationError := mgrTest.ValidateNetworkConfig(device1, deviceVersion1, deviceTypeTd, updates, deletes, 0)
 	assert.NilError(t, validationError, "ValidateTargetConfig error")
 
 	// Set the new change

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -290,7 +290,7 @@ func Test_SetNetworkConfig_Deep(t *testing.T) {
 
 	// Set the new change
 	const testNetworkChange networkchange.ID = "Test_SetNetworkConfig"
-	err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, string(testNetworkChange))
+	_, err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, string(testNetworkChange))
 	assert.NilError(t, err, "SetTargetConfig error")
 
 	nwChangeUpdates := make(chan stream.Event)
@@ -356,7 +356,7 @@ func Test_SetNetworkConfig_ConfigOnly_Deep(t *testing.T) {
 
 	// Set the new change
 	const testNetworkChange networkchange.ID = "ConfigOnly_SetNetworkConfig"
-	err := mgrTest.SetNetworkConfig(updatesForConfigOnlyDevice, deletesForConfigOnlyDevice, deviceInfo, string(testNetworkChange))
+	_, err := mgrTest.SetNetworkConfig(updatesForConfigOnlyDevice, deletesForConfigOnlyDevice, deviceInfo, string(testNetworkChange))
 	assert.NilError(t, err, "ConfigOnly_SetNetworkConfig error")
 
 	nwChangeUpdates := make(chan stream.Event)
@@ -456,7 +456,7 @@ func Test_SetNetworkConfig_Disconnected_Device(t *testing.T) {
 
 	// Set the new change
 	const testNetworkChange networkchange.ID = "Disconnected_SetNetworkConfig"
-	err := mgrTest.SetNetworkConfig(updatesForDisconnectedDevice, deletesForDisconnectedDevice, deviceInfo, string(testNetworkChange))
+	_, err := mgrTest.SetNetworkConfig(updatesForDisconnectedDevice, deletesForDisconnectedDevice, deviceInfo, string(testNetworkChange))
 	assert.NilError(t, err, "Disconnected_SetNetworkConfig error")
 
 	nwChangeUpdates := make(chan stream.Event)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -320,7 +320,7 @@ func Test_SetNetworkConfig(t *testing.T) {
 
 	// Set the new change
 	const testNetworkChange networkchange.ID = "Test_SetNetworkConfig"
-	err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, string(testNetworkChange))
+	_, err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, string(testNetworkChange))
 	assert.NilError(t, err, "SetTargetConfig error")
 	testUpdate, _ := mgrTest.NetworkChangesStore.Get(testNetworkChange)
 	assert.Assert(t, testUpdate != nil)
@@ -355,7 +355,7 @@ func Test_SetNetworkConfig_NewConfig(t *testing.T) {
 
 	updatesForDevice, deletesForDevice, deviceInfo := makeDeviceChanges(Device5, updates, deletes)
 
-	err := mgrTest.SetNetworkConfig(updatesForDevice, deletesForDevice, deviceInfo, NetworkChangeAddDevice5)
+	_, err := mgrTest.SetNetworkConfig(updatesForDevice, deletesForDevice, deviceInfo, NetworkChangeAddDevice5)
 	assert.NilError(t, err, "SetTargetConfig error")
 	testUpdate, _ := mgrTest.NetworkChangesStore.Get(NetworkChangeAddDevice5)
 	assert.Assert(t, testUpdate != nil)
@@ -385,7 +385,7 @@ func Test_SetMultipleSimilarNetworkConfig(t *testing.T) {
 	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueFloat(valueLeaf2B159)
 	updatesForDevice1, deletesForDevice1, deviceInfo := makeDeviceChanges(device1, updates, deletes)
 
-	err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "Testing")
+	_, err := mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "Testing")
 
 	// TODO - similar configs are currently not detected
 	t.Skip()
@@ -402,7 +402,7 @@ func Test_SetSingleSimilarNetworkConfig(t *testing.T) {
 	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueFloat(valueLeaf2B159)
 	updatesForDevice, deletesForDevice, deviceInfo := makeDeviceChanges(device1, updates, deletes)
 
-	err := mgrTest.SetNetworkConfig(updatesForDevice, deletesForDevice, deviceInfo, "Testing")
+	_, err := mgrTest.SetNetworkConfig(updatesForDevice, deletesForDevice, deviceInfo, "Testing")
 	assert.NilError(t, err, "Similar config not found")
 }
 
@@ -419,10 +419,10 @@ func TestManager_GetAllDeviceIds(t *testing.T) {
 	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueFloat(valueLeaf2B314)
 	deletes := []string{test1Cont1ACont2ALeaf2C}
 	updatesForDevice2, deletesForDevice2, deviceInfo2 := makeDeviceChanges("Device2", updates, deletes)
-	err := mgrTest.SetNetworkConfig(updatesForDevice2, deletesForDevice2, deviceInfo2, "Device2")
+	_, err := mgrTest.SetNetworkConfig(updatesForDevice2, deletesForDevice2, deviceInfo2, "Device2")
 	assert.NilError(t, err, "SetTargetConfig error")
 	updatesForDevice3, deletesForDevice3, deviceInfo3 := makeDeviceChanges("Device2", updates, deletes)
-	err = mgrTest.SetNetworkConfig(updatesForDevice3, deletesForDevice3, deviceInfo3, "Device3")
+	_, err = mgrTest.SetNetworkConfig(updatesForDevice3, deletesForDevice3, deviceInfo3, "Device3")
 	assert.NilError(t, err, "SetTargetConfig error")
 	mocks.MockStores.DeviceStore.EXPECT().List(gomock.Any()).AnyTimes()
 	deviceIds := mgrTest.GetAllDeviceIds()
@@ -503,7 +503,7 @@ func TestManager_ComputeRollbackFailure(t *testing.T) {
 
 	err := mgrTest.ValidateNetworkConfig(device1, deviceVersion1, deviceTypeTd, updates, deletes)
 	assert.NilError(t, err, "ValidateTargetConfig error")
-	err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback")
+	_, err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback")
 	assert.NilError(t, err, "Can't create change", err)
 
 	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueFloat(valueLeaf2B314)
@@ -514,7 +514,7 @@ func TestManager_ComputeRollbackFailure(t *testing.T) {
 	assert.NilError(t, err, "ValidateTargetConfig error")
 
 	updatesForDevice1, deletesForDevice1, deviceInfo = makeDeviceChanges(device1, updates, deletes)
-	err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback2")
+	_, err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback2")
 	assert.NilError(t, err, "Can't create change")
 
 	testingRollback, err := mocks.MockStores.NetworkChangesStore.Get("TestingRollback")
@@ -540,7 +540,7 @@ func TestManager_ComputeRollbackDelete(t *testing.T) {
 
 	err := mgrTest.ValidateNetworkConfig(device1, deviceVersion1, deviceTypeTd, updates, deletes)
 	assert.NilError(t, err, "ValidateTargetConfig error")
-	err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback")
+	_, err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback")
 	assert.NilError(t, err, "Can't create change", err)
 
 	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueFloat(valueLeaf2B314)
@@ -551,7 +551,7 @@ func TestManager_ComputeRollbackDelete(t *testing.T) {
 	assert.NilError(t, err, "ValidateTargetConfig error")
 
 	updatesForDevice1, deletesForDevice1, deviceInfo = makeDeviceChanges(device1, updates, deletes)
-	err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback2")
+	_, err = mgrTest.SetNetworkConfig(updatesForDevice1, deletesForDevice1, deviceInfo, "TestingRollback2")
 	assert.NilError(t, err, "Can't create change")
 
 	testingRollback2, err := mocks.MockStores.NetworkChangesStore.Get("TestingRollback2")

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -74,22 +74,22 @@ func (m *Manager) ValidateNetworkConfig(deviceName devicetype.ID, version device
 
 // SetNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
 func (m *Manager) SetNetworkConfig(targetUpdates map[string]devicechange.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info, netcfgchangename string) error {
+	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info, netcfgchangename string) (*networkchange.NetworkChange, error) {
 	//TODO evaluate need of user and add it back if need be.
 	allDeviceChanges, errChanges := m.computeNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
 	if errChanges != nil {
-		return errChanges
+		return nil, errChanges
 	}
 	newNetworkConfig, errNetChange := networkchange.NewNetworkChange(netcfgchangename, allDeviceChanges)
 	if errNetChange != nil {
-		return errNetChange
+		return nil, errNetChange
 	}
 	//Writing to the atomix backed store too
 	errStoreChange := m.NetworkChangesStore.Create(newNetworkConfig)
 	if errStoreChange != nil {
-		return errStoreChange
+		return nil, errStoreChange
 	}
-	return nil
+	return newNetworkConfig, nil
 }
 
 //computeNetworkConfig computes each device change

--- a/pkg/northbound/gnmi/get.go
+++ b/pkg/northbound/gnmi/get.go
@@ -119,10 +119,11 @@ func (s *Server) getUpdate(version devicetype.Version, prefix *gnmi.Path, path *
 	}
 
 	s.mu.RLock()
-	index := s.lastWrite
+	revision := s.lastWrite
 	s.mu.RUnlock()
 
-	configValues, errGetTargetCfg := manager.GetManager().DeviceStateStore.Get(devicetype.NewVersionedID(devicetype.ID(target), version), devicechange.Index(index))
+	configValues, errGetTargetCfg := manager.GetManager().GetTargetConfig(
+		devicetype.ID(target), version, pathAsString, revision)
 	if errGetTargetCfg != nil {
 		log.Error("Error while extracting config", errGetTargetCfg)
 		return nil, errGetTargetCfg

--- a/pkg/northbound/gnmi/service.go
+++ b/pkg/northbound/gnmi/service.go
@@ -45,7 +45,7 @@ func (s Service) Register(r *grpc.Server) {
 // Server implements the grpc GNMI service
 type Server struct {
 	mu        sync.RWMutex
-	lastWrite networkchange.Index
+	lastWrite networkchange.Revision
 }
 
 // Capabilities implements gNMI Capabilities

--- a/pkg/northbound/gnmi/service.go
+++ b/pkg/northbound/gnmi/service.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"context"
 	"fmt"
+	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	"github.com/onosproject/onos-config/pkg/manager"
 	"io/ioutil"
 	"sync"
@@ -43,7 +44,8 @@ func (s Service) Register(r *grpc.Server) {
 
 // Server implements the grpc GNMI service
 type Server struct {
-	mu sync.RWMutex
+	mu        sync.RWMutex
+	lastWrite networkchange.Index
 }
 
 // Capabilities implements gNMI Capabilities

--- a/pkg/store/change/device/state/store.go
+++ b/pkg/store/change/device/state/store.go
@@ -83,7 +83,9 @@ func (s *deviceChangeStoreStateStore) processCh(ch chan stream.Event) {
 		err := s.processChange(event.Object.(*networkchange.NetworkChange))
 		s.mu.Unlock()
 		if err != nil {
-			go s.listen()
+			go func() {
+				_ = s.listen()
+			}()
 			return
 		}
 	}
@@ -222,7 +224,6 @@ func (s *deviceChangeStoreStateStore) Get(id devicetype.VersionedID, revision ne
 type deviceChangeStateStore struct {
 	deviceID devicetype.VersionedID
 	state    map[string]*devicechange.TypedValue
-	changes  networkchangestore.Store
 }
 
 func (s *deviceChangeStateStore) update(value *devicechange.PathValue) {

--- a/pkg/test/mocks/store/device_state_store_mock.go
+++ b/pkg/test/mocks/store/device_state_store_mock.go
@@ -7,6 +7,7 @@ package store
 import (
 	gomock "github.com/golang/mock/gomock"
 	device "github.com/onosproject/onos-config/api/types/change/device"
+	network "github.com/onosproject/onos-config/api/types/change/network"
 	device0 "github.com/onosproject/onos-config/api/types/device"
 	reflect "reflect"
 )
@@ -17,7 +18,7 @@ type MockDeviceStateStore struct {
 	recorder *MockDeviceStateStoreMockRecorder
 }
 
-// MockDeviceStateStoreMockRecorder is the mock recorder for MockStore
+// MockDeviceStateStoreMockRecorder is the mock recorder for MockDeviceStateStore
 type MockDeviceStateStoreMockRecorder struct {
 	mock *MockDeviceStateStore
 }
@@ -35,16 +36,16 @@ func (m *MockDeviceStateStore) EXPECT() *MockDeviceStateStoreMockRecorder {
 }
 
 // Get mocks base method
-func (m *MockDeviceStateStore) Get(id device0.VersionedID, index device.Index) ([]*device.PathValue, error) {
+func (m *MockDeviceStateStore) Get(id device0.VersionedID, revision network.Revision) ([]*device.PathValue, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", id, index)
+	ret := m.ctrl.Call(m, "Get", id, revision)
 	ret0, _ := ret[0].([]*device.PathValue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get
-func (mr *MockDeviceStateStoreMockRecorder) Get(id, index interface{}) *gomock.Call {
+func (mr *MockDeviceStateStoreMockRecorder) Get(id, revision interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDeviceStateStore)(nil).Get), id, index)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDeviceStateStore)(nil).Get), id, revision)
 }


### PR DESCRIPTION
This pull request provides read-your-writes consistency and improve performance for northbound API calls. The changes that achieve this are:
* Refactor the device state cache to populate the cache from `NetworkChange`s and snapshots to guarantee the client can see changes written only to the `NetworkChange` store and not yet propagated to the `DeviceChange` store.
* Remove locks for gNMI sets and gets, locking only the operational state cache and revision reads/updates used for consistency (stores are always thread safe)
* Validates changes against the device state cache to avoid listing changes during set requests
* Fixes bugs in gNMI set/get introduced by previous changes