### PR TITLE
Fix linter issue

### DIFF
--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -425,9 +425,8 @@ func CheckDeviceValue(t *testing.T, deviceGnmiClient client.Impl, devicePaths []
 		assert.Equal(t, expectedValue, deviceValues[0].PathDataValue, "Query after set returned the wrong value: %s\n", expectedValue)
 		assert.Equal(t, 0, len(extensions))
 		return
-	} else {
-		assert.Fail(t, "Failed to query device: %v", deviceValuesError)
 	}
+	assert.Fail(t, "Failed to query device: %v", deviceValuesError)
 }
 
 // GetDeviceDestination :


### PR DESCRIPTION
@ray-milkey 
When I run ```make test``` locally it gives me a linter error and I am wondering why it is not detected in the travis job. 

```if` block ends with a `return` statement, so drop this `else` and outdent its block (golint)```