### PR TITLE
Generate unique ids for network changes

### DIFF
--- a/api/types/change/network/network.go
+++ b/api/types/change/network/network.go
@@ -29,7 +29,7 @@ func NewNetworkChange(networkChangeID string, changes []*devicechange.Change) (*
 	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
 	match := r1.FindString(networkChangeID)
 	if networkChangeID == "" {
-		uuid := utils.NewUuid()
+		uuid := utils.NewUUID()
 		networkChangeID = uuid.String()
 
 	} else if networkChangeID != match {

--- a/api/types/change/network/network.go
+++ b/api/types/change/network/network.go
@@ -16,9 +16,12 @@ package network
 
 import (
 	"fmt"
-	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	"regexp"
 	"time"
+
+	"github.com/onosproject/onos-config/pkg/utils"
+
+	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 )
 
 // NewNetworkChange creates a new network configuration
@@ -26,9 +29,11 @@ func NewNetworkChange(networkChangeID string, changes []*devicechange.Change) (*
 	r1 := regexp.MustCompile(`[a-zA-Z0-9\-_]+`)
 	match := r1.FindString(networkChangeID)
 	if networkChangeID == "" {
-		return nil, fmt.Errorf("Empty name not allowed")
+		uuid := utils.NewUuid()
+		networkChangeID = uuid.String()
+
 	} else if networkChangeID != match {
-		return nil, fmt.Errorf("Error in name %s", networkChangeID)
+		return nil, fmt.Errorf("error in name %s", networkChangeID)
 	}
 
 	return &NetworkChange{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Pallinder/go-randomdata v1.2.0
 	github.com/atomix/go-client v0.2.3
 	github.com/cenkalti/backoff v2.2.1+incompatible
-	github.com/docker/docker v1.13.1
+	github.com/docker/docker v1.13.1 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.3.1
 	github.com/golang/protobuf v1.3.3

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -16,13 +16,14 @@ package manager
 
 import (
 	"fmt"
+	"sort"
+
 	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
 	"github.com/onosproject/onos-config/pkg/store"
 	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	"github.com/onosproject/onos-config/pkg/utils"
-	"sort"
 )
 
 // SetConfigAlreadyApplied is a string constant for "Already applied:"
@@ -98,13 +99,14 @@ func (m *Manager) ValidateNetworkConfig(deviceName devicetype.ID, version device
 
 // SetNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
 func (m *Manager) SetNetworkConfig(targetUpdates map[string]devicechange.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info, netcfgchangename string) (*networkchange.NetworkChange, error) {
+	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info, netChangeID string) (*networkchange.NetworkChange, error) {
 	//TODO evaluate need of user and add it back if need be.
-	allDeviceChanges, errChanges := m.computeNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netcfgchangename)
+
+	allDeviceChanges, errChanges := m.computeNetworkConfig(targetUpdates, targetRemoves, deviceInfo, "")
 	if errChanges != nil {
 		return nil, errChanges
 	}
-	newNetworkConfig, errNetChange := networkchange.NewNetworkChange(netcfgchangename, allDeviceChanges)
+	newNetworkConfig, errNetChange := networkchange.NewNetworkChange(netChangeID, allDeviceChanges)
 	if errNetChange != nil {
 		return nil, errNetChange
 	}

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -17,7 +17,9 @@ package gnmi
 import (
 	"context"
 	"fmt"
-	"github.com/docker/docker/pkg/namesgenerator"
+	"strings"
+	"time"
+
 	devicechange "github.com/onosproject/onos-config/api/types/change/device"
 	networkchange "github.com/onosproject/onos-config/api/types/change/network"
 	devicetype "github.com/onosproject/onos-config/api/types/device"
@@ -31,8 +33,6 @@ import (
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"strings"
-	"time"
 )
 
 type mapTargetUpdates map[string]devicechange.TypedValueMap
@@ -101,10 +101,6 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	netCfgChangeName, version, deviceType, err := extractExtensions(req)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-
-	if netCfgChangeName == "" {
-		netCfgChangeName = namesgenerator.GetRandomName(0)
 	}
 
 	//Temporary map in order to not to modify the original removes but optimize calculations during validation
@@ -213,7 +209,7 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 			Ext: &gnmi_ext.Extension_RegisteredExt{
 				RegisteredExt: &gnmi_ext.RegisteredExtension{
 					Id:  GnmiExtensionNetwkChangeID,
-					Msg: []byte(netCfgChangeName),
+					Msg: []byte(change.ID),
 				},
 			},
 		},

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -149,8 +149,8 @@ func WithChangeID(id networkchange.ID) WatchOption {
 
 // newChangeID creates a new network change ID
 func newChangeID() networkchange.ID {
-	newUuid := utils.NewUuid()
-	return networkchange.ID(newUuid.String())
+	newUUID := utils.NewUUID()
+	return networkchange.ID(newUUID.String())
 }
 
 // atomixStore is the default implementation of the NetworkConfig store

--- a/pkg/store/change/network/store.go
+++ b/pkg/store/change/network/store.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/onosproject/onos-config/pkg/utils"
+
 	"github.com/atomix/go-client/pkg/client/indexedmap"
 	"github.com/atomix/go-client/pkg/client/primitive"
 	"github.com/atomix/go-client/pkg/client/util/net"
@@ -147,7 +149,8 @@ func WithChangeID(id networkchange.ID) WatchOption {
 
 // newChangeID creates a new network change ID
 func newChangeID() networkchange.ID {
-	return networkchange.ID(uuid.New().String())
+	newUuid := utils.NewUuid()
+	return networkchange.ID(newUuid.String())
 }
 
 // atomixStore is the default implementation of the NetworkConfig store

--- a/pkg/utils/uuid.go
+++ b/pkg/utils/uuid.go
@@ -18,11 +18,11 @@ import (
 	"github.com/google/uuid"
 )
 
-// NewUuid generates a new uuid
-func NewUuid() uuid.UUID {
-	newUuid, err := uuid.NewUUID()
+// NewUUID generates a new uuid
+func NewUUID() uuid.UUID {
+	newUUID, err := uuid.NewUUID()
 	if err != nil {
-		newUuid = uuid.New()
+		newUUID = uuid.New()
 	}
-	return newUuid
+	return newUUID
 }

--- a/pkg/utils/uuid.go
+++ b/pkg/utils/uuid.go
@@ -1,0 +1,28 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"github.com/google/uuid"
+)
+
+// NewUuid generates a new uuid
+func NewUuid() uuid.UUID {
+	newUuid, err := uuid.NewUUID()
+	if err != nil {
+		newUuid = uuid.New()
+	}
+	return newUuid
+}


### PR DESCRIPTION
This PR fixes this issue https://github.com/onosproject/onos-config/issues/1192. The problem is the network change name which is generated by random generator and used as a change ID is not unique specially if you run onos-config in multinode cluster. the use still can provide a network config change name to be used as the change ID but it should be unique otherwise Atomix is going to give the precondition failed error. 