### PR TITLE
Fix bug in opstate subscription events 

### DIFF
--- a/pkg/northbound/gnmi/subscribe.go
+++ b/pkg/northbound/gnmi/subscribe.go
@@ -242,7 +242,7 @@ func listenForOpStateUpdates(opStateChan chan events.OperationalStateEvent, stre
 				continue
 			}
 
-			err = buildAndSendUpdate(pathGnmi, target, opStateChange.Value(), len(opStateChange.Value().Bytes) > 0, stream)
+			err = buildAndSendUpdate(pathGnmi, target, opStateChange.Value(), len(opStateChange.Value().Bytes) == 0, stream)
 			if err != nil {
 				log.Error("Error in sending update path ", err)
 				resChan <- result{success: false, err: err}


### PR DESCRIPTION
Northbound subscribe events for opstate paths were always being returned as DELETE