### PR TITLE
Modelregistry: fix bug in ExtractPaths

### DIFF
--- a/pkg/modelregistry/jsonvalues/convertJsonTd2_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonTd2_test.go
@@ -215,10 +215,13 @@ func Test_DecomposeJSONWithPathsTd2OpState(t *testing.T) {
 			"/cont1b-state/list2b[index1=101][index2=102]/leaf3c",
 			"/cont1b-state/list2b[index1=101][index2=103]/leaf3c",
 			"/cont1b-state/list2b[index1=101][index2=102]/leaf3d",
-			"/cont1b-state/list2b[index1=101][index2=103]/leaf3d",
 			"/cont1b-state/cont2c/leaf3b":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_STRING, pathValue.Path)
 			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 0)
+		case "/cont1b-state/list2b[index1=101][index2=103]/leaf3d":
+			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_STRING, pathValue.Path)
+			strVal := (*devicechange.TypedString)(pathValue.GetValue()).String()
+			assert.Equal(t, "IDTYPE2", strVal) // Should do the conversion fron "2" to "IDTYPE2"
 		case
 			"/cont1b-state/leaf2d":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_UINT, pathValue.Path)

--- a/pkg/modelregistry/jsonvalues/jsonToValues.go
+++ b/pkg/modelregistry/jsonvalues/jsonToValues.go
@@ -246,7 +246,6 @@ func handleAttribute(value interface{}, parentPath string, modelROpaths modelreg
 		enum = subPath.Enum
 	} else {
 		modeltype = pathElem.ValueType
-		//enum = pathElem.
 	}
 	var typedValue *devicechange.TypedValue
 	switch modeltype {

--- a/pkg/modelregistry/jsonvalues/jsonToValues.go
+++ b/pkg/modelregistry/jsonvalues/jsonToValues.go
@@ -21,13 +21,11 @@ import (
 	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"math"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 )
 
-const matchOnIndex = `(\[.*?]).*?`
 const (
 	slash     = "/"
 	equals    = "="
@@ -35,8 +33,6 @@ const (
 	brktclose = "]"
 	colon     = ":"
 )
-
-var rOnIndex = regexp.MustCompile(matchOnIndex)
 
 type indexValue struct {
 	name  string
@@ -90,7 +86,7 @@ func extractValuesWithPaths(f interface{}, parentPath string,
 			for _, obj := range objs {
 				isIndex := false
 				for i, idxName := range indexNames {
-					if removePathIndices(obj.Path) == fmt.Sprintf("%s/%s", removePathIndices(parentPath), idxName) {
+					if modelregistry.RemovePathIndices(obj.Path) == fmt.Sprintf("%s/%s", modelregistry.RemovePathIndices(parentPath), idxName) {
 						indices = append(indices, indexValue{name: idxName, value: obj.Value, order: i})
 						isIndex = true
 						break
@@ -234,6 +230,7 @@ func handleAttribute(value interface{}, parentPath string, modelROpaths modelreg
 	var ok bool
 	var pathElem *modelregistry.ReadWritePathElem
 	var subPath *modelregistry.ReadOnlyAttrib
+	var enum map[int]string
 	var err error
 	pathElem, modelPath, ok = findModelRwPathNoIndices(modelRWpaths, parentPath)
 	if !ok {
@@ -246,8 +243,10 @@ func handleAttribute(value interface{}, parentPath string, modelROpaths modelreg
 			return nil, fmt.Errorf("unable to locate %s in model", parentPath)
 		}
 		modeltype = subPath.Datatype
+		enum = subPath.Enum
 	} else {
 		modeltype = pathElem.ValueType
+		//enum = pathElem.
 	}
 	var typedValue *devicechange.TypedValue
 	switch modeltype {
@@ -255,7 +254,31 @@ func handleAttribute(value interface{}, parentPath string, modelROpaths modelreg
 		var stringVal string
 		switch valueTyped := value.(type) {
 		case string:
-			stringVal = valueTyped
+			if len(enum) > 0 {
+				// Compare values and convert from digit if necessary
+				for k, v := range enum {
+					if v == valueTyped {
+						stringVal = valueTyped
+						break
+					} else if fmt.Sprintf("%d", k) == valueTyped {
+						stringVal = v
+						break
+					}
+				}
+				if stringVal == "" {
+					enumOpts := make([]string, len(enum)*2)
+					i := 0
+					for k, v := range enum {
+						enumOpts[i*2] = fmt.Sprintf("%d", k)
+						enumOpts[i*2+1] = v
+						i++
+					}
+					return nil, fmt.Errorf("value %s for %s does not match any enumerated value %s",
+						valueTyped, parentPath, strings.Join(enumOpts, ";"))
+				}
+			} else {
+				stringVal = valueTyped
+			}
 		case float64:
 			stringVal = fmt.Sprintf("%g", value)
 		case bool:
@@ -392,9 +415,9 @@ func handleAttributeLeafList(modeltype devicechange.ValueType,
 func findModelRwPathNoIndices(modelRWpaths modelregistry.ReadWritePathMap,
 	searchpath string) (*modelregistry.ReadWritePathElem, string, bool) {
 
-	searchpathNoIndices := removePathIndices(searchpath)
+	searchpathNoIndices := modelregistry.RemovePathIndices(searchpath)
 	for path, value := range modelRWpaths {
-		if removePathIndices(path) == searchpathNoIndices {
+		if modelregistry.RemovePathIndices(path) == searchpathNoIndices {
 			pathWithNumericalIdx, err := insertNumericalIndices(path, searchpath)
 			if err != nil {
 				return nil, fmt.Sprintf("could not replace wildcards in model path with numerical ids %v", err), false
@@ -408,7 +431,7 @@ func findModelRwPathNoIndices(modelRWpaths modelregistry.ReadWritePathMap,
 func findModelRoPathNoIndices(modelROpaths modelregistry.ReadOnlyPathMap,
 	searchpath string) (*modelregistry.ReadOnlyAttrib, string, bool) {
 
-	searchpathNoIndices := removePathIndices(searchpath)
+	searchpathNoIndices := modelregistry.RemovePathIndices(searchpath)
 	for path, value := range modelROpaths {
 		for subpath, subpathValue := range value {
 			var fullpath string
@@ -417,7 +440,7 @@ func findModelRoPathNoIndices(modelROpaths modelregistry.ReadOnlyPathMap,
 			} else {
 				fullpath = fmt.Sprintf("%s%s", path, subpath)
 			}
-			if removePathIndices(fullpath) == searchpathNoIndices {
+			if modelregistry.RemovePathIndices(fullpath) == searchpathNoIndices {
 				pathWithNumericalIdx, err := insertNumericalIndices(fullpath, searchpath)
 				if err != nil {
 					return nil, fmt.Sprintf("could not replace wildcards in model path with numerical ids %v", err), false
@@ -447,13 +470,13 @@ func stripNamespace(path string) string {
 func indicesOfPath(modelROpaths modelregistry.ReadOnlyPathMap,
 	modelRWpaths modelregistry.ReadWritePathMap, searchpath string) []string {
 
-	searchpathNoIndices := removePathIndices(searchpath)
+	searchpathNoIndices := modelregistry.RemovePathIndices(searchpath)
 	// First search through the RW paths
 	for path := range modelRWpaths {
-		pathNoIndices := removePathIndices(path)
+		pathNoIndices := modelregistry.RemovePathIndices(path)
 		// Find a short path
 		if pathNoIndices[:strings.LastIndex(pathNoIndices, slash)] == searchpathNoIndices {
-			return extractIndexNames(path)
+			return modelregistry.ExtractIndexNames(path)
 		}
 	}
 
@@ -466,33 +489,15 @@ func indicesOfPath(modelROpaths modelregistry.ReadOnlyPathMap,
 			} else {
 				fullpath = fmt.Sprintf("%s%s", path, subpath)
 			}
-			pathNoIndices := removePathIndices(fullpath)
+			pathNoIndices := modelregistry.RemovePathIndices(fullpath)
 			// Find a short path
 			if pathNoIndices[:strings.LastIndex(pathNoIndices, slash)] == searchpathNoIndices {
-				return extractIndexNames(fullpath)
+				return modelregistry.ExtractIndexNames(fullpath)
 			}
 		}
 	}
 
 	return []string{}
-}
-
-func removePathIndices(path string) string {
-	jsonMatches := rOnIndex.FindAllStringSubmatch(path, -1)
-	for _, m := range jsonMatches {
-		path = strings.ReplaceAll(path, m[1], "")
-	}
-	return path
-}
-
-func extractIndexNames(path string) []string {
-	indexNames := make([]string, 0)
-	jsonMatches := rOnIndex.FindAllStringSubmatch(path, -1)
-	for _, m := range jsonMatches {
-		idxName := m[1][1:strings.LastIndex(m[1], "=")]
-		indexNames = append(indexNames, idxName)
-	}
-	return indexNames
 }
 
 func insertNumericalIndices(modelPath string, jsonPath string) (string, error) {

--- a/pkg/modelregistry/jsonvalues/jsonToValues_test.go
+++ b/pkg/modelregistry/jsonvalues/jsonToValues_test.go
@@ -162,25 +162,6 @@ func Test_indicesOfPath(t *testing.T) {
 	assert.Equal(t, "severity", indices[2])
 }
 
-func Test_removePathIndices(t *testing.T) {
-	const jsonPath = "/p/q/r[10]/s/t[20]/u/v[30]/w"
-	const jsonPathRemovedIdx = "/p/q/r/s/t/u/v/w"
-	noIndices := removePathIndices(jsonPath)
-	assert.Equal(t, jsonPathRemovedIdx, noIndices)
-}
-
-func Test_extractIndexNames(t *testing.T) {
-	const modelPath = "/p/q/r[a=*]/s/t[b=*][c=*]/u/v[d=*][e=*][f=*]/w"
-	indexNames := extractIndexNames(modelPath)
-	assert.Equal(t, 6, len(indexNames))
-	assert.Equal(t, "a", indexNames[0])
-	assert.Equal(t, "b", indexNames[1])
-	assert.Equal(t, "c", indexNames[2])
-	assert.Equal(t, "d", indexNames[3])
-	assert.Equal(t, "e", indexNames[4])
-	assert.Equal(t, "f", indexNames[5])
-}
-
 func Test_insertNumericalIndices(t *testing.T) {
 	const modelPath = "/p/q/r[a=*]/s/t[b=*][c=*]/u/v[d=*][e=*][f=*]/w"
 	const jsonPath = "/p/q/r[10]/s/t[20]/u/v[30]/w"

--- a/pkg/modelregistry/jsonvalues/testdata/sample-testdevice2-opstate.json
+++ b/pkg/modelregistry/jsonvalues/testdata/sample-testdevice2-opstate.json
@@ -16,7 +16,7 @@
         "index1": 101,
         "index2": 103,
         "leaf3c": "Second mock Value",
-        "leaf3d": "IDTYPE2"
+        "leaf3d": "2"
       }
     ],
     "leaf2d": 10001,

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -661,22 +661,25 @@ func Test_Ntp(t *testing.T) {
 }
 
 func Test_RemovePathIndices(t *testing.T) {
-	assert.Equal(t,
-		RemovePathIndices("/cont1b-state"),
-		"/cont1b-state")
+	assert.Equal(t, "/cont1b-state",
+		RemovePathIndices("/cont1b-state"))
 
-	assert.Equal(t,
-		RemovePathIndices("/cont1b-state/list2b[index=test1]/index"),
-		"/cont1b-state/list2b[index=*]/index")
+	assert.Equal(t, "/cont1b-state/list2b/index",
+		RemovePathIndices("/cont1b-state/list2b[index=test1]/index"))
 
-	assert.Equal(t,
-		RemovePathIndices("/cont1b-state/list2b[index=test1,test2]/index"),
-		"/cont1b-state/list2b[index=*]/index")
+	assert.Equal(t, "/cont1b-state/list2b/index",
+		RemovePathIndices("/cont1b-state/list2b[index=test1,test2]/index"))
 
-	assert.Equal(t,
-		RemovePathIndices("/cont1b-state/list2b[index=test1]/index/t3[name=5]"),
-		"/cont1b-state/list2b[index=*]/index/t3[name=*]")
+	assert.Equal(t, "/cont1b-state/list2b/index/t3",
+		RemovePathIndices("/cont1b-state/list2b[index=test1]/index/t3[name=5]"))
 
+}
+
+func Test_RemovePathIndices2(t *testing.T) {
+	const jsonPath = "/p/q/r[10]/s/t[20]/u/v[30]/w"
+	const jsonPathRemovedIdx = "/p/q/r/s/t/u/v/w"
+	noIndices := RemovePathIndices(jsonPath)
+	assert.Equal(t, jsonPathRemovedIdx, noIndices)
 }
 
 func Test_formatName1(t *testing.T) {
@@ -694,4 +697,16 @@ func Test_formatName2(t *testing.T) {
 		Prefix: &yang.Value{Name: "pfx1"},
 	}
 	assert.Equal(t, formatName(&dirEntry1, true, "/testpath/testpath2", ""), "/testpath/testpath2/testname[name=*]")
+}
+
+func Test_extractIndexNames(t *testing.T) {
+	const modelPath = "/p/q/r[a=*]/s/t[b=*][c=*]/u/v[d=*][e=*][f=*]/w"
+	indexNames := ExtractIndexNames(modelPath)
+	assert.Equal(t, 6, len(indexNames))
+	assert.Equal(t, "a", indexNames[0])
+	assert.Equal(t, "b", indexNames[1])
+	assert.Equal(t, "c", indexNames[2])
+	assert.Equal(t, "d", indexNames[3])
+	assert.Equal(t, "e", indexNames[4])
+	assert.Equal(t, "f", indexNames[5])
 }

--- a/pkg/northbound/gnmi/set_test.go
+++ b/pkg/northbound/gnmi/set_test.go
@@ -521,7 +521,7 @@ func TestSet_checkForReadOnly(t *testing.T) {
 	err := server.checkForReadOnly("device-1", "TestDevice", "1.0.0", updateT1, make([]string, 0))
 	assert.NilError(t, err, "unexpected error on T1")
 	err = server.checkForReadOnly("device-2", "TestDevice", "1.0.0", updateT2, make([]string, 0))
-	assert.Error(t, err, `update contains a change to a read only path /cont1a/cont2a/leaf2c. Rejected. /cont1a/cont2a/leaf2c, /cont1a/cont2a/leaf2c, /, /cont1a/cont2a/leaf2c`)
+	assert.Error(t, err, `update contains a change to a read only path /cont1a/cont2a/leaf2c. Rejected. /cont1a/cont2a/leaf2c, /cont1a/cont2a/leaf2c, /cont1a/cont2a/leaf2c, /, /cont1a/cont2a/leaf2c`)
 }
 
 // Tests giving a new device without specifying a type


### PR DESCRIPTION
Also removed a duplicate function

Convert enum (from identityref) as numbers in to strings