### PR TITLE
Use functional options to initialize Factory

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -149,15 +149,15 @@ func (m *Manager) Run() {
 	go listenOnResponseChannel(m.SouthboundErrorChan, m)
 
 	factory, err := synchronizer.NewFactory(
-		synchronizer.TopoChannel(m.TopoChannel),
-		synchronizer.OpStateChannel(m.OperationalStateChannel),
-		synchronizer.SouthboundErrChan(m.SouthboundErrorChan),
-		synchronizer.Dispatcher(m.Dispatcher),
-		synchronizer.ModelRegistry(m.ModelRegistry),
-		synchronizer.OperationalStateCache(m.OperationalStateCache),
-		synchronizer.NewTargetFn(southbound.TargetGenerator),
-		synchronizer.OperationalStateCacheLock(m.OperationalStateCacheLock),
-		synchronizer.DeviceChangeStore(m.DeviceChangesStore),
+		synchronizer.WithTopoChannel(m.TopoChannel),
+		synchronizer.WithOpStateChannel(m.OperationalStateChannel),
+		synchronizer.WithSouthboundErrChan(m.SouthboundErrorChan),
+		synchronizer.WithDispatcher(m.Dispatcher),
+		synchronizer.WithModelRegistry(m.ModelRegistry),
+		synchronizer.WithOperationalStateCache(m.OperationalStateCache),
+		synchronizer.WithNewTargetFn(southbound.TargetGenerator),
+		synchronizer.WithOperationalStateCacheLock(m.OperationalStateCacheLock),
+		synchronizer.WithDeviceChangeStore(m.DeviceChangesStore),
 	)
 
 	if err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -147,12 +147,27 @@ func (m *Manager) Run() {
 	go m.Dispatcher.ListenOperationalState(m.OperationalStateChannel)
 	// Listening for errors in the Southbound
 	go listenOnResponseChannel(m.SouthboundErrorChan, m)
-	//TODO we need to find a way to avoid passing down parameter but at the same time not hve circular dependecy sb-mgr
-	go synchronizer.Factory(m.TopoChannel, m.OperationalStateChannel, m.SouthboundErrorChan,
-		m.Dispatcher, m.ModelRegistry, m.OperationalStateCache, southbound.TargetGenerator, m.OperationalStateCacheLock, m.DeviceChangesStore)
-	log.Debug("Device factory started")
 
-	err := m.DeviceStore.Watch(m.TopoChannel)
+	factory, err := synchronizer.NewFactory(
+		synchronizer.TopoChannel(m.TopoChannel),
+		synchronizer.OpStateChannel(m.OperationalStateChannel),
+		synchronizer.SouthboundErrChan(m.SouthboundErrorChan),
+		synchronizer.Dispatcher(m.Dispatcher),
+		synchronizer.ModelRegistry(m.ModelRegistry),
+		synchronizer.OperationalStateCache(m.OperationalStateCache),
+		synchronizer.NewTargetFn(southbound.TargetGenerator),
+		synchronizer.OperationalStateCacheLock(m.OperationalStateCacheLock),
+		synchronizer.DeviceChangeStore(m.DeviceChangesStore),
+	)
+
+	if err != nil {
+		log.Error("Error in creating device factory", err)
+	}
+
+	go factory.TopoEventHandler()
+	log.Debug("Device Event Handler started")
+
+	err = m.DeviceStore.Watch(m.TopoChannel)
 	if err != nil {
 		log.Error("Error Watching devices", err)
 	}

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -17,6 +17,10 @@ package synchronizer
 import (
 	"context"
 	"fmt"
+	"math"
+	syncPrimitives "sync"
+	"time"
+
 	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
 	"github.com/onosproject/onos-config/pkg/dispatcher"
@@ -26,9 +30,6 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/change/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	topodevice "github.com/onosproject/onos-topo/api/device"
-	"math"
-	syncPrimitives "sync"
-	"time"
 )
 
 var connectionMonitors = make(map[topodevice.ID]*connectionMonitor)
@@ -37,19 +38,102 @@ var connections = make(map[topodevice.ID]bool)
 const backoffInterval = 10 * time.Millisecond
 const maxBackoffTime = 5 * time.Second
 
-// Factory is a go routine thread that listens out for Device creation
-// and deletion events and spawns Synchronizer threads for them
-// These connectionMonitors then listen out for configEvents relative to a device and
-func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- events.OperationalStateEvent,
-	southboundErrorChan chan<- events.DeviceResponse, dispatcher *dispatcher.Dispatcher,
-	modelRegistry *modelregistry.ModelRegistry, operationalStateCache map[topodevice.ID]devicechange.TypedValueMap,
-	newTargetFn func() southbound.TargetIf,
-	operationalStateCacheLock *syncPrimitives.RWMutex, deviceChangeStore device.Store) {
+// Factory device factory data structures
+type Factory struct {
+	topoChannel               <-chan *topodevice.ListResponse
+	opStateChan               chan<- events.OperationalStateEvent
+	southboundErrorChan       chan<- events.DeviceResponse
+	dispatcher                *dispatcher.Dispatcher
+	modelRegistry             *modelregistry.ModelRegistry
+	operationalStateCache     map[topodevice.ID]devicechange.TypedValueMap
+	newTargetFn               func() southbound.TargetIf
+	operationalStateCacheLock *syncPrimitives.RWMutex
+	deviceChangeStore         device.Store
+}
 
+// NewFactory create a new factory
+func NewFactory(options ...func(*Factory)) (*Factory, error) {
+	factory := &Factory{}
+
+	for _, option := range options {
+		option(factory)
+	}
+
+	// TODO do some checks to make sure the data structures initialized properly
+
+	return factory, nil
+
+}
+
+// TopoChannel sets factory topo channel
+func TopoChannel(topoChannel <-chan *topodevice.ListResponse) func(*Factory) {
+	return func(factory *Factory) {
+		factory.topoChannel = topoChannel
+	}
+}
+
+// OpStateChannel sets factory opStateChannel
+func OpStateChannel(opStateChan chan<- events.OperationalStateEvent) func(*Factory) {
+	return func(factory *Factory) {
+		factory.opStateChan = opStateChan
+	}
+}
+
+// SouthboundErrChan sets factory southbound error channel
+func SouthboundErrChan(southboundErrorChan chan<- events.DeviceResponse) func(*Factory) {
+	return func(factory *Factory) {
+		factory.southboundErrorChan = southboundErrorChan
+	}
+}
+
+// Dispatcher sets factory dispatcher
+func Dispatcher(dispatcher *dispatcher.Dispatcher) func(*Factory) {
+	return func(factory *Factory) {
+		factory.dispatcher = dispatcher
+	}
+}
+
+// ModelRegistry set factory model registry
+func ModelRegistry(modelRegistry *modelregistry.ModelRegistry) func(*Factory) {
+	return func(factory *Factory) {
+		factory.modelRegistry = modelRegistry
+	}
+}
+
+// OperationalStateCache sets factory operational state cache
+func OperationalStateCache(operationalStateCache map[topodevice.ID]devicechange.TypedValueMap) func(*Factory) {
+	return func(info *Factory) {
+		info.operationalStateCache = operationalStateCache
+	}
+}
+
+// NewTargetFn sets factory southbound target function
+func NewTargetFn(newTargetFn func() southbound.TargetIf) func(*Factory) {
+	return func(factory *Factory) {
+		factory.newTargetFn = newTargetFn
+	}
+}
+
+// OperationalStateCacheLock sets factory operational state cache lock
+func OperationalStateCacheLock(operationalStateCacheLock *syncPrimitives.RWMutex) func(*Factory) {
+	return func(factory *Factory) {
+		factory.operationalStateCacheLock = operationalStateCacheLock
+	}
+}
+
+// DeviceChangeStore sets factory device change store
+func DeviceChangeStore(deviceChangeStore device.Store) func(*Factory) {
+	return func(factory *Factory) {
+		factory.deviceChangeStore = deviceChangeStore
+	}
+}
+
+// TopoEventHandler handle topo device events
+func (f *Factory) TopoEventHandler() {
 	errChan := make(chan events.DeviceResponse)
 	for {
 		select {
-		case topoEvent, ok := <-topoChannel:
+		case topoEvent, ok := <-f.topoChannel:
 			if !ok {
 				return
 			}
@@ -59,15 +143,15 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 			if !ok && topoEvent.Type != topodevice.ListResponse_REMOVED {
 				log.Infof("Topo device %s %s", device.ID, topoEvent.Type)
 				connMon = &connectionMonitor{
-					opStateChan:               opStateChan,
+					opStateChan:               f.opStateChan,
 					southboundErrorChan:       errChan,
-					dispatcher:                dispatcher,
-					modelRegistry:             modelRegistry,
-					operationalStateCache:     operationalStateCache,
-					operationalStateCacheLock: operationalStateCacheLock,
-					deviceChangeStore:         deviceChangeStore,
+					dispatcher:                f.dispatcher,
+					modelRegistry:             f.modelRegistry,
+					operationalStateCache:     f.operationalStateCache,
+					operationalStateCacheLock: f.operationalStateCacheLock,
+					deviceChangeStore:         f.deviceChangeStore,
 					device:                    device,
-					target:                    newTargetFn(),
+					target:                    f.newTargetFn(),
 				}
 				connectionMonitors[device.ID] = connMon
 				go connMon.connect()
@@ -104,7 +188,7 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 				}
 				if !changed {
 					log.Infof("Topo device %s UPDATE not supported %v", device.ID, device)
-					southboundErrorChan <- events.NewErrorEventNoChangeID(
+					f.southboundErrorChan <- events.NewErrorEventNoChangeID(
 						events.EventTypeTopoUpdate, string(device.ID),
 						fmt.Errorf("topo update event ignored %v", topoEvent))
 				}
@@ -139,9 +223,10 @@ func Factory(topoChannel <-chan *topodevice.ListResponse, opStateChan chan<- eve
 			case events.EventTypeDeviceConnected:
 				connections[deviceID] = true
 			}
-			southboundErrorChan <- event
+			f.southboundErrorChan <- event
 		}
 	}
+
 }
 
 // connectionMonitor reacts to device events to establish connections to the device

--- a/pkg/southbound/synchronizer/factory.go
+++ b/pkg/southbound/synchronizer/factory.go
@@ -65,64 +65,64 @@ func NewFactory(options ...func(*Factory)) (*Factory, error) {
 
 }
 
-// TopoChannel sets factory topo channel
-func TopoChannel(topoChannel <-chan *topodevice.ListResponse) func(*Factory) {
+// WithTopoChannel sets factory topo channel
+func WithTopoChannel(topoChannel <-chan *topodevice.ListResponse) func(*Factory) {
 	return func(factory *Factory) {
 		factory.topoChannel = topoChannel
 	}
 }
 
-// OpStateChannel sets factory opStateChannel
-func OpStateChannel(opStateChan chan<- events.OperationalStateEvent) func(*Factory) {
+// WithOpStateChannel sets factory opStateChannel
+func WithOpStateChannel(opStateChan chan<- events.OperationalStateEvent) func(*Factory) {
 	return func(factory *Factory) {
 		factory.opStateChan = opStateChan
 	}
 }
 
-// SouthboundErrChan sets factory southbound error channel
-func SouthboundErrChan(southboundErrorChan chan<- events.DeviceResponse) func(*Factory) {
+// WithSouthboundErrChan sets factory southbound error channel
+func WithSouthboundErrChan(southboundErrorChan chan<- events.DeviceResponse) func(*Factory) {
 	return func(factory *Factory) {
 		factory.southboundErrorChan = southboundErrorChan
 	}
 }
 
-// Dispatcher sets factory dispatcher
-func Dispatcher(dispatcher *dispatcher.Dispatcher) func(*Factory) {
+// WithDispatcher sets factory dispatcher
+func WithDispatcher(dispatcher *dispatcher.Dispatcher) func(*Factory) {
 	return func(factory *Factory) {
 		factory.dispatcher = dispatcher
 	}
 }
 
-// ModelRegistry set factory model registry
-func ModelRegistry(modelRegistry *modelregistry.ModelRegistry) func(*Factory) {
+// WithModelRegistry set factory model registry
+func WithModelRegistry(modelRegistry *modelregistry.ModelRegistry) func(*Factory) {
 	return func(factory *Factory) {
 		factory.modelRegistry = modelRegistry
 	}
 }
 
-// OperationalStateCache sets factory operational state cache
-func OperationalStateCache(operationalStateCache map[topodevice.ID]devicechange.TypedValueMap) func(*Factory) {
-	return func(info *Factory) {
-		info.operationalStateCache = operationalStateCache
+// WithOperationalStateCache sets factory operational state cache
+func WithOperationalStateCache(operationalStateCache map[topodevice.ID]devicechange.TypedValueMap) func(*Factory) {
+	return func(factory *Factory) {
+		factory.operationalStateCache = operationalStateCache
 	}
 }
 
-// NewTargetFn sets factory southbound target function
-func NewTargetFn(newTargetFn func() southbound.TargetIf) func(*Factory) {
+// WithNewTargetFn sets factory southbound target function
+func WithNewTargetFn(newTargetFn func() southbound.TargetIf) func(*Factory) {
 	return func(factory *Factory) {
 		factory.newTargetFn = newTargetFn
 	}
 }
 
-// OperationalStateCacheLock sets factory operational state cache lock
-func OperationalStateCacheLock(operationalStateCacheLock *syncPrimitives.RWMutex) func(*Factory) {
+// WithOperationalStateCacheLock sets factory operational state cache lock
+func WithOperationalStateCacheLock(operationalStateCacheLock *syncPrimitives.RWMutex) func(*Factory) {
 	return func(factory *Factory) {
 		factory.operationalStateCacheLock = operationalStateCacheLock
 	}
 }
 
-// DeviceChangeStore sets factory device change store
-func DeviceChangeStore(deviceChangeStore device.Store) func(*Factory) {
+// WithDeviceChangeStore sets factory device change store
+func WithDeviceChangeStore(deviceChangeStore device.Store) func(*Factory) {
 	return func(factory *Factory) {
 		factory.deviceChangeStore = deviceChangeStore
 	}

--- a/pkg/southbound/synchronizer/factory_test.go
+++ b/pkg/southbound/synchronizer/factory_test.go
@@ -73,15 +73,15 @@ func TestFactory_Revert(t *testing.T) {
 	wg.Add(1)
 
 	factory, err := NewFactory(
-		TopoChannel(topoChan),
-		OpStateChannel(opstateChan),
-		SouthboundErrChan(responseChan),
-		Dispatcher(dispatcher),
-		ModelRegistry(models),
-		OperationalStateCache(opstateCache),
-		NewTargetFn(southbound.NewTarget),
-		OperationalStateCacheLock(opStateCacheLock),
-		DeviceChangeStore(deviceChangeStore),
+		WithTopoChannel(topoChan),
+		WithOpStateChannel(opstateChan),
+		WithSouthboundErrChan(responseChan),
+		WithDispatcher(dispatcher),
+		WithModelRegistry(models),
+		WithOperationalStateCache(opstateCache),
+		WithNewTargetFn(southbound.NewTarget),
+		WithOperationalStateCacheLock(opStateCacheLock),
+		WithDeviceChangeStore(deviceChangeStore),
 	)
 
 	assert.NilError(t, err)


### PR DESCRIPTION
This PR uses functional options to initialize Factory required data structures that we can expand it easily without passing a new argument to Factory function. 