### PR TITLE
Do not disconnect from the device if there is not path to subscribe

### DIFF
--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -383,6 +383,11 @@ func (sync *Synchronizer) subscribeOpState(target southbound.TargetIf, errChan c
 		Origin:            "",
 	}
 
+	if len(subscribePaths) == 0 {
+		log.Info("No operational state path found for subscription")
+		return
+	}
+
 	log.Infof("Subscribing to %d paths. %s", len(subscribePaths), string(sync.key))
 	req, err := southbound.NewSubscribeRequest(options)
 	if err != nil {


### PR DESCRIPTION
I noticed that if there is not operational state path in the model to subscribe to, that function sends an error message which leads to disconnect onos-config from the device. 