### PR TITLE
Support file-based configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onosproject/config-models/modelplugin/devicesim-1.0.0 v0.0.0-20200303111912-723f2289d4c2
 	github.com/onosproject/config-models/modelplugin/testdevice-1.0.0 v0.0.0-20200303111912-723f2289d4c2
 	github.com/onosproject/config-models/modelplugin/testdevice-2.0.0 v0.0.0-20200304144136-6992f473b240
-	github.com/onosproject/onos-lib-go v0.0.0-20200311221003-fad88142208e
+	github.com/onosproject/onos-lib-go v0.0.0-20200318222217-3c0f4a7ed58b
 	github.com/onosproject/onos-test v0.0.0-20200306000348-1f2c86fc76c6
 	github.com/onosproject/onos-topo v0.0.0-20200218171206-55029b503689
 	github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,12 @@ github.com/onosproject/onos-lib-go v0.0.0-20200307155659-8ad70c22b981 h1:ao+nAtL
 github.com/onosproject/onos-lib-go v0.0.0-20200307155659-8ad70c22b981/go.mod h1:tbdH7aqxvcOLSfz8cgiDwNP5szPnll1/m9HYKbXruSI=
 github.com/onosproject/onos-lib-go v0.0.0-20200311221003-fad88142208e h1:gmR2xTdzpbSYgoPH3R83l8P/JnCUDK7eVaTqhWo9X6s=
 github.com/onosproject/onos-lib-go v0.0.0-20200311221003-fad88142208e/go.mod h1:gnWmBzxrrUIdMPbwcBudAxIJCALzRj/CdSpaCfrgwkU=
+github.com/onosproject/onos-lib-go v0.0.0-20200317205302-d54b7f33b9de h1:f95/+gMpll37SAemDmgWv5+jm794iopmtGGQoPykwEE=
+github.com/onosproject/onos-lib-go v0.0.0-20200317205302-d54b7f33b9de/go.mod h1:gnWmBzxrrUIdMPbwcBudAxIJCALzRj/CdSpaCfrgwkU=
+github.com/onosproject/onos-lib-go v0.0.0-20200318085111-7a1561372660 h1:3s4OB+oCoSrQa3Vhmgrf6Cpt9259jYJdootY04KhAPs=
+github.com/onosproject/onos-lib-go v0.0.0-20200318085111-7a1561372660/go.mod h1:gnWmBzxrrUIdMPbwcBudAxIJCALzRj/CdSpaCfrgwkU=
+github.com/onosproject/onos-lib-go v0.0.0-20200318222217-3c0f4a7ed58b h1:ZbXioCOdmU1C8wMToj/WtAaViPkn594qlc+xwuVg/0U=
+github.com/onosproject/onos-lib-go v0.0.0-20200318222217-3c0f4a7ed58b/go.mod h1:gnWmBzxrrUIdMPbwcBudAxIJCALzRj/CdSpaCfrgwkU=
 github.com/onosproject/onos-ran v0.0.0-20200205211410-0667c7147453/go.mod h1:mDd/65obXVUsEGFSLmxokw6QaW/3YCYal+HV1Y08kf8=
 github.com/onosproject/onos-ran v0.0.0-20200210203428-df3953bf0fb1 h1:fXm7bKsrvhohMYk/YZtZ++sFZGhdEgPDvHJuPjw7FdQ=
 github.com/onosproject/onos-ran v0.0.0-20200210203428-df3953bf0fb1/go.mod h1:mIi1jgByW+1Ns9vZg/lAXyTXDGi7wI6zWiqhnB9qiKU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,51 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/onosproject/onos-lib-go/pkg/atomix"
+	configlib "github.com/onosproject/onos-lib-go/pkg/config"
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+)
+
+var config *Config
+
+// Config is the onos-config configuration
+type Config struct {
+	// Atomix is the Atomix configuration
+	Atomix atomix.Config `yaml:"atomix,omitempty"`
+	// Logging is the logging configuration
+	Logging logging.Config `yaml:"logging,omitempty"`
+}
+
+// GetConfig gets the onos-config configuration
+func GetConfig() (Config, error) {
+	if config == nil {
+		config = &Config{}
+		if err := configlib.Load(config); err != nil {
+			return Config{}, err
+		}
+	}
+	return *config, nil
+}
+
+// GetConfigOrDie gets the onos-config configuration or panics
+func GetConfigOrDie() Config {
+	config, err := GetConfig()
+	if err != nil {
+		panic(err)
+	}
+	return config
+}

--- a/pkg/store/change/device/store.go
+++ b/pkg/store/change/device/store.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/config"
 	"io"
 	"sync"
 	"time"
@@ -41,19 +42,14 @@ func getDeviceChangesName(deviceID device.VersionedID) string {
 }
 
 // NewAtomixStore returns a new persistent Store
-func NewAtomixStore() (Store, error) {
-	client, err := atomix.GetAtomixClient()
-	if err != nil {
-		return nil, err
-	}
-
-	group, err := client.GetDatabase(context.Background(), atomix.GetAtomixRaftGroup())
+func NewAtomixStore(config config.Config) (Store, error) {
+	database, err := atomix.GetDatabase(config.Atomix, config.Atomix.GetDatabase(atomix.DatabaseTypeConsensus))
 	if err != nil {
 		return nil, err
 	}
 
 	changesFactory := func(deviceID device.VersionedID) (indexedmap.IndexedMap, error) {
-		return group.GetIndexedMap(context.Background(), getDeviceChangesName(deviceID))
+		return database.GetIndexedMap(context.Background(), getDeviceChangesName(deviceID))
 	}
 
 	return &atomixStore{

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
+	"github.com/onosproject/onos-config/pkg/config"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-lib-go/pkg/atomix"
@@ -37,18 +38,13 @@ func init() {
 }
 
 // NewAtomixStore returns a new persistent Store
-func NewAtomixStore() (Store, error) {
-	client, err := atomix.GetAtomixClient()
+func NewAtomixStore(config config.Config) (Store, error) {
+	database, err := atomix.GetDatabase(config.Atomix, config.Atomix.GetDatabase(atomix.DatabaseTypeConsensus))
 	if err != nil {
 		return nil, err
 	}
 
-	group, err := client.GetDatabase(context.Background(), atomix.GetAtomixRaftGroup())
-	if err != nil {
-		return nil, err
-	}
-
-	changes, err := group.GetIndexedMap(context.Background(), changesName)
+	changes, err := database.GetIndexedMap(context.Background(), changesName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/leadership/store.go
+++ b/pkg/store/leadership/store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/atomix/go-client/pkg/client/election"
 	"github.com/atomix/go-client/pkg/client/primitive"
 	"github.com/atomix/go-client/pkg/client/util/net"
+	"github.com/onosproject/onos-config/pkg/config"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-lib-go/pkg/atomix"
 	"io"
@@ -56,18 +57,13 @@ type Leadership struct {
 }
 
 // NewAtomixStore returns a new persistent Store
-func NewAtomixStore() (Store, error) {
-	client, err := atomix.GetAtomixClient()
+func NewAtomixStore(config config.Config) (Store, error) {
+	database, err := atomix.GetDatabase(config.Atomix, config.Atomix.GetDatabase(atomix.DatabaseTypeConsensus))
 	if err != nil {
 		return nil, err
 	}
 
-	group, err := client.GetDatabase(context.Background(), atomix.GetAtomixRaftGroup())
-	if err != nil {
-		return nil, err
-	}
-
-	election, err := group.GetElection(context.Background(), primitiveName, election.WithID(string(cluster.GetNodeID())))
+	election, err := database.GetElection(context.Background(), primitiveName, election.WithID(string(cluster.GetNodeID())))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/mastership/store.go
+++ b/pkg/store/mastership/store.go
@@ -15,8 +15,8 @@
 package mastership
 
 import (
-	"context"
 	"github.com/atomix/go-client/pkg/client/util/net"
+	"github.com/onosproject/onos-config/pkg/config"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-lib-go/pkg/atomix"
 	topodevice "github.com/onosproject/onos-topo/api/device"
@@ -54,13 +54,8 @@ type Mastership struct {
 }
 
 // NewAtomixStore returns a new persistent Store
-func NewAtomixStore() (Store, error) {
-	client, err := atomix.GetAtomixClient()
-	if err != nil {
-		return nil, err
-	}
-
-	database, err := client.GetDatabase(context.Background(), atomix.GetAtomixRaftGroup())
+func NewAtomixStore(config config.Config) (Store, error) {
+	database, err := atomix.GetDatabase(config.Atomix, config.Atomix.GetDatabase(atomix.DatabaseTypeConsensus))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/snapshot/device/store.go
+++ b/pkg/store/snapshot/device/store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/onosproject/onos-config/api/types/device"
 	devicesnapshot "github.com/onosproject/onos-config/api/types/snapshot/device"
+	"github.com/onosproject/onos-config/pkg/config"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-lib-go/pkg/atomix"
 	"io"
@@ -33,23 +34,18 @@ const deviceSnapshotsName = "device-snapshots"
 const snapshotsName = "snapshots"
 
 // NewAtomixStore returns a new persistent Store
-func NewAtomixStore() (Store, error) {
-	client, err := atomix.GetAtomixClient()
+func NewAtomixStore(config config.Config) (Store, error) {
+	database, err := atomix.GetDatabase(config.Atomix, config.Atomix.GetDatabase(atomix.DatabaseTypeConsensus))
 	if err != nil {
 		return nil, err
 	}
 
-	group, err := client.GetDatabase(context.Background(), atomix.GetAtomixRaftGroup())
+	deviceSnapshots, err := database.GetMap(context.Background(), deviceSnapshotsName)
 	if err != nil {
 		return nil, err
 	}
 
-	deviceSnapshots, err := group.GetMap(context.Background(), deviceSnapshotsName)
-	if err != nil {
-		return nil, err
-	}
-
-	snapshots, err := group.GetMap(context.Background(), snapshotsName)
+	snapshots, err := database.GetMap(context.Background(), snapshotsName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/snapshot/network/store.go
+++ b/pkg/store/snapshot/network/store.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
 	networksnapshot "github.com/onosproject/onos-config/api/types/snapshot/network"
+	"github.com/onosproject/onos-config/pkg/config"
 	"github.com/onosproject/onos-config/pkg/store/cluster"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-lib-go/pkg/atomix"
@@ -37,18 +38,13 @@ func init() {
 }
 
 // NewAtomixStore returns a new persistent Store
-func NewAtomixStore() (Store, error) {
-	client, err := atomix.GetAtomixClient()
+func NewAtomixStore(config config.Config) (Store, error) {
+	database, err := atomix.GetDatabase(config.Atomix, config.Atomix.GetDatabase(atomix.DatabaseTypeConsensus))
 	if err != nil {
 		return nil, err
 	}
 
-	group, err := client.GetDatabase(context.Background(), atomix.GetAtomixRaftGroup())
-	if err != nil {
-		return nil, err
-	}
-
-	snapshots, err := group.GetIndexedMap(context.Background(), snapshotsName)
+	snapshots, err := database.GetIndexedMap(context.Background(), snapshotsName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR replaces the use of environment variables for store configurations and supports additional logging configuration via a configuration file. The configuration file is loaded using [new onos-lib-go functions](https://github.com/onosproject/onos-lib-go/pull/25).

*Note that this feature should not be merged until Helm charts and tests have been updated to supply store configurations via configuration files*