### PR TITLE
Add a workaround for golangci-lint bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
     - master
 
 before_script:
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.23.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.23.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.1
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ deps: # @HELP ensure that the required dependencies are in place
 	bash -c "diff -u <(echo -n) <(git diff go.sum)"
 
 linters: # @HELP examines Go source code and reports coding problems
-	golangci-lint run --timeout 30m
+	# Retry as a workaround for https://github.com/golangci/golangci-lint/issues/840
+	for retry in 1 2 3; do echo "Running linter, attempt #$$retry";  golangci-lint run --timeout 30m && s=0 && break || s=$$? && sleep 1; done; (exit $$s)
 
 license_check: # @HELP examine and ensure license headers exist
 	@if [ ! -d "../build-tools" ]; then cd .. && git clone https://github.com/onosproject/build-tools.git; fi


### PR DESCRIPTION
See https://github.com/golangci/golangci-lint/issues/840

This issue seen intermittentily when building this repo using v1.23.1 or v1.21.0 of linter

Here is an example on macOS which shows intermittent problem with v1.21.0 ...
```

18:21 $ curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.23.1/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
golangci/golangci-lint info checking GitHub for tag 'v1.21.0'
golangci/golangci-lint info found version: 1.21.0 for v1.21.0/darwin/amd64
golangci/golangci-lint info installed /Users/kmcpeake/go/bin/golangci-lint
18:22 $ golangci-lint cache clean
18:22 $ golangci-lint run --timeout 30m
18:22 $ golangci-lint cache clean
18:22 $ golangci-lint run --timeout 30m
WARN [runner] Can't run linter goanalysis_metalinter: fact_deprecated: failed prerequisites: fact_deprecated@github.com/onosproject/onos-test/pkg/onit/env
18:22 $ golangci-lint cache clean
18:23 $ golangci-lint run --timeout 30m
18:23 $ golangci-lint --version
golangci-lint has version 1.21.0 built from 645e794 on 2019-10-15T18:15:04Z

```
golangci-lint says v1.19.1 does not have this problem but reverting to
it highlights other go warnings than detected currently (plus it has
worse performance)