### PR TITLE
SBI: when --insecure is selected need to use certs

### DIFF
--- a/pkg/southbound/clientManager.go
+++ b/pkg/southbound/clientManager.go
@@ -56,7 +56,7 @@ func createDestination(device topodevice.Device) (*client.Destination, topodevic
 			log.Info("Insecure TLS connection to ", device.Address)
 			d.TLS = &tls.Config{InsecureSkipVerify: true}
 		} else {
-			log.Info("Insecure TLS connection to ", device.Address)
+			log.Info("Secure TLS connection to ", device.Address)
 		}
 		if device.TLS.CaCert == "" {
 			log.Info("Loading default CA onfca")

--- a/pkg/southbound/clientManager.go
+++ b/pkg/southbound/clientManager.go
@@ -49,12 +49,15 @@ func createDestination(device topodevice.Device) (*client.Destination, topodevic
 		d.Timeout = *device.Timeout
 	}
 	if device.TLS.Plain {
-		log.Info("Plain connection connection to ", device.Address)
-	} else if device.TLS.Insecure {
-		log.Info("Insecure connection to ", device.Address)
-		d.TLS = &tls.Config{InsecureSkipVerify: true}
+		log.Info("Plain (non TLS) connection connection to ", device.Address)
 	} else {
 		d.TLS = &tls.Config{}
+		if device.TLS.Insecure {
+			log.Info("Insecure TLS connection to ", device.Address)
+			d.TLS = &tls.Config{InsecureSkipVerify: true}
+		} else {
+			log.Info("Insecure TLS connection to ", device.Address)
+		}
 		if device.TLS.CaCert == "" {
 			log.Info("Loading default CA onfca")
 			d.TLS.RootCAs = getCertPoolDefault()


### PR DESCRIPTION
I should have done this over a year ago :-).

When `--insecure` is specified, it means:
**"still connect over TLS but do not check that the server cert DN matches its hostname"**

So when `--insecure` is specified, the client Certs specified in `onos-topo` for that device OR the default certificates need to be configured in the gNMI client.