### PR TITLE
Add an HA test for session failover

### DIFF
--- a/cmd/onos-config-tests/main.go
+++ b/cmd/onos-config-tests/main.go
@@ -19,12 +19,14 @@ import (
 	"github.com/onosproject/helmit/pkg/test"
 	"github.com/onosproject/onos-config/test/cli"
 	"github.com/onosproject/onos-config/test/gnmi"
+	"github.com/onosproject/onos-config/test/ha"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {
 	registry.RegisterTestSuite("cli", &cli.TestSuite{})
 	registry.RegisterTestSuite("gnmi", &gnmi.TestSuite{})
+	registry.RegisterTestSuite("ha", &ha.TestSuite{})
 
 	test.Main()
 }

--- a/pkg/southbound/synchronizer/device_update.go
+++ b/pkg/southbound/synchronizer/device_update.go
@@ -83,6 +83,7 @@ func (s *Session) updateDevice(connectivity topodevice.ConnectivityState, channe
 	}
 
 	topoDevice.Attributes[mastershipTermKey] = strconv.FormatUint(uint64(s.mastershipState.Term), 10)
+	topoDevice.Attributes[mastershipMasterKey] = string(s.mastershipState.Master)
 	_, err = s.deviceStore.Update(topoDevice)
 	if err != nil {
 		log.Errorf("Device %s is not updated %s", id, err.Error())

--- a/pkg/southbound/synchronizer/session.go
+++ b/pkg/southbound/synchronizer/session.go
@@ -41,9 +41,10 @@ import (
 )
 
 const (
-	backoffInterval   = 10 * time.Millisecond
-	maxBackoffTime    = 5 * time.Second
-	mastershipTermKey = "onos-config.mastership.term"
+	backoffInterval     = 10 * time.Millisecond
+	maxBackoffTime      = 5 * time.Second
+	mastershipTermKey   = "onos-config.mastership.term"
+	mastershipMasterKey = "onos-config.mastership.master"
 )
 
 // Session a gNMI session

--- a/test/ha/session_failover.go
+++ b/test/ha/session_failover.go
@@ -1,0 +1,64 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/onosproject/onos-config/test/utils/gnmi"
+	hautils "github.com/onosproject/onos-config/test/utils/ha"
+	"github.com/onosproject/onos-topo/api/device"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	mastershipTermKey   = "onos-config.mastership.term"
+	mastershipMasterKey = "onos-config.mastership.master"
+)
+
+func (s *TestSuite) TestSessionFailOver(t *testing.T) {
+	simulator := gnmi.CreateSimulator(t)
+	assert.NotNil(t, simulator)
+	var currentTerm int
+	var masterNode string
+	found := gnmi.WaitForDevice(t, func(d *device.Device) bool {
+		currentTerm, _ = strconv.Atoi(d.Attributes[mastershipTermKey])
+		masterNode = d.Attributes[mastershipMasterKey]
+		return len(d.Protocols) > 0 &&
+			d.Protocols[0].Protocol == device.Protocol_GNMI &&
+			d.Protocols[0].ConnectivityState == device.ConnectivityState_REACHABLE &&
+			d.Protocols[0].ChannelState == device.ChannelState_CONNECTED &&
+			d.Protocols[0].ServiceState == device.ServiceState_AVAILABLE
+	}, 5*time.Second)
+	assert.Equal(t, true, found)
+	assert.Equal(t, currentTerm, 1)
+	masterPod := hautils.FindPodWithPrefix(t, masterNode)
+	// Crash master pod
+	hautils.CrashPodOrFail(t, masterPod)
+
+	// Waits for a new master to be selected, establish a connection to the device
+	// and updates the device state
+	found = gnmi.WaitForDevice(t, func(d *device.Device) bool {
+		currentTerm, _ = strconv.Atoi(d.Attributes[mastershipTermKey])
+		return currentTerm == 2 && len(d.Protocols) > 0 &&
+			d.Protocols[0].Protocol == device.Protocol_GNMI &&
+			d.Protocols[0].ConnectivityState == device.ConnectivityState_REACHABLE &&
+			d.Protocols[0].ChannelState == device.ChannelState_CONNECTED &&
+			d.Protocols[0].ServiceState == device.ServiceState_AVAILABLE
+	}, 70*time.Second)
+
+}

--- a/test/ha/session_failover.go
+++ b/test/ha/session_failover.go
@@ -40,7 +40,7 @@ func (s *TestSuite) TestSessionFailOver(t *testing.T) {
 	found := gnmi.WaitForDevice(t, func(d *device.Device) bool {
 		currentTerm, _ = strconv.Atoi(d.Attributes[mastershipTermKey])
 		masterNode = d.Attributes[mastershipMasterKey]
-		return len(d.Protocols) > 0 &&
+		return currentTerm == 1 && len(d.Protocols) > 0 &&
 			d.Protocols[0].Protocol == device.Protocol_GNMI &&
 			d.Protocols[0].ConnectivityState == device.ConnectivityState_REACHABLE &&
 			d.Protocols[0].ChannelState == device.ChannelState_CONNECTED &&
@@ -52,7 +52,7 @@ func (s *TestSuite) TestSessionFailOver(t *testing.T) {
 	// Crash master pod
 	hautils.CrashPodOrFail(t, masterPod)
 
-	// Waits for a new master to be selected, establish a connection to the device
+	// Waits for a new master to be elected (i.e. the term will be increased), it establishes a connection to the device
 	// and updates the device state
 	found = gnmi.WaitForDevice(t, func(d *device.Device) bool {
 		currentTerm, _ = strconv.Atoi(d.Attributes[mastershipTermKey])

--- a/test/ha/session_failover.go
+++ b/test/ha/session_failover.go
@@ -30,6 +30,8 @@ const (
 	mastershipMasterKey = "onos-config.mastership.master"
 )
 
+// TestSessionFailOver tests gnmi session failover is happening when the master node
+// is crashed
 func (s *TestSuite) TestSessionFailOver(t *testing.T) {
 	simulator := gnmi.CreateSimulator(t)
 	assert.NotNil(t, simulator)
@@ -60,5 +62,6 @@ func (s *TestSuite) TestSessionFailOver(t *testing.T) {
 			d.Protocols[0].ChannelState == device.ChannelState_CONNECTED &&
 			d.Protocols[0].ServiceState == device.ServiceState_AVAILABLE
 	}, 70*time.Second)
+	assert.Equal(t, true, found)
 
 }

--- a/test/ha/suite.go
+++ b/test/ha/suite.go
@@ -1,0 +1,77 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"sync"
+
+	"github.com/onosproject/onos-test/pkg/onostest"
+
+	"github.com/onosproject/helmit/pkg/helm"
+	"github.com/onosproject/helmit/pkg/test"
+)
+
+type testSuite struct {
+	test.Suite
+}
+
+// TestSuite is the onos-config CLI test suite
+type TestSuite struct {
+	testSuite
+	mux sync.Mutex
+}
+
+const onosComponentName = "onos-config"
+const testName = "ha-test"
+
+// SetupTestSuite sets up the onos-config CLI test suite
+func (s *TestSuite) SetupTestSuite() error {
+	err := helm.Chart(onostest.ControllerChartName, onostest.AtomixChartRepo).
+		Release(onostest.AtomixName(testName, onosComponentName)).
+		Set("scope", "Namespace").
+		Install(true)
+	if err != nil {
+		return err
+	}
+
+	err = helm.Chart(onostest.RaftStorageControllerChartName, onostest.AtomixChartRepo).
+		Release(onostest.RaftReleaseName(onosComponentName)).
+		Set("scope", "Namespace").
+		Install(true)
+	if err != nil {
+		return err
+	}
+
+	err = helm.Chart("onos-topo", onostest.OnosChartRepo).
+		Release("onos-topo").
+		Set("image.tag", "latest").
+		Set("storage.controller", onostest.AtomixController(testName, onosComponentName)).
+		Install(true)
+	if err != nil {
+		return err
+	}
+
+	err = helm.Chart("onos-config", onostest.OnosChartRepo).
+		Release("onos-config").
+		Set("image.tag", "latest").
+		Set("replicaCount", "2").
+		Set("storage.controller", onostest.AtomixController(testName, onosComponentName)).
+		Install(true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/test/ha/suite.go
+++ b/test/ha/suite.go
@@ -15,8 +15,6 @@
 package ha
 
 import (
-	"sync"
-
 	"github.com/onosproject/onos-test/pkg/onostest"
 
 	"github.com/onosproject/helmit/pkg/helm"
@@ -30,7 +28,6 @@ type testSuite struct {
 // TestSuite is the onos-config CLI test suite
 type TestSuite struct {
 	testSuite
-	mux sync.Mutex
 }
 
 const onosComponentName = "onos-config"

--- a/test/utils/ha/utils.go
+++ b/test/utils/ha/utils.go
@@ -1,0 +1,61 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ha
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onosproject/helmit/pkg/helm"
+	"github.com/onosproject/helmit/pkg/kubernetes"
+	v1 "github.com/onosproject/helmit/pkg/kubernetes/core/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	onosComponentName = "onos-config"
+)
+
+// GetPodListOrFail gets the list of pods active in the onos-config release. The test is failed if getting the list returns
+// an error.
+func GetPodListOrFail(t *testing.T) []*v1.Pod {
+	release := helm.Chart(onosComponentName).Release(onosComponentName)
+	client := kubernetes.NewForReleaseOrDie(release)
+	podList, err := client.
+		CoreV1().
+		Pods().
+		List()
+	assert.NoError(t, err)
+	return podList
+}
+
+// CrashPodOrFail deletes the given pod and fails the test if there is an error
+func CrashPodOrFail(t *testing.T, pod *v1.Pod) {
+	err := pod.Delete()
+	assert.NoError(t, err)
+}
+
+// FindPodWithPrefix looks for the first pod whose name matches the given prefix string. The test is failed
+// if no matching pod is found.
+func FindPodWithPrefix(t *testing.T, prefix string) *v1.Pod {
+	podList := GetPodListOrFail(t)
+	for _, p := range podList {
+		if strings.HasPrefix(p.Name, prefix) {
+			return p
+		}
+	}
+	assert.Failf(t, "No pod found matching %s", prefix)
+	return nil
+}


### PR DESCRIPTION
This PR adds an HA test to verify in the case of a master pod failure, a new master will be elected, it will be connected to the device and the device will be updated properly. 
At the moment, it takes around 1 minute to that happens because 30 seconds is the time which is needed to detect failure and choose a new master and 25-30 seconds will needed to kill the master pod and it becomes ready again. 

#1052 