### PR TITLE
Make benchmark runs use the correct namespace

### DIFF
--- a/benchmark/gnmi/suite.go
+++ b/benchmark/gnmi/suite.go
@@ -42,7 +42,7 @@ func (s *BenchmarkSuite) SetupSuite(c *benchmark.Context) error {
 	atomix := helm.
 		Chart("atomix-controller").
 		Release("atomix-controller").
-		Set("namespace", helm.Namespace())
+		Set("scope", "Namespace")
 	err := atomix.Install(true)
 	if err != nil {
 		return err


### PR DESCRIPTION
gnmi benchmarks were getting put in the wrong namespace