### PR TITLE
Sets master arbitration extension 

### DIFF
--- a/pkg/southbound/synchronizer/device_update.go
+++ b/pkg/southbound/synchronizer/device_update.go
@@ -18,11 +18,16 @@ import (
 	"errors"
 	"strconv"
 
+	"github.com/openconfig/gnmi/proto/gnmi_ext"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/cenkalti/backoff"
 
+	gpb "github.com/openconfig/gnmi/proto/gnmi"
+
+	"github.com/onosproject/gnmi/proto/gnmi_ext"
 	"github.com/onosproject/onos-config/pkg/events"
 
 	topodevice "github.com/onosproject/onos-topo/api/device"
@@ -117,6 +122,29 @@ func (s *Session) updateDisconnectedDevice() error {
 	err := s.updateDevice(topodevice.ConnectivityState_UNREACHABLE, topodevice.ChannelState_DISCONNECTED,
 		topodevice.ServiceState_UNAVAILABLE)
 	return err
+
+}
+
+func (s *Session) setMasterArbitrationExt() {
+
+	term := &gnmi_ext.Uint128{
+		Low:  0,
+		High: uint64(s.mastershipState.Term),
+	}
+
+	masterArbitrationExt := gnmi_ext.Extension_MasterArbitration{
+		MasterArbitration: &gnmi_ext.MasterArbitration{
+			ElectionId: term,
+		},
+	}
+
+	extensions := []*gnmi_ext.Extension{{Ext: &masterArbitrationExt}}
+
+	masterArbitration := gpb.SetRequest{
+		Extension: extensions,
+	}
+
+	s.target.Set()
 
 }
 

--- a/pkg/southbound/synchronizer/session.go
+++ b/pkg/southbound/synchronizer/session.go
@@ -63,6 +63,7 @@ type Session struct {
 	device                    *topodevice.Device
 	target                    southbound.TargetIf
 	cancel                    context.CancelFunc
+	ctx                       context.Context
 	closed                    bool
 	mu                        sync.RWMutex
 }
@@ -144,6 +145,7 @@ func (s *Session) synchronize() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
 	s.cancel = cancel
+	s.ctx = ctx
 	s.mu.Unlock()
 
 	s.mu.RLock()

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -19,12 +19,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/onosproject/onos-test/pkg/onostest"
 	"io"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/onosproject/onos-test/pkg/onostest"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/onosproject/helmit/pkg/helm"


### PR DESCRIPTION
This PR adds a function that will be called after we receive an event that onos-config instance is connected to the device but before updating the device stat to  send an empty Set RPC with the election ID (i.e. mastership term) only. 

#1210 