### PR TITLE
Fix update device function 

### DIFF
--- a/test/gnmi/subscribestatediagstest.go
+++ b/test/gnmi/subscribestatediagstest.go
@@ -16,10 +16,11 @@ package gnmi
 
 import (
 	"context"
-	"github.com/onosproject/onos-config/api/diags"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/onosproject/onos-config/api/diags"
 
 	"github.com/onosproject/onos-config/test/utils/gnmi"
 	"github.com/onosproject/onos-topo/api/device"
@@ -47,7 +48,6 @@ func (s *TestSuite) TestSubscribeStateDiags(t *testing.T) {
 
 	// Wait for config to connect to the device
 	gnmi.WaitForDeviceAvailable(t, deviceID, 10*time.Second)
-	time.Sleep(250 * time.Millisecond)
 
 	// Make an opstate diags client
 	opstateClient, err := gnmi.NewOpStateDiagsClient()

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -85,7 +85,6 @@ func (s *TestSuite) TestSubscribeOnce(t *testing.T) {
 // TestSubscribe tests a stream subscription to updates to a device
 func (s *TestSuite) TestSubscribe(t *testing.T) {
 	// Create a simulated device
-	t.Skip()
 	simulator := gnmi.CreateSimulator(t)
 
 	// Wait for config to connect to the device


### PR DESCRIPTION
This PR fixes the issue that exists in updateDevice function. The problem is that updateDevice function was retrying to update the state of a device that has been removed already and it is not in the device store anymore.  