### PR TITLE
Add multiple back to back set integration test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/onosproject/onos-config
 go 1.14
 
 require (
+	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/atomix/go-client v0.2.3
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/Microsoft/hcsshim v0.8.7 h1:ptnOoufxGSzauVTsdE+wMYnCWA301PdoN4xg5oRdZ
 github.com/Microsoft/hcsshim v0.8.7/go.mod h1:OHd7sQqRFrYd3RmSgbgji+ctCwkbq2wbEYNSzOYtcBQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/Pallinder/go-randomdata v1.2.0 h1:DZ41wBchNRb/0GfsePLiSwb0PHZmT67XY00lCDlaYPg=
+github.com/Pallinder/go-randomdata v1.2.0/go.mod h1:yHmJgulpD2Nfrm0cR9tI/+oAgRqCQQixsA8HyRZfV9Y=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=

--- a/test/gnmi/multiplesettest.go
+++ b/test/gnmi/multiplesettest.go
@@ -1,0 +1,75 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gnmi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Pallinder/go-randomdata"
+
+	"github.com/onosproject/onos-config/api/types/change/network"
+	"github.com/onosproject/onos-config/test/utils/gnmi"
+	"github.com/onosproject/onos-config/test/utils/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func generateTimezoneName() string {
+
+	usCity := randomdata.ProvinceForCountry("US")
+	timeZone := "US/" + usCity
+	return timeZone
+}
+
+// TestMultipleSet tests multiple query/set/delete of a single GNMI path to a single device
+func (s *TestSuite) TestMultipleSet(t *testing.T) {
+	// Create a simulated device
+	simulator := gnmi.CreateSimulator(t)
+
+	// Make a GNMI client to use for requests
+	gnmiClient := gnmi.GetGNMIClientOrFail(t)
+
+	var changeIDs []network.ID
+
+	for i := 0; i < 10; i++ {
+
+		msValue := generateTimezoneName()
+
+		devicePath := gnmi.GetDevicePathWithValue(simulator.Name(), tzPath, msValue, proto.StringVal)
+		// Set a value using gNMI client
+		changeID := gnmi.SetGNMIValueOrFail(t, gnmiClient, devicePath, gnmi.NoPaths, gnmi.NoExtensions)
+
+		// Append the changeID to list of changeIDs
+		changeIDs = append(changeIDs, changeID)
+
+		// Check that the value was set correctly
+		gnmi.CheckGNMIValue(t, gnmiClient, devicePath, msValue, 0, "Query after set returned the wrong value")
+
+		// Remove the path we added
+		gnmi.SetGNMIValueOrFail(t, gnmiClient, gnmi.NoPaths, devicePath, gnmi.NoExtensions)
+
+		//  Make sure it got removed
+		gnmi.CheckGNMIValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
+
+	}
+
+	// Make sure all of the changes have been completed
+	for _, changeID := range changeIDs {
+		complete := gnmi.WaitForNetworkChangeComplete(t, changeID, 1*time.Second)
+		assert.True(t, complete, "Set never completed")
+	}
+	// Shut down the device we created
+	gnmi.DeleteSimulator(t, simulator)
+}

--- a/test/gnmi/multiplesettest.go
+++ b/test/gnmi/multiplesettest.go
@@ -67,7 +67,7 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 
 	// Make sure all of the changes have been completed
 	for _, changeID := range changeIDs {
-		complete := gnmi.WaitForNetworkChangeComplete(t, changeID, 1*time.Second)
+		complete := gnmi.WaitForNetworkChangeComplete(t, changeID, 5*time.Second)
 		assert.True(t, complete, "Set never completed")
 	}
 	// Shut down the device we created


### PR DESCRIPTION
This PR adds a simple integration tests to run multiple back to back set operations and make sure all of the changes are in the Completed state. We have an issue #1045 which is not reproducible at the moment but this test will be detect if that happens again.