### PR TITLE
Test subscribe to an opstate cache path

### DIFF
--- a/test/gnmi/subscribestatediagstest.go
+++ b/test/gnmi/subscribestatediagstest.go
@@ -1,4 +1,4 @@
-// Copyright 2019-present Open Networking Foundation.
+// Copyright 2020-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,13 +71,13 @@ func (s *TestSuite) TestSubscribeStateDiags(t *testing.T) {
 		}
 		assert.NoError(t, responseErr)
 		if filterResponse(response) {
-			validateDiagsStateResponse(t, response, simulator.Name(), false)
+			validateDiagsStateResponse(t, response)
 			i++
 		}
 	}
 }
 
-func validateDiagsStateResponse(t *testing.T, resp *diags.OpStateResponse, device string, delete bool) {
+func validateDiagsStateResponse(t *testing.T, resp *diags.OpStateResponse) {
 	t.Helper()
 	assert.Equal(t, resp.Pathvalue.Path, dateTimePath)
 

--- a/test/gnmi/subscribestatediagstest.go
+++ b/test/gnmi/subscribestatediagstest.go
@@ -1,0 +1,89 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"context"
+	"github.com/onosproject/onos-config/api/diags"
+	"io"
+	"testing"
+	"time"
+
+	testutils "github.com/onosproject/onos-config/test/utils"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/onosproject/onos-topo/api/device"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	dateTimePath = "/system/state/current-datetime"
+)
+
+var (
+	previousTime = time.Now().Add(-5 * time.Second)
+)
+
+func filterResponse(response *diags.OpStateResponse) bool {
+	return response.Pathvalue.Path == dateTimePath
+}
+
+// TestSubscribeStateDiags tests a stream subscription to updates to a device using the diags API
+func (s *TestSuite) TestSubscribeStateDiags(t *testing.T) {
+	// Bring up a new simulated device
+	simulator := env.NewSimulator().AddOrDie()
+	deviceName := simulator.Name()
+	deviceID := device.ID(deviceName)
+
+	// Wait for config to connect to the device
+	testutils.WaitForDeviceAvailable(t, deviceID, 10*time.Second)
+	time.Sleep(250 * time.Millisecond)
+
+	// Make an opstate diags client
+	clientConnection, clientConnectionError := env.Config().Connect()
+	assert.NoError(t, clientConnectionError)
+	opstateClient := diags.CreateOpStateDiagsClient(clientConnection)
+
+	subscribe := &diags.OpStateRequest{
+		DeviceId:  deviceName,
+		Subscribe: true,
+	}
+
+	stream, streamErr := opstateClient.GetOpState(context.Background(), subscribe)
+	assert.NoError(t, streamErr)
+
+	i := 1
+	for i <= 5 {
+		response, responseErr := stream.Recv()
+		if responseErr == io.EOF {
+			break
+		}
+		assert.NoError(t, responseErr)
+		if filterResponse(response) {
+			validateDiagsStateResponse(t, response, simulator.Name(), false)
+			i++
+		}
+	}
+}
+
+func validateDiagsStateResponse(t *testing.T, resp *diags.OpStateResponse, device string, delete bool) {
+	t.Helper()
+	assert.Equal(t, resp.Pathvalue.Path, dateTimePath)
+
+	updatedTimeString := resp.Pathvalue.Value.ValueToString()
+	updatedTime, timeParseError := time.Parse("2006-01-02T15:04:05Z-07:00", updatedTimeString)
+	assert.NoError(t, timeParseError, "Error parsing time string from path value")
+	assert.True(t, previousTime.Before(updatedTime), "Path time value is not in the future")
+	previousTime = updatedTime
+}

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -1,4 +1,4 @@
-// Copyright 2019-present Open Networking Foundation.
+// Copyright 2020-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -1,0 +1,151 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"fmt"
+	"github.com/onosproject/onos-config/pkg/utils"
+	"github.com/openconfig/gnmi/client"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	testutils "github.com/onosproject/onos-config/test/utils"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/onosproject/onos-topo/api/device"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSubscribeStateGnmi tests a stream subscription to updates to a device using the diags API
+func (s *TestSuite) TestSubscribeStateGnmi(t *testing.T) {
+	const dateTimePath = "/system/state/current-datetime"
+
+	previousTime = time.Now().Add(-5 * time.Second)
+
+	// Bring up a new simulated device
+	simulator := env.NewSimulator().AddOrDie()
+	deviceName := simulator.Name()
+	deviceID := device.ID(deviceName)
+
+	// Wait for config to connect to the device
+	testutils.WaitForDeviceAvailable(t, deviceID, 10*time.Second)
+	time.Sleep(250 * time.Millisecond)
+
+	// Make a GNMI client to use for subscribe
+	subC := client.BaseClient{}
+
+	path, err := utils.ParseGNMIElements(utils.SplitPath(dateTimePath))
+
+	assert.NoError(t, err, "Unexpected error doing parsing")
+
+	path.Target = simulator.Name()
+
+	subReq := subscribeRequest{
+		path:          path,
+		subListMode:   gnmi.SubscriptionList_STREAM,
+		subStreamMode: gnmi.SubscriptionMode_TARGET_DEFINED,
+	}
+
+	request, errReq := buildRequest(subReq)
+
+	assert.NoError(t, errReq, "Can't build Request")
+
+	q, errQuery := client.NewQuery(request)
+
+	assert.NoError(t, errQuery, "Can't build Query")
+
+	dest := env.Config().Destination()
+
+	q.Addrs = dest.Addrs
+	q.Timeout = dest.Timeout
+	q.Target = dest.Target
+	q.Credentials = dest.Credentials
+	q.TLS = dest.TLS
+
+	respChan := make(chan *gnmi.SubscribeResponse)
+
+	q.ProtoHandler = func(msg proto.Message) error {
+		resp, ok := msg.(*gnmi.SubscribeResponse)
+		if !ok {
+			return fmt.Errorf("failed to type assert message %#v", msg)
+		}
+		respChan <- resp
+		return nil
+	}
+
+	var response *gnmi.SubscribeResponse
+
+	// Subscription has to be spawned into a separate thread as it is blocking.
+	go func() {
+		errSubscribe := subC.Subscribe(testutils.MakeContext(), q, "gnmi")
+		assert.NoError(t, errSubscribe, "Subscription Error")
+	}()
+
+	// Sleeping in order to make sure the subscribe request is properly stored and processed.
+	time.Sleep(100000)
+
+	i := 1
+	for i <= 10 {
+		select {
+		case response = <-respChan:
+			validateGnmiStateResponse(t, response, simulator.Name())
+			i++
+		case <-time.After(10 * time.Second):
+			assert.FailNow(t, "Expected Update Response")
+		}
+	}
+}
+
+func validateGnmiStateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string) {
+	t.Helper()
+
+	switch v := resp.Response.(type) {
+	case *gnmi.SubscribeResponse_Update:
+		validateGnmiStateUpdateResponse(t, v, device)
+
+	case *gnmi.SubscribeResponse_SyncResponse:
+		validateGnmiStateSyncResponse(t, v)
+
+	default:
+		assert.Fail(t, "Unknown GNMI state response type")
+	}
+}
+
+func validateGnmiStateUpdateResponse(t *testing.T, update *gnmi.SubscribeResponse_Update, device string) {
+	t.Helper()
+
+	assert.True(t, update.Update != nil, "Update should not be nil")
+	assert.Equal(t, 1, len(update.Update.GetUpdate()))
+	assert.NotNil(t, update.Update.GetUpdate()[0])
+
+	pathResponse := update.Update.GetUpdate()[0].Path
+	assert.Equal(t, pathResponse.Target, device)
+	assert.Equal(t, 3, len(pathResponse.Elem), "Expected 3 path elements")
+	assert.Equal(t, pathResponse.Elem[0].Name, "system")
+	assert.Equal(t, pathResponse.Elem[1].Name, "state")
+	assert.Equal(t, pathResponse.Elem[2].Name, "current-datetime")
+	updatedTimeString := update.Update.GetUpdate()[0].Val.GetStringVal()
+	updatedTime, timeParseError := time.Parse("2006-01-02T15:04:05Z-07:00", updatedTimeString)
+	assert.NoError(t, timeParseError)
+
+	assert.True(t, previousTime.Before(updatedTime), "Path time value is not in the future")
+	previousTime = updatedTime
+}
+
+func validateGnmiStateSyncResponse(t *testing.T, sync *gnmi.SubscribeResponse_SyncResponse) {
+	t.Helper()
+	assert.True(t, sync.SyncResponse)
+}

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -126,17 +126,7 @@ func validateGnmiStateResponse(t *testing.T, resp *gnmi.SubscribeResponse, devic
 
 func validateGnmiStateUpdateResponse(t *testing.T, update *gnmi.SubscribeResponse_Update, device string) {
 	t.Helper()
-
-	assert.True(t, update.Update != nil, "Update should not be nil")
-	assert.Equal(t, 1, len(update.Update.GetUpdate()))
-	assert.NotNil(t, update.Update.GetUpdate()[0])
-
-	pathResponse := update.Update.GetUpdate()[0].Path
-	assert.Equal(t, pathResponse.Target, device)
-	assert.Equal(t, 3, len(pathResponse.Elem), "Expected 3 path elements")
-	assert.Equal(t, pathResponse.Elem[0].Name, "system")
-	assert.Equal(t, pathResponse.Elem[1].Name, "state")
-	assert.Equal(t, pathResponse.Elem[2].Name, "current-datetime")
+	assertUpdateResponse(t, update, device, subDateTimePath, "")
 	updatedTimeString := update.Update.GetUpdate()[0].Val.GetStringVal()
 	updatedTime, timeParseError := time.Parse("2006-01-02T15:04:05Z-07:00", updatedTimeString)
 	assert.NoError(t, timeParseError)
@@ -147,5 +137,5 @@ func validateGnmiStateUpdateResponse(t *testing.T, update *gnmi.SubscribeRespons
 
 func validateGnmiStateSyncResponse(t *testing.T, sync *gnmi.SubscribeResponse_SyncResponse) {
 	t.Helper()
-	assert.True(t, sync.SyncResponse)
+	assertSyncResponse(t, sync)
 }

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -57,10 +57,7 @@ func (s *TestSuite) TestSubscribeStateGnmi(t *testing.T) {
 		subStreamMode: gnmi.SubscriptionMode_TARGET_DEFINED,
 	}
 
-	request, errReq := buildRequest(subReq)
-	assert.NoError(t, errReq, "Can't build Request")
-
-	q, respChan, errQuery := buildQuery(request)
+	q, respChan, errQuery := buildQueryRequest(subReq)
 	assert.NoError(t, errQuery, "Can't build Query")
 
 	var response *gnmi.SubscribeResponse

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -1,4 +1,4 @@
-// Copyright 2019-present Open Networking Foundation.
+// Copyright 2020-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -1,4 +1,4 @@
-// Copyright 2020-present Open Networking Foundation.
+// Copyright 2019-present Open Networking Foundation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -27,7 +27,6 @@ import (
 	"github.com/openconfig/gnmi/client"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/assert"
-	log "k8s.io/klog"
 )
 
 const (
@@ -279,43 +278,9 @@ func validateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string,
 		assert.Equal(t, v.SyncResponse, true, "Sync should be true")
 	case *gnmi.SubscribeResponse_Update:
 		if delete {
-			assertDeleteResponse(t, v, device)
+			assertDeleteResponse(t, v, device, subTzPath)
 		} else {
-			assertUpdateResponse(t, v, device)
+			assertUpdateResponse(t, v, device, subTzPath, subValue)
 		}
 	}
-}
-
-func assertUpdateResponse(t *testing.T, response *gnmi.SubscribeResponse_Update, device string) {
-	assert.True(t, response.Update != nil, "Update should not be nil")
-	assert.Equal(t, len(response.Update.GetUpdate()), 1)
-	if response.Update.GetUpdate()[0] == nil {
-		log.Error("response should contain at least one update and that should not be nil")
-		t.FailNow()
-	}
-	pathResponse := response.Update.GetUpdate()[0].Path
-	assert.Equal(t, pathResponse.Target, device)
-	assert.Equal(t, len(pathResponse.Elem), 4, "Expected 4 path elements")
-	assert.Equal(t, pathResponse.Elem[0].Name, "system")
-	assert.Equal(t, pathResponse.Elem[1].Name, "clock")
-	assert.Equal(t, pathResponse.Elem[2].Name, "config")
-	assert.Equal(t, pathResponse.Elem[3].Name, "timezone-name")
-	assert.Equal(t, response.Update.GetUpdate()[0].Val.GetStringVal(), subValue)
-	assert.Equal(t, response.Update.GetUpdate()[0].Val.GetStringVal(), subValue)
-}
-
-func assertDeleteResponse(t *testing.T, response *gnmi.SubscribeResponse_Update, device string) {
-	assert.True(t, response.Update != nil, "Delete should not be nil")
-	assert.Equal(t, len(response.Update.GetDelete()), 1)
-	if response.Update.GetDelete()[0] == nil {
-		log.Error("response should contain at least one delete path")
-		t.FailNow()
-	}
-	pathResponse := response.Update.GetDelete()[0]
-	assert.Equal(t, pathResponse.Target, device)
-	assert.Equal(t, len(pathResponse.Elem), 4, "Expected 3 path elements")
-	assert.Equal(t, pathResponse.Elem[0].Name, "system")
-	assert.Equal(t, pathResponse.Elem[1].Name, "clock")
-	assert.Equal(t, pathResponse.Elem[2].Name, "config")
-	assert.Equal(t, pathResponse.Elem[3].Name, "timezone-name")
 }

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -120,8 +120,7 @@ func (s *TestSuite) TestSubscribe(t *testing.T) {
 
 	// Subscription has to be spawned into a separate thread as it is blocking.
 	go func() {
-		errSubscribe := subC.Subscribe(testutils.MakeContext(), *q, "gnmi")
-		assert.NoError(t, errSubscribe, "Subscription Error: %v", errSubscribe)
+		_ = subC.Subscribe(testutils.MakeContext(), *q, "gnmi")
 	}()
 
 	// Sleeping in order to make sure the subscribe request is properly stored and processed.

--- a/test/gnmi/subscribetestutils.go
+++ b/test/gnmi/subscribetestutils.go
@@ -33,6 +33,12 @@ const (
 	subDateTimePath = "/system/state/current-datetime"
 )
 
+type subscribeRequest struct {
+	path          *gnmi.Path
+	subListMode   gnmi.SubscriptionList_Mode // Mode of the subscription: ONCE, STREAM, POLL
+	subStreamMode gnmi.SubscriptionMode      // mode of subscribe STREAM: ON_CHANGE, SAMPLE, TARGET_DEFINED
+}
+
 func buildRequest(subReq subscribeRequest) (*gnmi.SubscribeRequest, error) {
 	prefixPath, err := utils.ParseGNMIElements(utils.SplitPath(""))
 	if err != nil {
@@ -96,6 +102,19 @@ func buildQuery(request *gnmi.SubscribeRequest) (*client.Query, chan *gnmi.Subsc
 	}
 
 	return &q, respChan, nil
+}
+
+func buildQueryRequest(subReq subscribeRequest) (*client.Query, chan *gnmi.SubscribeResponse, error) {
+	request, errReq := buildRequest(subReq)
+	if errReq != nil {
+		return nil, nil, errReq
+	}
+
+	q, respChan, errQuery := buildQuery(request)
+	if errQuery != nil {
+		return nil, nil, errReq
+	}
+	return q, respChan, nil
 }
 
 func assertPathSegments(t *testing.T, pathResponse *gnmi.Path, path string) {

--- a/test/gnmi/subscribetestutils.go
+++ b/test/gnmi/subscribetestutils.go
@@ -1,0 +1,161 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/onosproject/onos-config/pkg/utils"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/openconfig/gnmi/client"
+	"github.com/openconfig/gnmi/proto/gnmi"
+	"github.com/stretchr/testify/assert"
+	log "k8s.io/klog"
+	"strings"
+	"testing"
+)
+
+const (
+	subTzValue      = "Europe/Madrid"
+	subTzPath       = "/system/clock/config/timezone-name"
+	subDateTimePath = "/system/state/current-datetime"
+)
+
+func xxxbuildRequest(pathString string, target string) (*gnmi.SubscribeRequest, error) {
+	path, err := utils.ParseGNMIElements(utils.SplitPath(pathString))
+
+	if err != nil {
+		return nil, err
+	}
+
+	path.Target = target
+
+	subReq := subscribeRequest{
+		path:        path,
+		subListMode: gnmi.SubscriptionList_ONCE,
+	}
+
+	prefixPath, err := utils.ParseGNMIElements(utils.SplitPath(""))
+	if err != nil {
+		return nil, err
+	}
+	subscription := &gnmi.Subscription{}
+	switch subReq.subListMode {
+	case gnmi.SubscriptionList_STREAM:
+		subscription = &gnmi.Subscription{
+			Path: subReq.path,
+			Mode: subReq.subStreamMode,
+		}
+	case gnmi.SubscriptionList_ONCE:
+		subscription = &gnmi.Subscription{
+			Path: subReq.path,
+		}
+	case gnmi.SubscriptionList_POLL:
+		subscription = &gnmi.Subscription{
+			Path: subReq.path,
+		}
+	}
+	subscriptions := make([]*gnmi.Subscription, 0)
+	subscriptions = append(subscriptions, subscription)
+	subList := &gnmi.SubscriptionList{
+		Subscription: subscriptions,
+		Mode:         subReq.subListMode,
+		UpdatesOnly:  true,
+		Prefix:       prefixPath,
+	}
+	request := &gnmi.SubscribeRequest{
+		Request: &gnmi.SubscribeRequest_Subscribe{
+			Subscribe: subList,
+		},
+	}
+	return request, nil
+}
+
+func buildQuery(request *gnmi.SubscribeRequest) (*client.Query, chan *gnmi.SubscribeResponse, error) {
+	q, errQuery := client.NewQuery(request)
+	if errQuery != nil {
+		return nil, nil, errQuery
+	}
+
+	dest := env.Config().Destination()
+
+	q.Addrs = dest.Addrs
+	q.Timeout = dest.Timeout
+	q.Target = dest.Target
+	q.Credentials = dest.Credentials
+	q.TLS = dest.TLS
+
+	respChan := make(chan *gnmi.SubscribeResponse)
+
+	q.ProtoHandler = func(msg proto.Message) error {
+		resp, ok := msg.(*gnmi.SubscribeResponse)
+		if !ok {
+			return fmt.Errorf("failed to type assert message %#v", msg)
+		}
+		respChan <- resp
+		return nil
+	}
+
+	return &q, respChan, nil
+}
+
+func assertPathSegments(t *testing.T, pathResponse *gnmi.Path, path string) {
+	pathSegments := strings.Split(path, "/")[1:]
+	assert.Equal(t, len(pathSegments), len(pathResponse.Elem), "Path element count is incorrect")
+
+	for i, segment := range pathSegments {
+		assert.Equal(t, segment, pathResponse.Elem[i].Name)
+	}
+}
+
+
+func assertUpdateResponse(t *testing.T, response *gnmi.SubscribeResponse_Update, device string, path string, expectedValue string) {
+	assert.True(t, response.Update != nil, "Update should not be nil")
+	assert.Equal(t, len(response.Update.GetUpdate()), 1)
+	if response.Update.GetUpdate()[0] == nil {
+		log.Error("response should contain at least one update and that should not be nil")
+		t.FailNow()
+	}
+	pathResponse := response.Update.GetUpdate()[0].Path
+	assert.Equal(t, pathResponse.Target, device)
+	assertPathSegments(t, pathResponse, path)
+
+	if expectedValue != "" {
+		assert.Equal(t, expectedValue, response.Update.GetUpdate()[0].Val.GetStringVal())
+	}
+}
+
+func assertDeleteResponse(t *testing.T, response *gnmi.SubscribeResponse_Update, device string, path string) {
+	assert.True(t, response.Update != nil, "Delete should not be nil")
+	assert.Equal(t, len(response.Update.GetDelete()), 1)
+	if response.Update.GetDelete()[0] == nil {
+		log.Error("response should contain at least one delete path")
+		t.FailNow()
+	}
+	pathResponse := response.Update.GetDelete()[0]
+	assert.Equal(t, pathResponse.Target, device)
+	pathSegments := strings.Split(path, "/")[1:]
+	assert.Equal(t, len(pathSegments), len(pathResponse.Elem), "Path element count is incorrect")
+
+	for i, segment := range pathSegments {
+		assert.Equal(t, segment, pathResponse.Elem[i].Name)
+	}
+	assertPathSegments(t, pathResponse, path)
+}
+
+func assertSyncResponse(t *testing.T, sync *gnmi.SubscribeResponse_SyncResponse) {
+	t.Helper()
+	assert.True(t, sync.SyncResponse)
+}

--- a/test/gnmi/subscribetestutils.go
+++ b/test/gnmi/subscribetestutils.go
@@ -33,20 +33,7 @@ const (
 	subDateTimePath = "/system/state/current-datetime"
 )
 
-func xxxbuildRequest(pathString string, target string) (*gnmi.SubscribeRequest, error) {
-	path, err := utils.ParseGNMIElements(utils.SplitPath(pathString))
-
-	if err != nil {
-		return nil, err
-	}
-
-	path.Target = target
-
-	subReq := subscribeRequest{
-		path:        path,
-		subListMode: gnmi.SubscriptionList_ONCE,
-	}
-
+func buildRequest(subReq subscribeRequest) (*gnmi.SubscribeRequest, error) {
 	prefixPath, err := utils.ParseGNMIElements(utils.SplitPath(""))
 	if err != nil {
 		return nil, err
@@ -119,7 +106,6 @@ func assertPathSegments(t *testing.T, pathResponse *gnmi.Path, path string) {
 		assert.Equal(t, segment, pathResponse.Elem[i].Name)
 	}
 }
-
 
 func assertUpdateResponse(t *testing.T, response *gnmi.SubscribeResponse_Update, device string, path string, expectedValue string) {
 	assert.True(t, response.Update != nil, "Update should not be nil")


### PR DESCRIPTION
This PR introduces two new subscribe tests to check on opstate cache paths that the device is updating. One used the diags API, one uses a straight GNMI call. This also refactors the existing subscribe tests to use utility routines to cut down on duplicate code.