### PR TITLE
Handling updated Value Type from onos-api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/atomix/go-client v0.4.1
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v1.13.1 // indirect
-	github.com/go-playground/overalls v0.0.0-20191218162659-7df9f728c018 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.4.4
 	github.com/golang/protobuf v1.4.3
@@ -16,26 +15,25 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
-	github.com/mattn/goveralls v0.0.7 // indirect
 	github.com/onosproject/config-models/modelplugin/devicesim-1.0.0 v0.0.0-20201130213019-492043aed0df
 	github.com/onosproject/config-models/modelplugin/testdevice-1.0.0 v0.0.0-20201130213019-492043aed0df
 	github.com/onosproject/config-models/modelplugin/testdevice-2.0.0 v0.0.0-20201130213019-492043aed0df
 	github.com/onosproject/helmit v0.6.8
-	github.com/onosproject/onos-api/go v0.7.0
+	github.com/onosproject/onos-api/go v0.7.2
 	github.com/onosproject/onos-lib-go v0.7.0
 	github.com/onosproject/onos-test v0.6.4
-	github.com/onosproject/onos-topo v0.7.0 // indirect
 	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802
 	github.com/openconfig/goyang v0.2.1
 	github.com/openconfig/ygot v0.8.12
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.9.1
+	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.6
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1
-	github.com/yookoala/realpath v1.0.0 // indirect
 	go.uber.org/multierr v1.4.0 // indirect
+	golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375 // indirect
 	google.golang.org/grpc v1.33.2
 	gopkg.in/yaml.v2 v2.2.8
 	gotest.tools v2.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -327,8 +327,6 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
-github.com/go-playground/overalls v0.0.0-20191218162659-7df9f728c018 h1:mKMuZuxwRig082824nGPyH0xVjaKDPjf41kI9W2aTk0=
-github.com/go-playground/overalls v0.0.0-20191218162659-7df9f728c018/go.mod h1:UqxAgEOt89sCiXlrc/ycnx00LVvUO/eS8tMUkWX4R7w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
@@ -494,7 +492,6 @@ github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
-github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4 h1:snbPLB8fVfU9iwbbo30TPtbLRzwWu6aJS6Xh4eaaviA=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
@@ -504,8 +501,6 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.2 h1:UnlwIPBGaTZfPQ6T1IGzPI0EkYAQmT9fAEJ/poFC63o=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.9/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
-github.com/mattn/goveralls v0.0.7 h1:vzy0i4a2iDzEFMdXIxcanRadkr0FBvSBKUmj0P8SPlQ=
-github.com/mattn/goveralls v0.0.7/go.mod h1:h8b4ow6FxSPMQHF6o2ve3qsclnffZjYTNEKmLesRwqw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
@@ -544,17 +539,18 @@ github.com/onosproject/config-models/modelplugin/testdevice-2.0.0 v0.0.0-2020113
 github.com/onosproject/config-models/modelplugin/testdevice-2.0.0 v0.0.0-20201130213019-492043aed0df/go.mod h1:mV2lHVyrXfFOkDAD3w/5DLW8BeEdjPKdbSbQam8LbTI=
 github.com/onosproject/helmit v0.6.8 h1:f/DjOzQp/NFzbTClM7qn4WwQ5DgR/13OD1FWJ4VxqfE=
 github.com/onosproject/helmit v0.6.8/go.mod h1:EorNGSNGWojXGxBEuiNmPScae+R2C5WYfg/13gKEPLw=
-github.com/onosproject/onos-api/go v0.7.0 h1:BjfN78bE/TXadUODrkYbaDsb1hyiV90dNiLoIkl5eV0=
-github.com/onosproject/onos-api/go v0.7.0/go.mod h1:HLfWE9aouIeOmi4soR6bxK2cZ33NbnFMvdyv9fmjaSg=
+github.com/onosproject/onos-api/go v0.7.2 h1:MduxbuoAYFYT5BhQZ/eqpIz4ZKJRIedog1y0qbDnMgY=
+github.com/onosproject/onos-api/go v0.7.2/go.mod h1:HLfWE9aouIeOmi4soR6bxK2cZ33NbnFMvdyv9fmjaSg=
 github.com/onosproject/onos-lib-go v0.7.0 h1:+BxQc0K4nej8qsciArvk6QC3Do6VKQevbIegpR3Kil8=
 github.com/onosproject/onos-lib-go v0.7.0/go.mod h1:ttkK+fV2CULZFHiq6FBZ69i7/Nymi1Wow1DNy0Ik/2o=
 github.com/onosproject/onos-test v0.6.4 h1:ocJhMv5mZ5RsojkhBUadE68Q6uSgBZpyDDjnwOPmu6g=
 github.com/onosproject/onos-test v0.6.4/go.mod h1:Ugb1OKR2bJhZjqpSMm9F5o6Ma2iwbtswhSlNyXXPgrg=
-github.com/onosproject/onos-topo v0.7.0/go.mod h1:0k/5a1TRXJPi44VimnsOG1xnFH6UxQBrDjjDHUUjfKg=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openconfig/gnmi v0.0.0-20200414194230-1597cc0f2600/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
 github.com/openconfig/gnmi v0.0.0-20200508230933-d19cebf5e7be/go.mod h1:M/EcuapNQgvzxo1DDXHK4tx3QpYM/uG4l591v33jG2A=
@@ -586,6 +582,7 @@ github.com/pelletier/go-toml v1.4.0 h1:u3Z1r+oOXJIkxqw34zVhyPgjBsm6X2wn21NWs/HfS
 github.com/pelletier/go-toml v1.4.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pierrec/lz4 v2.4.1+incompatible h1:mFe7ttWaflA46Mhqh+jUfjp2qTbPYxLB2/OyBppH9dg=
 github.com/pierrec/lz4 v2.4.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -639,8 +636,10 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -700,10 +699,12 @@ github.com/xeipuuv/gojsonschema v1.1.0/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4m
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43 h1:+lm10QQTNSBd8DVTNGHx7o/IKu9HYDvLMffDhbyLccI=
 github.com/yvasiyarov/go-metrics v0.0.0-20140926110328-57bccd1ccd43/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
+github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50 h1:hlE8//ciYMztlGpl/VA+Zm1AcTPHYkHJPbHqE6WJUXE=
 github.com/yvasiyarov/gorelic v0.0.0-20141212073537-a9bba5b9ab50/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
+github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f h1:ERexzlUfuTvpE74urLSbIQW0Z/6hF9t8U4NsJLaioAY=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -763,7 +764,7 @@ golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU
 golang.org/x/mobile v0.0.0-20190806162312-597adff16ade/go.mod h1:AlhUtkH4DA4asiFC5RgK7ZKmauvtkAVcy9L0epCzlWo=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
-golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -866,7 +867,6 @@ golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200113040837-eac381796e91/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375 h1:SjQ2+AKWgZLc1xej6WSzL+Dfs5Uyd5xcZH1mGC411IA=
 golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -926,9 +926,11 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20141024133853-64131543e789/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
@@ -939,6 +941,7 @@ gopkg.in/jcmturner/aescts.v1 v1.0.1 h1:cVVZBK2b1zY26haWB4vbBiZrfFQnfbTVrE3xZq6hr
 gopkg.in/jcmturner/aescts.v1 v1.0.1/go.mod h1:nsR8qBOg+OucoIW+WMhB3GspUQXq9XorLnQb9XtvcOo=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1 h1:cIuC1OLRGZrld+16ZJvvZxVJeKPsvd5eUIvxfoN5hSM=
 gopkg.in/jcmturner/dnsutils.v1 v1.0.1/go.mod h1:m3v+5svpVOhtFAP/wSz+yzh4Mc0Fg7eRhxkJMWSIz9Q=
+gopkg.in/jcmturner/goidentity.v3 v3.0.0 h1:1duIyWiTaYvVx3YX2CYtpJbUFd7/UuPYCfgXtQ3VTbI=
 gopkg.in/jcmturner/goidentity.v3 v3.0.0/go.mod h1:oG2kH0IvSYNIu80dVAyu/yoefjq1mNfM5bm88whjWx4=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0 h1:a9tsXlIDD9SKxotJMK3niV7rPZAJeX2aD/0yg3qlIrg=
 gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
@@ -951,6 +954,7 @@ gopkg.in/square/go-jose.v1 v1.1.2/go.mod h1:QpYS+a4WhS+DTlyQIi6Ka7MS3SuR9a055rgX
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.5.1 h1:7odma5RETjNHWJnR32wx8t+Io4djHE1PqxCFx3iiZ2w=
 gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
@@ -1010,6 +1014,7 @@ modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03
 modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
+rsc.io/letsencrypt v0.0.3 h1:H7xDfhkaFFSYEJlKeq38RwX2jYcnTeHuDQyT+mMNMwM=
 rsc.io/letsencrypt v0.0.3/go.mod h1:buyQKZ6IXrRnB7TdkHP0RyEybLx18HHyOSoTyoOLqNY=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/pkg/controller/snapshot/device/controller_test.go
+++ b/pkg/controller/snapshot/device/controller_test.go
@@ -291,7 +291,7 @@ func newSet(index networkchange.Index, device device.ID, path string, created ti
 			},
 			{
 				Path:  fmt.Sprintf("/%s/meaning", path),
-				Value: devicechange.NewTypedValueInt64(39 + len(path)),
+				Value: devicechange.NewTypedValueInt(39+len(path), 32),
 			},
 		},
 	})

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -279,7 +279,7 @@ func Test_SetNetworkConfig_Deep(t *testing.T) {
 
 	// Making change
 	updates := make(devicechange.TypedValueMap)
-	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint64(valueLeaf2A789)
+	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint(valueLeaf2A789, 16)
 	deletes := []string{test1Cont1ACont2ALeaf2C}
 	updatesForDevice1, deletesForDevice1, deviceInfo := makeDeviceChanges(device1, updates, deletes)
 
@@ -327,7 +327,7 @@ func Test_SetNetworkConfig_Deep(t *testing.T) {
 	for _, updatedVal := range updatedVals {
 		switch updatedVal.Path {
 		case test1Cont1ACont2ALeaf2A:
-			assert.Equal(t, (*devicechange.TypedUint64)(updatedVal.GetValue()).Uint(), valueLeaf2A789)
+			assert.Equal(t, (*devicechange.TypedUint)(updatedVal.GetValue()).Uint(), valueLeaf2A789)
 			assert.Equal(t, updatedVal.Removed, false)
 		case test1Cont1ACont2ALeaf2C:
 			assert.Equal(t, updatedVal.GetValue().ValueToString(), "")
@@ -348,8 +348,8 @@ func Test_SetNetworkConfig_ConfigOnly_Deep(t *testing.T) {
 
 	// Making change
 	updates := make(devicechange.TypedValueMap)
-	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint64(valueLeaf2A789)
-	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueDecimal64(1590, 3)
+	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint(valueLeaf2A789, 16)
+	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueDecimal(1590, 3)
 	deletes := []string{}
 	updatesForConfigOnlyDevice, deletesForConfigOnlyDevice, deviceInfo := makeDeviceChanges(deviceConfigOnly, updates, deletes)
 
@@ -393,7 +393,7 @@ func Test_SetNetworkConfig_ConfigOnly_Deep(t *testing.T) {
 	for _, updatedVal := range updatedVals {
 		switch updatedVal.Path {
 		case test1Cont1ACont2ALeaf2A:
-			assert.Equal(t, (*devicechange.TypedUint64)(updatedVal.GetValue()).Uint(), valueLeaf2A789)
+			assert.Equal(t, (*devicechange.TypedUint)(updatedVal.GetValue()).Uint(), valueLeaf2A789)
 			assert.Equal(t, updatedVal.Removed, false)
 		case test1Cont1ACont2ALeaf2B:
 			assert.Equal(t, updatedVal.GetValue().ValueToString(), "1.590")
@@ -445,8 +445,8 @@ func Test_SetNetworkConfig_Disconnected_Device(t *testing.T) {
 
 	// Making change
 	updates := make(devicechange.TypedValueMap)
-	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint64(valueLeaf2A789)
-	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueDecimal64(1590, 3)
+	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint(valueLeaf2A789, 16)
+	updates[test1Cont1ACont2ALeaf2B] = devicechange.NewTypedValueDecimal(1590, 3)
 	deletes := []string{}
 	updatesForDisconnectedDevice, deletesForDisconnectedDevice, deviceInfo := makeDeviceChanges(deviceDisconn, updates, deletes)
 	assert.Assert(t, updatesForDisconnectedDevice != nil)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -283,14 +283,14 @@ func setUp(t *testing.T) (*Manager, *AllMocks) {
 	return mgrTest, &allMocks
 }
 
-func makeDeviceChanges(device string, updates devicechange.TypedValueMap, deletes []string) (
-	map[string]devicechange.TypedValueMap, map[string][]string, map[devicetype.ID]cache.Info) {
+func makeDeviceChanges(device devicetype.ID, updates devicechange.TypedValueMap, deletes []string) (
+	map[devicetype.ID]devicechange.TypedValueMap, map[devicetype.ID][]string, map[devicetype.ID]cache.Info) {
 	deviceInfo := make(map[devicetype.ID]cache.Info)
-	deviceInfo[devicetype.ID(device)] = cache.Info{DeviceID: devicetype.ID(device), Type: deviceTypeTd, Version: deviceVersion1}
+	deviceInfo[device] = cache.Info{DeviceID: device, Type: deviceTypeTd, Version: deviceVersion1}
 
-	updatesForDevice := make(map[string]devicechange.TypedValueMap)
+	updatesForDevice := make(map[devicetype.ID]devicechange.TypedValueMap)
 	updatesForDevice[device] = updates
-	deletesForDevice := make(map[string][]string)
+	deletesForDevice := make(map[devicetype.ID][]string)
 	deletesForDevice[device] = deletes
 	return updatesForDevice, deletesForDevice, deviceInfo
 }
@@ -319,7 +319,7 @@ func Test_SetNetworkConfig(t *testing.T) {
 
 	// Making change
 	updates := make(devicechange.TypedValueMap)
-	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint64(valueLeaf2A789)
+	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint(valueLeaf2A789, 16)
 	deletes := []string{test1Cont1ACont2ALeaf2C}
 	updatesForDevice1, deletesForDevice1, deviceInfo := makeDeviceChanges(device1, updates, deletes)
 
@@ -341,7 +341,7 @@ func Test_SetNetworkConfig(t *testing.T) {
 
 	// Asserting update to 2A
 	assert.Equal(t, updatedVals[0].Path, test1Cont1ACont2ALeaf2A)
-	assert.Equal(t, (*devicechange.TypedUint64)(updatedVals[0].GetValue()).Uint(), valueLeaf2A789)
+	assert.Equal(t, (*devicechange.TypedUint)(updatedVals[0].GetValue()).Uint(), valueLeaf2A789)
 	assert.Equal(t, updatedVals[0].Removed, false)
 
 	// Asserting deletion of 2C
@@ -359,7 +359,7 @@ func Test_SetNetworkConfig_NewConfig(t *testing.T) {
 	const NetworkChangeAddDevice5 = "NetworkChangeAddDevice5"
 
 	updates := make(devicechange.TypedValueMap)
-	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint64(valueLeaf2A789)
+	updates[test1Cont1ACont2ALeaf2A] = devicechange.NewTypedValueUint(valueLeaf2A789, 16)
 	deletes := []string{test1Cont1ACont2ALeaf2C}
 
 	updatesForDevice, deletesForDevice, deviceInfo := makeDeviceChanges(Device5, updates, deletes)

--- a/pkg/manager/setconfig.go
+++ b/pkg/manager/setconfig.go
@@ -98,8 +98,8 @@ func (m *Manager) ValidateNetworkConfig(deviceName devicetype.ID, version device
 }
 
 // SetNetworkConfig creates and stores a new netork config for the given updates and deletes and targets
-func (m *Manager) SetNetworkConfig(targetUpdates map[string]devicechange.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info, netChangeID string) (*networkchange.NetworkChange, error) {
+func (m *Manager) SetNetworkConfig(targetUpdates map[devicetype.ID]devicechange.TypedValueMap,
+	targetRemoves map[devicetype.ID][]string, deviceInfo map[devicetype.ID]cache.Info, netChangeID string) (*networkchange.NetworkChange, error) {
 	//TODO evaluate need of user and add it back if need be.
 
 	allDeviceChanges, errChanges := m.computeNetworkConfig(targetUpdates, targetRemoves, deviceInfo, "")
@@ -119,17 +119,17 @@ func (m *Manager) SetNetworkConfig(targetUpdates map[string]devicechange.TypedVa
 }
 
 //computeNetworkConfig computes each device change
-func (m *Manager) computeNetworkConfig(targetUpdates map[string]devicechange.TypedValueMap,
-	targetRemoves map[string][]string, deviceInfo map[devicetype.ID]cache.Info,
+func (m *Manager) computeNetworkConfig(targetUpdates map[devicetype.ID]devicechange.TypedValueMap,
+	targetRemoves map[devicetype.ID][]string, deviceInfo map[devicetype.ID]cache.Info,
 	description string) ([]*devicechange.Change, error) {
 
 	deviceChanges := make([]*devicechange.Change, 0)
 	for target, updates := range targetUpdates {
 		//FIXME this is a sequential job, not parallelized
-		version := deviceInfo[devicetype.ID(target)].Version
-		deviceType := deviceInfo[devicetype.ID(target)].Type
+		version := deviceInfo[target].Version
+		deviceType := deviceInfo[target].Type
 		newChange, err := m.ComputeDeviceChange(
-			devicetype.ID(target), version, deviceType, updates, targetRemoves[target], description)
+			target, version, deviceType, updates, targetRemoves[target], description)
 		if err != nil {
 			log.Error("Error in setting config: ", newChange, " for target ", err)
 			continue
@@ -141,10 +141,10 @@ func (m *Manager) computeNetworkConfig(targetUpdates map[string]devicechange.Typ
 
 	// Some targets might only have removes
 	for target, removes := range targetRemoves {
-		version := deviceInfo[devicetype.ID(target)].Version
-		deviceType := deviceInfo[devicetype.ID(target)].Type
+		version := deviceInfo[target].Version
+		deviceType := deviceInfo[target].Type
 		newChange, err := m.ComputeDeviceChange(
-			devicetype.ID(target), version, deviceType, make(devicechange.TypedValueMap), removes, description)
+			target, version, deviceType, make(devicechange.TypedValueMap), removes, description)
 		if err != nil {
 			log.Error("Error in setting config: ", newChange, " for target ", err)
 			continue

--- a/pkg/modelregistry/jsonvalues/convertJsonDs1_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonDs1_test.go
@@ -72,7 +72,7 @@ func Test_correctJsonPathValues2(t *testing.T) {
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=10]/state/priority",
 			"/system/openflow/controllers/controller[name=second]/connections/connection[aux-id=11]/state/priority":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_UINT, pathValue.Path)
-			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 0)
+			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 1)
 		default:
 			t.Fatal("Unexpected path", pathValue.Path)
 		}
@@ -111,7 +111,7 @@ func Test_correctJsonPathRwValuesSubInterfaces(t *testing.T) {
 			"/interfaces/interface[name=eth1]/hold-time/config/down",
 			"/interfaces/interface[name=eth1]/hold-time/config/up":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_UINT, pathValue.Path)
-			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 0)
+			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 1)
 		default:
 			t.Fatal("Unexpected path", pathValue.Path)
 		}

--- a/pkg/modelregistry/jsonvalues/convertJsonTd2_test.go
+++ b/pkg/modelregistry/jsonvalues/convertJsonTd2_test.go
@@ -98,10 +98,10 @@ func Test_DecomposeJSONWithPathsTd2_config(t *testing.T) {
 		case
 			"/cont1a/cont2a/leaf2e":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_LEAFLIST_INT, pathValue.Path)
-			leaf2eLl := (*devicechange.TypedLeafListInt64)(pathValue.Value)
-			assert.Equal(t, 5, len(leaf2eLl.List()))
-			assert.Equal(t, 5, leaf2eLl.List()[0])
-			assert.Equal(t, 1, leaf2eLl.List()[4])
+			leaf2eLl, width := (*devicechange.TypedLeafListInt)(pathValue.Value).List()
+			assert.Equal(t, devicechange.WidthThirtyTwo, width)
+			assert.Equal(t, 5, len(leaf2eLl))
+			assert.DeepEqual(t, []int64{5, 4, 3, 2, 1}, leaf2eLl)
 		case
 			"/cont1a/cont2a/leaf2a",
 			"/cont1a/list2a[name=l2a1]/tx-power",
@@ -225,7 +225,7 @@ func Test_DecomposeJSONWithPathsTd2OpState(t *testing.T) {
 		case
 			"/cont1b-state/leaf2d":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_UINT, pathValue.Path)
-			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 0)
+			assert.Equal(t, len(pathValue.GetValue().GetTypeOpts()), 1)
 		case
 			"/cont1b-state/cont2c/leaf3a":
 			assert.Equal(t, pathValue.GetValue().GetType(), devicechange.ValueType_BOOL, pathValue.Path)

--- a/pkg/modelregistry/jsonvalues/jsonToValues_test.go
+++ b/pkg/modelregistry/jsonvalues/jsonToValues_test.go
@@ -140,7 +140,7 @@ func Test_findModelRoPathNoIndices(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.Equal(t, modelPath, fullpath)
 	assert.Assert(t, roAttr != nil, "roAttr map not expected to be nil")
-	assert.Equal(t, devicechange.ValueType_STRING, roAttr.Datatype)
+	assert.Equal(t, devicechange.ValueType_STRING, roAttr.ValueType)
 }
 
 func Test_stripNamespace(t *testing.T) {
@@ -200,8 +200,8 @@ func Test_replaceIndices(t *testing.T) {
 
 	indices := make([]indexValue, 0)
 	indices = append(indices, indexValue{"a", devicechange.NewTypedValueString("12"), 0})
-	indices = append(indices, indexValue{"b", devicechange.NewTypedValueUint64(34), 1})
-	indices = append(indices, indexValue{"c", devicechange.NewTypedValueInt64(56), 2})
+	indices = append(indices, indexValue{"b", devicechange.NewTypedValueUint(34, 8), 1})
+	indices = append(indices, indexValue{"c", devicechange.NewTypedValueInt(56, 8), 2})
 	indices = append(indices, indexValue{"d", devicechange.NewTypedValueString("78"), 3})
 	indices = append(indices, indexValue{"e", devicechange.NewTypedValueString("9"), 4})
 	indices = append(indices, indexValue{"f", devicechange.NewTypedValueString("10"), 5})

--- a/pkg/modelregistry/modelregistryTestDevice1_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice1_test.go
@@ -49,7 +49,7 @@ func Test_SchemaTestDevice1(t *testing.T) {
 	assert.Equal(t, len(leaf2c), 1, "expected /cont1a/cont2a/leaf2c to have only 1 subpath")
 	leaf2cVt, leaf2cVtOk := leaf2c["/"]
 	assert.Assert(t, leaf2cVtOk, "expected /cont1a/cont2a/leaf2c to have subpath /")
-	assert.Equal(t, leaf2cVt.Datatype, devicechange.ValueType_STRING)
+	assert.Equal(t, leaf2cVt.ValueType, devicechange.ValueType_STRING)
 	assert.Equal(t, leaf2cVt.Description, "") // TODO: When YGOT is updated to extract description then update this
 	assert.Equal(t, leaf2cVt.Units, "")
 
@@ -59,15 +59,15 @@ func Test_SchemaTestDevice1(t *testing.T) {
 
 	cont1bVt, cont1bVtOk := cont1b["/leaf2d"]
 	assert.Assert(t, cont1bVtOk, "expected /cont1b-state to have subpath /leaf2d")
-	assert.Equal(t, cont1bVt.Datatype, devicechange.ValueType_UINT)
+	assert.Equal(t, cont1bVt.ValueType, devicechange.ValueType_UINT)
 
 	l2bIdxVt, l2bIdxVtOk := cont1b["/list2b[index=*]/index"]
 	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
-	assert.Equal(t, l2bIdxVt.Datatype, devicechange.ValueType_UINT)
+	assert.Equal(t, l2bIdxVt.ValueType, devicechange.ValueType_UINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1b["/list2b[index=*]/leaf3c"]
 	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
-	assert.Equal(t, l2bLeaf3cVt.Datatype, devicechange.ValueType_STRING)
+	assert.Equal(t, l2bLeaf3cVt.ValueType, devicechange.ValueType_STRING)
 
 	////////////////////////////////////////////////////
 	/// Read write paths

--- a/pkg/modelregistry/modelregistryTestDevice2_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice2_test.go
@@ -46,7 +46,7 @@ func Test_SchemaTestDevice2(t *testing.T) {
 	assert.Equal(t, len(leaf2c), 1, "expected /cont1a/cont2a/leaf2c to have only 1 subpath")
 	leaf2cVt, leaf2cVtOk := leaf2c["/"]
 	assert.Assert(t, leaf2cVtOk, "expected /cont1a/cont2a/leaf2c to have subpath /")
-	assert.Equal(t, leaf2cVt.Datatype, devicechange.ValueType_STRING)
+	assert.Equal(t, leaf2cVt.ValueType, devicechange.ValueType_STRING)
 
 	cont1bState, cont1bStateOk := readOnlyPathsTestDevice2["/cont1b-state"]
 	assert.Assert(t, cont1bStateOk, "expected to get /cont1b-state")
@@ -54,15 +54,15 @@ func Test_SchemaTestDevice2(t *testing.T) {
 
 	cont1bVt, cont1bVtOk := cont1bState["/leaf2d"]
 	assert.Assert(t, cont1bVtOk, "expected /cont1b-state to have subpath /leaf2d")
-	assert.Equal(t, cont1bVt.Datatype, devicechange.ValueType_UINT)
+	assert.Equal(t, cont1bVt.ValueType, devicechange.ValueType_UINT)
 
 	l2bIdxVt, l2bIdxVtOk := cont1bState["/list2b[index1=*][index2=*]/index2"]
 	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
-	assert.Equal(t, l2bIdxVt.Datatype, devicechange.ValueType_UINT)
+	assert.Equal(t, l2bIdxVt.ValueType, devicechange.ValueType_UINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1bState["/list2b[index1=*][index2=*]/leaf3c"]
 	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
-	assert.Equal(t, l2bLeaf3cVt.Datatype, devicechange.ValueType_STRING)
+	assert.Equal(t, l2bLeaf3cVt.ValueType, devicechange.ValueType_STRING)
 
 	////////////////////////////////////////////////////
 	/// Read write paths

--- a/pkg/modelregistry/modelregistry_test.go
+++ b/pkg/modelregistry/modelregistry_test.go
@@ -637,11 +637,11 @@ func Test_NtpServer(t *testing.T) {
 	for p, v := range readOnlyPaths[k] {
 		switch p {
 		case "/address", "/association-type", "/port":
-			assert.Equal(t, int(v.Datatype), 1, "Unexpected type %i for %s", v, p)
+			assert.Equal(t, int(v.ValueType), 1, "Unexpected type %i for %s", v, p)
 		case "/iburst", "/prefer":
-			assert.Equal(t, int(v.Datatype), 4, "Unexpected type %i for %s", v, p)
+			assert.Equal(t, int(v.ValueType), 4, "Unexpected type %i for %s", v, p)
 		case "/offset", "/poll-interval", "/root-delay", "/root-dispersion", "/stratum", "/version":
-			assert.Equal(t, int(v.Datatype), 3, "Unexpected type %i for %s", v, p)
+			assert.Equal(t, int(v.ValueType), 3, "Unexpected type %i for %s", v, p)
 		default:
 			t.Fatalf("Unexpected readOnlyPath sub path %s for %s. %v", p, k, v)
 		}

--- a/pkg/northbound/admin/admin.go
+++ b/pkg/northbound/admin/admin.go
@@ -56,7 +56,7 @@ type Server struct {
 
 // UploadRegisterModel uploads and registers a new model plugin.
 func (s Server) UploadRegisterModel(stream admin.ConfigAdminService_UploadRegisterModelServer) error {
-	response := admin.RegisterResponse{Name: "Unknown"}
+	response := admin.RegisterResponse{Name: "WidthUnknown"}
 	soFileName := ""
 
 	const TEMPFILE = "/tmp/uploaded_model_plugin.tmp"
@@ -135,7 +135,7 @@ func (s Server) ListRegisteredModels(req *admin.ListModelsRequest, stream admin.
 					for subPath, subPathType := range subpathList {
 						subPathPb := admin.ReadOnlySubPath{
 							SubPath:   subPath,
-							ValueType: subPathType.Datatype,
+							ValueType: subPathType.ValueType,
 						}
 						subPathsPb = append(subPathsPb, &subPathPb)
 					}

--- a/pkg/northbound/admin/admin_test.go
+++ b/pkg/northbound/admin/admin_test.go
@@ -178,8 +178,8 @@ func generateSnapshotData(count int) []*devicesnapshot.Snapshot {
 			SnapshotID:    "test-snapshot",
 			ChangeIndex:   device2.Index(shIdx),
 			Values: []*device2.PathValue{
-				{Path: "/a/b/c", Value: device2.NewTypedValueInt64(shIdx)},
-				{Path: "/a/b/d", Value: device2.NewTypedValueInt64(10 * shIdx)},
+				{Path: "/a/b/c", Value: device2.NewTypedValueInt(shIdx, 32)},
+				{Path: "/a/b/d", Value: device2.NewTypedValueInt(10*shIdx, 32)},
 			},
 		}
 	}

--- a/pkg/northbound/gnmi/get_test.go
+++ b/pkg/northbound/gnmi/get_test.go
@@ -95,7 +95,7 @@ func Test_getNoPathElems(t *testing.T) {
 
 // Test_getAllDevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevices(t *testing.T) {
-	server, _ := setUpForGetSetTests(t)
+	server, _, _ := setUpForGetSetTests(t)
 
 	allDevicesPath := gnmi.Path{Elem: make([]*gnmi.PathElem, 0), Target: "*"}
 
@@ -117,7 +117,7 @@ func Test_getAllDevices(t *testing.T) {
 
 // Test_getalldevices is where a wildcard is used for target - path is ignored
 func Test_getAllDevicesInPrefix(t *testing.T) {
-	server, _ := setUpForGetSetTests(t)
+	server, _, _ := setUpForGetSetTests(t)
 
 	request := gnmi.GetRequest{
 		Prefix: &gnmi.Path{Target: "*"},

--- a/pkg/northbound/gnmi/set.go
+++ b/pkg/northbound/gnmi/set.go
@@ -17,7 +17,6 @@ package gnmi
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	devicechange "github.com/onosproject/onos-api/go/onos/config/change/device"
@@ -35,8 +34,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type mapTargetUpdates map[string]devicechange.TypedValueMap
-type mapTargetRemoves map[string][]string
+type mapTargetUpdates map[devicetype.ID]devicechange.TypedValueMap
+type mapTargetRemoves map[devicetype.ID][]string
+type mapTargetModels map[devicetype.ID]modelregistry.ReadWritePathMap
 
 // Set implements gNMI Set
 func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetResponse, error) {
@@ -50,36 +50,43 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 
 	targetUpdates := make(mapTargetUpdates)
 	targetRemoves := make(mapTargetRemoves)
+	targetModels := make(mapTargetModels)
+
+	netCfgChangeName, version, deviceType, err := extractExtensions(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	log.Infof("gNMI Set Request %v", req)
-	//Update
+	prefixTarget := devicetype.ID(req.GetPrefix().GetTarget())
+
+	//Update - extract targets and their models
 	for _, u := range req.GetUpdate() {
-		target := u.Path.GetTarget()
+		target := devicetype.ID(u.Path.GetTarget())
 		if target == "" { //Try the prefix
-			target = req.GetPrefix().GetTarget()
+			target = prefixTarget
 		}
-		if target == "" {
-			return nil, status.Error(codes.InvalidArgument, "no target given in update")
-		}
-		var err error
-		targetUpdates[target], err = s.formatUpdateOrReplace(req.GetPrefix(), u, targetUpdates)
+		rwPaths, err := extractModelForTarget(target, version, deviceType, targetModels)
 		if err != nil {
-			log.Warn("Error in update ", err)
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, err
+		}
+		targetUpdates[target], err = s.formatUpdateOrReplace(req.GetPrefix(), u, targetUpdates, rwPaths)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	//Replace
 	for _, u := range req.GetReplace() {
-		target := u.Path.GetTarget()
+		target := devicetype.ID(u.Path.GetTarget())
 		if target == "" { //Try the prefix
-			target = req.GetPrefix().GetTarget()
+			target = prefixTarget
 		}
-		if target == "" {
-			return nil, status.Errorf(codes.InvalidArgument, "No target given in update %v", u)
+		rwPaths, err := extractModelForTarget(target, version, deviceType, targetModels)
+		if err != nil {
+			return nil, err
 		}
-		var err error
-		targetUpdates[target], err = s.formatUpdateOrReplace(req.GetPrefix(), u, targetUpdates)
+		targetUpdates[target], err = s.formatUpdateOrReplace(req.GetPrefix(), u, targetUpdates, rwPaths)
 		if err != nil {
 			log.Warn("Error in replace", err)
 			return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -88,19 +95,18 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 
 	//Delete
 	for _, u := range req.GetDelete() {
-		target := u.GetTarget()
+		target := devicetype.ID(u.GetTarget())
 		if target == "" { //Try the prefix
-			target = req.GetPrefix().GetTarget()
+			target = prefixTarget
 		}
-		if target == "" {
-			return nil, status.Errorf(codes.InvalidArgument, "No target given in delete %v", u)
+		rwPaths, err := extractModelForTarget(target, version, deviceType, targetModels)
+		if err != nil {
+			return nil, err
 		}
-		targetRemoves[target] = s.doDelete(req.GetPrefix(), u, targetRemoves)
-	}
-
-	netCfgChangeName, version, deviceType, err := extractExtensions(req)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+		targetRemoves[target], err = s.doDelete(req.GetPrefix(), u, targetRemoves, rwPaths)
+		if err != nil {
+			return nil, fmt.Errorf("doDelete() %s", err.Error())
+		}
 	}
 
 	//Temporary map in order to not to modify the original removes but optimize calculations during validation
@@ -117,12 +123,12 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 	deviceInfo := make(map[devicetype.ID]cache.Info)
 	//Checking for wrong configuration against the device models for updates
 	for target, updates := range targetUpdates {
-		deviceType, version, err = mgr.CheckCacheForDevice(devicetype.ID(target), deviceType, version)
+		deviceType, version, err = mgr.CheckCacheForDevice(target, deviceType, version)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		deviceInfo[devicetype.ID(target)] = cache.Info{
-			DeviceID: devicetype.ID(target),
+		deviceInfo[target] = cache.Info{
+			DeviceID: target,
 			Type:     deviceType,
 			Version:  version,
 		}
@@ -134,21 +140,16 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-
-		err = s.checkForReadOnly(target, deviceType, version, updates, targetRemoves[target])
-		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
 		delete(targetRemovesTmp, target)
 	}
 	//Checking for wrong configuration against the device models for deletes
 	for target, removes := range targetRemovesTmp {
-		deviceType, version, err = mgr.CheckCacheForDevice(devicetype.ID(target), deviceType, version)
+		deviceType, version, err = mgr.CheckCacheForDevice(target, deviceType, version)
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		deviceInfo[devicetype.ID(target)] = cache.Info{
-			DeviceID: devicetype.ID(target),
+		deviceInfo[target] = cache.Info{
+			DeviceID: target,
 			Type:     deviceType,
 			Version:  version,
 		}
@@ -160,16 +161,10 @@ func (s *Server) Set(ctx context.Context, req *gnmi.SetRequest) (*gnmi.SetRespon
 		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-
-		err = s.checkForReadOnly(target, deviceType, version, make(devicechange.TypedValueMap), removes)
-		if err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
 	}
 
 	// Creating and setting the config on the atomix Store
 	change, errSet := mgr.SetNetworkConfig(targetUpdates, targetRemoves, deviceInfo, netCfgChangeName)
-
 	if errSet != nil {
 		log.Errorf("Error while setting config in atomix %s", errSet.Error())
 		return nil, status.Error(codes.Internal, errSet.Error())
@@ -248,10 +243,10 @@ func extractExtensions(req *gnmi.SetRequest) (string, devicetype.Version, device
 // This deals with either a path and a value (simple case) or a path with
 // a JSON body which implies multiple paths and values.
 func (s *Server) formatUpdateOrReplace(prefix *gnmi.Path, u *gnmi.Update,
-	targetUpdates mapTargetUpdates) (devicechange.TypedValueMap, error) {
-	target := u.Path.GetTarget()
+	targetUpdates mapTargetUpdates, rwPaths modelregistry.ReadWritePathMap) (devicechange.TypedValueMap, error) {
+	target := devicetype.ID(u.Path.GetTarget())
 	if target == "" {
-		target = prefix.GetTarget()
+		target = devicetype.ID(prefix.GetTarget())
 	}
 	prefixPath := utils.StrPath(prefix)
 	path := utils.StrPath(u.Path)
@@ -269,25 +264,6 @@ func (s *Server) formatUpdateOrReplace(prefix *gnmi.Path, u *gnmi.Update,
 		log.Infof("Processing Json Value in set from base %s: %s",
 			path, string(jsonVal))
 
-		var rwPaths modelregistry.ReadWritePathMap
-		infos := manager.GetManager().DeviceCache.GetDevicesByID(devicetype.ID(target))
-		if len(infos) == 0 {
-			return nil, fmt.Errorf("cannot process JSON payload because "+
-				"device %s is not in DeviceCache", target)
-		}
-		// Iterate through configs to find match for target
-		for _, info := range infos {
-			rwPaths, ok = manager.GetManager().ModelRegistry.
-				ModelReadWritePaths[utils.ToModelName(info.Type, info.Version)]
-			if ok {
-				break
-			}
-		}
-		if rwPaths == nil {
-			return nil, fmt.Errorf("cannot process JSON payload because "+
-				"Model Plugin not available for target %s", target)
-		}
-
 		pathValues, err := jsonvalues.DecomposeJSONWithPaths(path, jsonVal, nil, rwPaths)
 		if err != nil {
 			log.Warnf("Json value in Set could not be parsed %v", err)
@@ -300,8 +276,11 @@ func (s *Server) formatUpdateOrReplace(prefix *gnmi.Path, u *gnmi.Update,
 			updates[cv.Path] = cv.GetValue()
 		}
 	} else {
-
-		update, err := values.GnmiTypedValueToNativeType(u.Val)
+		rwPathElem, err := findPathFromModel(path, rwPaths)
+		if err != nil {
+			return nil, err
+		}
+		update, err := values.GnmiTypedValueToNativeType(u.Val, rwPathElem)
 		if err != nil {
 			return nil, err
 		}
@@ -312,10 +291,12 @@ func (s *Server) formatUpdateOrReplace(prefix *gnmi.Path, u *gnmi.Update,
 
 }
 
-func (s *Server) doDelete(prefix *gnmi.Path, u *gnmi.Path, targetRemoves mapTargetRemoves) []string {
-	target := u.GetTarget()
+func (s *Server) doDelete(prefix *gnmi.Path, u *gnmi.Path,
+	targetRemoves mapTargetRemoves, rwPaths modelregistry.ReadWritePathMap) ([]string, error) {
+
+	target := devicetype.ID(u.GetTarget())
 	if target == "" {
-		target = prefix.GetTarget()
+		target = devicetype.ID(prefix.GetTarget())
 	}
 	deletes, ok := targetRemoves[target]
 	if !ok {
@@ -326,82 +307,14 @@ func (s *Server) doDelete(prefix *gnmi.Path, u *gnmi.Path, targetRemoves mapTarg
 	if prefixPath != "/" {
 		path = fmt.Sprintf("%s%s", prefixPath, path)
 	}
+	// Checks for read only paths
+	_, err := findPathFromModel(path, rwPaths)
+	if err != nil {
+		return nil, err
+	}
 	deletes = append(deletes, path)
-	return deletes
+	return deletes, nil
 
-}
-
-// iterate through the updates and check that none of them include a `set` of a
-// readonly attribute - this is done by checking with the relevant model
-func (s *Server) checkForReadOnly(target string, deviceType devicetype.Type, version devicetype.Version,
-	targetUpdates devicechange.TypedValueMap, targetRemoves []string) error {
-
-	modelreg := manager.GetManager().ModelRegistry
-
-	// This ignores versions - if it's RO in one version will be regarded
-	// as RO in all versions - very unlikely that modelRoPaths would change
-	// YANG items from `config false` to `config true` across versions
-	modelRoPaths, ok := modelreg.
-		ModelReadOnlyPaths[utils.ToModelName(deviceType, version)]
-	if !ok {
-		log.Warnf("Cannot check for Read Only paths for %s %s because "+
-			"Model Plugin not available - continuing", deviceType, version)
-		return nil
-	}
-
-	modelRwPaths, ok := modelreg.
-		ModelReadWritePaths[utils.ToModelName(deviceType, version)]
-	if !ok {
-		log.Warnf("Cannot check for Read Only paths for %s %s because "+
-			"Model Plugin not available - continuing", deviceType, version)
-		return nil
-	}
-
-	// Now iterate through the consolidated set of targets and see if any are read-only paths
-	for path := range targetUpdates { // map - just need the key
-		if err := compareRoPaths(path, modelRoPaths, modelRwPaths); err != nil {
-			return fmt.Errorf("update %s", err)
-		}
-	}
-
-	// Now iterate through the consolidated set of targets and see if any are read-only paths
-	for _, path := range targetRemoves { // map - just need the key
-		if err := compareRoPaths(path, modelRoPaths, modelRwPaths); err != nil {
-			return fmt.Errorf("remove %s", err)
-		}
-	}
-
-	return nil
-}
-
-func compareRoPaths(path string, modelRoPaths modelregistry.ReadOnlyPathMap, modelRwPaths modelregistry.ReadWritePathMap) error {
-	log.Infof("Testing %s for read only", path)
-	for ropath, subpaths := range modelRoPaths {
-		// Search through for list indices and replace with generic
-		modelPathNiIdx := modelregistry.RemovePathIndices(path)
-		ropathNoIdx := modelregistry.RemovePathIndices(ropath)
-		if strings.HasPrefix(modelPathNiIdx, ropathNoIdx) {
-			for s := range subpaths {
-				fullpath := ropathNoIdx
-				if s != "/" {
-					fullpath = fmt.Sprintf("%s%s", ropathNoIdx, s)
-				}
-				if fullpath == modelPathNiIdx {
-					// Check that this is not one of those in both config and state (e.g. index of a list)
-					for rwpath := range modelRwPaths {
-						rwpathNoIdx := modelregistry.RemovePathIndices(rwpath)
-						if rwpathNoIdx == modelPathNiIdx {
-							return nil
-						}
-					}
-					return fmt.Errorf("contains a change to a "+
-						"read only path %s. Rejected. %s, %s, %s, %s, %s",
-						path, modelPathNiIdx, ropath, ropathNoIdx, s, fullpath)
-				}
-			}
-		}
-	}
-	return nil
 }
 
 func buildUpdateResult(pathStr string, target string, op gnmi.UpdateResult_Operation) (*gnmi.UpdateResult, error) {
@@ -419,13 +332,13 @@ func buildUpdateResult(pathStr string, target string, op gnmi.UpdateResult_Opera
 
 }
 
-func validateChange(target string, deviceType devicetype.Type, version devicetype.Version,
+func validateChange(target devicetype.ID, deviceType devicetype.Type, version devicetype.Version,
 	targetUpdates devicechange.TypedValueMap, targetRemoves []string, lastWrite networkchange.Revision) error {
 	if len(targetUpdates) == 0 && len(targetRemoves) == 0 {
 		return fmt.Errorf("no updates found in change on %s - invalid", target)
 	}
 	log.Infof("Validating change %s:%s:%s", target, deviceType, version)
-	errValidation := manager.GetManager().ValidateNetworkConfig(devicetype.ID(target), version, deviceType,
+	errValidation := manager.GetManager().ValidateNetworkConfig(target, version, deviceType,
 		targetUpdates, targetRemoves, lastWrite)
 	if errValidation != nil {
 		log.Errorf("Error in validating config, updates %s, removes %s for target %s, err: %s", targetUpdates,
@@ -434,4 +347,49 @@ func validateChange(target string, deviceType devicetype.Type, version devicetyp
 	}
 	log.Infof("Validating change %s:%s:%s DONE", target, deviceType, version)
 	return nil
+}
+
+func extractModelForTarget(target devicetype.ID,
+	ext101Version devicetype.Version, ext102Type devicetype.Type,
+	targetModels mapTargetModels) (modelregistry.ReadWritePathMap, error) {
+
+	if target == "" {
+		return nil, status.Error(codes.InvalidArgument, "no target given")
+	}
+	if rwPaths, hasModel := targetModels[target]; hasModel {
+		return rwPaths, nil
+	}
+
+	actualType, actualVersion, err := manager.GetManager().CheckCacheForDevice(target, ext102Type, ext101Version)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	modelName := utils.ToModelName(actualType, actualVersion)
+	rwPaths, ok := manager.GetManager().ModelRegistry.ModelReadWritePaths[modelName]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"unable to find model registry for %s (for target %s)", modelName, target)
+	}
+	targetModels[target] = rwPaths
+	return rwPaths, nil
+}
+
+func findPathFromModel(path string, rwPaths modelregistry.ReadWritePathMap) (*modelregistry.ReadWritePathElem, error) {
+	searchpathNoIndices := modelregistry.RemovePathIndices(path)
+	// First search through the RW paths
+	var rwPathElem modelregistry.ReadWritePathElem
+	var ok bool
+	for modelPath, modelElem := range rwPaths {
+		pathNoIndices := modelregistry.RemovePathIndices(modelPath)
+		// Find a short path
+		if pathNoIndices == searchpathNoIndices {
+			rwPathElem = modelElem
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return nil, fmt.Errorf("unable to find RW model path %s", path)
+	}
+	return &rwPathElem, nil
 }

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -334,7 +334,8 @@ func (sync Synchronizer) opCacheUpdate(notifications []*gnmi.Notification,
 					sync.operationalCache[cv.Path] = value
 				}
 			} else if sync.encoding == gnmi.Encoding_PROTO {
-				typedVal, err := values.GnmiTypedValueToNativeType(update.Val)
+				// TODO: Look up the model path from the update.Path
+				typedVal, err := values.GnmiTypedValueToNativeType(update.Val, nil)
 				if err != nil {
 					log.Warn("Error converting gnmi value to Typed"+
 						" Value", update.Val, " for ", update.Path)
@@ -462,7 +463,8 @@ func (sync *Synchronizer) opStateSubHandler(msg proto.Message) error {
 
 			// FIXME: this is a hack to ignore bogus values in phantom notifications coming from Stratum for some reason
 			if valStr != "unsupported yet" {
-				val, err := values.GnmiTypedValueToNativeType(update.Val)
+				// TODO: Look up the model path from the update.Path
+				val, err := values.GnmiTypedValueToNativeType(update.Val, nil)
 				if err != nil {
 					return fmt.Errorf("can't translate to Typed value %s", err)
 				}

--- a/pkg/southbound/synchronizer/synchronizer_test.go
+++ b/pkg/southbound/synchronizer/synchronizer_test.go
@@ -83,12 +83,15 @@ func synchronizerSetUp(t *testing.T) (synchronizerParameters, error) {
 	// See modelplugin/yang/TestDevice-1.0.0/test1@2018-02-20.yang for paths
 	roPathMap := make(modelregistry.ReadOnlyPathMap)
 	roSubPath1 := make(modelregistry.ReadOnlySubPathMap)
-	roSubPath1["/"] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
+	roSubPath1["/"] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
 	roPathMap[cont1aCont2aLeaf2c] = roSubPath1
 	roSubPath2 := make(modelregistry.ReadOnlySubPathMap)
-	roSubPath2[leaf2d] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath2[list2bWcLeaf3c] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath2[list2bWcIndex] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
+	roSubPath2[leaf2d] = modelregistry.ReadOnlyAttrib{
+		ValueType: devicechange.ValueType_UINT,
+		TypeOpts:  []uint8{uint8(devicechange.WidthSixteen)},
+	}
+	roSubPath2[list2bWcLeaf3c] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath2[list2bWcIndex] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
 	roPathMap[cont1bState] = roSubPath2
 
 	ctrl := gomock.NewController(t)
@@ -341,7 +344,7 @@ func setUpStatePaths(t *testing.T) (*gnmi.Path, *gnmi.TypedValue, *gnmi.Path, *g
 	assert.NilError(t, err)
 	opPath, err := utils.ParseGNMIElements(utils.SplitPath(cont1bState + leaf2d))
 	assert.NilError(t, err)
-	opValue, err := values.NativeTypeToGnmiTypedValue(devicechange.NewTypedValueUint64(10002))
+	opValue, err := values.NativeTypeToGnmiTypedValue(devicechange.NewTypedValueUint(10002, 16))
 	assert.NilError(t, err)
 	return statePath, stateValue, opPath, opValue
 }
@@ -632,27 +635,27 @@ func Test_LikeStratum(t *testing.T) {
 	// See modelplugin/yang/TestDevice-1.0.0/test1@2018-02-20.yang for paths
 	roPathMap := make(modelregistry.ReadOnlyPathMap)
 	roSubPath1 := make(modelregistry.ReadOnlySubPathMap)
-	roSubPath1[ifIndex] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[ifName] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath1[adminStatus] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath1[hardwarePort] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath1[healthIndicator] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath1[lastChange] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath1[operStatus] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_STRING}
-	roSubPath1[countersInBroadcastPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInDiscards] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInErrors] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInFcsErrors] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInMcastPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInOctets] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInUnicastPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInUnknPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersInBcastPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersOutDiscards] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersOutErrs] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersOutMcastPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersOutOctets] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
-	roSubPath1[countersOutUcastPkts] = modelregistry.ReadOnlyAttrib{Datatype: devicechange.ValueType_UINT}
+	roSubPath1[ifIndex] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[ifName] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath1[adminStatus] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath1[hardwarePort] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath1[healthIndicator] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath1[lastChange] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath1[operStatus] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_STRING}
+	roSubPath1[countersInBroadcastPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInDiscards] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInErrors] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInFcsErrors] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInMcastPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInOctets] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInUnicastPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInUnknPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersInBcastPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersOutDiscards] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersOutErrs] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersOutMcastPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersOutOctets] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
+	roSubPath1[countersOutUcastPkts] = modelregistry.ReadOnlyAttrib{ValueType: devicechange.ValueType_UINT}
 	roPathMap[interfacesInterfaceWcState] = roSubPath1
 
 	opstateChan := make(chan events.OperationalStateEvent)

--- a/pkg/store/change/device/utils/utils_test.go
+++ b/pkg/store/change/device/utils/utils_test.go
@@ -76,14 +76,14 @@ var Config1Paths = [11]string{
 var Config1Values = [11][]byte{
 	make([]byte, 0), // 0
 	make([]byte, 0),
-	{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
-	{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
-	{100, 101, 102},              // ValueLeaf2CDef
-	{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
+	{13}, // ValueLeaf2A13
+	{1, 10, 0, 0, 0, 53, 0, 0, 0, 2, 201, 15, 207, 128, 220, 51, 112, 0}, // ValueLeaf2B314 3
+	{100, 101, 102},             // ValueLeaf2CDef
+	{97, 98, 99, 100, 101, 102}, // ValueLeaf1AAbcdef 5
 	make([]byte, 0),
-	{8, 0, 0, 0, 0, 0, 0, 0},         // ValueTxout1Txpwr8
+	{8},                              // ValueTxout1Txpwr8
 	make([]byte, 0),                  // 10
-	{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout3Txpwr16
+	{16},                             // ValueTxout3Txpwr16
 	{87, 88, 89, 45, 49, 50, 51, 52}, // ValueLeaftopWxy1234
 }
 
@@ -120,16 +120,16 @@ var Config1PreviousPaths = [13]string{
 var Config1PreviousValues = [13][]byte{
 	{}, // 0
 	{},
-	{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
-	{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
-	{97, 98, 99},                 // ValueLeaf2CAbc
-	{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
+	{13}, // ValueLeaf2A13
+	{1, 10, 0, 0, 0, 53, 0, 0, 0, 2, 201, 15, 207, 128, 220, 51, 112, 0}, // ValueLeaf2B314 3
+	{97, 98, 99},                // ValueLeaf2CAbc
+	{97, 98, 99, 100, 101, 102}, // ValueLeaf1AAbcdef 5
 	{},
-	{8, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
+	{8}, // ValueTxout1Txpwr8
 	{},
-	{10, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
+	{10},                             // ValueTxout2Txpwr10
 	{},                               // 10
-	{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout3Txpwr16,
+	{16},                             // ValueTxout3Txpwr16,
 	{87, 88, 89, 45, 49, 50, 51, 52}, // ValueLeaftopWxy1234,
 }
 
@@ -166,14 +166,14 @@ var Config1FirstPaths = [11]string{
 var Config1FirstValues = [11][]byte{
 	{}, // 0
 	{},
-	{13, 0, 0, 0, 0, 0, 0, 0},        // ValueLeaf2A13
-	{0, 0, 0, 128, 149, 67, 249, 63}, // ValueLeaf2B159 3
-	{97, 98, 99},                     // ValueLeaf2CAbc
-	{97, 98, 99, 100, 101, 102},      // ValueLeaf1AAbcdef 5
+	{13}, // ValueLeaf2A13
+	{1, 10, 0, 0, 0, 53, 0, 0, 0, 1, 202, 28, 172, 8, 49, 38, 232, 0}, // ValueLeaf2B159 3
+	{97, 98, 99},                // ValueLeaf2CAbc
+	{97, 98, 99, 100, 101, 102}, // ValueLeaf1AAbcdef 5
 	{},
-	{8, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
+	{8}, // ValueTxout1Txpwr8
 	{},
-	{10, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
+	{10},                             // ValueTxout2Txpwr10
 	{87, 88, 89, 45, 49, 50, 51, 52}, //ValueLeaftopWxy1234, 10
 }
 
@@ -208,14 +208,14 @@ var Config2Paths = [11]string{
 var Config2Values = [11][]byte{
 	{}, // 0
 	{},
-	{13, 0, 0, 0, 0, 0, 0, 0},    // ValueLeaf2A13
-	{0, 0, 0, 0, 250, 33, 9, 64}, // ValueLeaf2B314 3
-	{103, 104, 105},              // ValueLeaf2CGhi
-	{97, 98, 99, 100, 101, 102},  // ValueLeaf1AAbcdef 5
+	{13}, // ValueLeaf2A13
+	{1, 10, 0, 0, 0, 53, 0, 0, 0, 2, 201, 15, 207, 128, 220, 51, 112, 0}, // ValueLeaf2B314 3
+	{103, 104, 105},             // ValueLeaf2CGhi
+	{97, 98, 99, 100, 101, 102}, // ValueLeaf1AAbcdef 5
 	{},
-	{10, 0, 0, 0, 0, 0, 0, 0}, // ValueTxout1Txpwr8
+	{10}, // ValueTxout1Txpwr8
 	{},
-	{16, 0, 0, 0, 0, 0, 0, 0},        // ValueTxout2Txpwr10
+	{16},                             // ValueTxout2Txpwr10
 	{87, 88, 89, 45, 49, 50, 51, 52}, //ValueLeaftopWxy1234, 10
 }
 
@@ -262,14 +262,14 @@ func setUp(t *testing.T) (*devicechange.DeviceChange, *devicechange.DeviceChange
 	mockChangeStore := mockstore.NewMockDeviceChangesStore(ctrl)
 	config1Value01, _ := devicechange.NewChangeValue(Test1Cont1A, devicechange.NewTypedValueEmpty(), false)
 	config1Value02, _ := devicechange.NewChangeValue(Test1Cont1ACont2A, devicechange.NewTypedValueEmpty(), false)
-	config1Value03, _ := devicechange.NewChangeValue(Test1Cont1ACont2ALeaf2A, devicechange.NewTypedValueUint64(ValueLeaf2A13), false)
+	config1Value03, _ := devicechange.NewChangeValue(Test1Cont1ACont2ALeaf2A, devicechange.NewTypedValueUint(ValueLeaf2A13, 8), false)
 	config1Value04, _ := devicechange.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechange.NewTypedValueFloat(ValueLeaf2B159), false)
 	config1Value05, _ := devicechange.NewChangeValue(Test1Cont1ACont2ALeaf2C, devicechange.NewTypedValueString(ValueLeaf2CAbc), false)
 	config1Value06, _ := devicechange.NewChangeValue(Test1Cont1ALeaf1A, devicechange.NewTypedValueString(ValueLeaf1AAbcdef), false)
 	config1Value07, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout1, devicechange.NewTypedValueEmpty(), false)
-	config1Value08, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout1Txpwr, devicechange.NewTypedValueUint64(ValueTxout1Txpwr8), false)
+	config1Value08, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout1Txpwr, devicechange.NewTypedValueUint(ValueTxout1Txpwr8, 8), false)
 	config1Value09, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout2, devicechange.NewTypedValueEmpty(), false)
-	config1Value10, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout2Txpwr, devicechange.NewTypedValueUint64(ValueTxout2Txpwr10), false)
+	config1Value10, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout2Txpwr, devicechange.NewTypedValueUint(ValueTxout2Txpwr10, 8), false)
 	config1Value11, _ := devicechange.NewChangeValue(Test1Leaftoplevel, devicechange.NewTypedValueString(ValueLeaftopWxy1234), false)
 
 	device1 := makeDevice(topodevice.ID(Device1ID))
@@ -298,7 +298,7 @@ func setUp(t *testing.T) (*devicechange.DeviceChange, *devicechange.DeviceChange
 
 	config2Value01, _ := devicechange.NewChangeValue(Test1Cont1ACont2ALeaf2B, devicechange.NewTypedValueFloat(ValueLeaf2B314), false)
 	config2Value02, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout3, devicechange.NewTypedValueEmpty(), false)
-	config2Value03, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout3Txpwr, devicechange.NewTypedValueUint64(ValueTxout3Txpwr16), false)
+	config2Value03, _ := devicechange.NewChangeValue(Test1Cont1AList2ATxout3Txpwr, devicechange.NewTypedValueUint(ValueTxout3Txpwr16, 8), false)
 
 	change2 := devicechange.Change{
 		Values: []*devicechange.ChangeValue{

--- a/pkg/store/store-api_test.go
+++ b/pkg/store/store-api_test.go
@@ -46,7 +46,7 @@ func BenchmarkCreateChangeValue(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		path := fmt.Sprintf("/test-%s", strconv.Itoa(b.N))
-		cv, _ := devicechange.NewChangeValue(path, devicechange.NewTypedValueUint64(uint(i)), false)
+		cv, _ := devicechange.NewChangeValue(path, devicechange.NewTypedValueUint(uint(i), 32), false)
 		err := devicechange.IsPathValid(cv.Path)
 		assert.NilError(b, err, "path not valid %s", err)
 

--- a/pkg/store/tree_test.go
+++ b/pkg/store/tree_test.go
@@ -78,24 +78,24 @@ var (
 
 func setUpTree() {
 	configValues = make([]*devicechange.PathValue, 13)
-	configValues[0] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2A, Value: devicechange.NewTypedValueUint64(ValueLeaf2A12)}
-	configValues[1] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2A, Value: devicechange.NewTypedValueUint64(ValueLeaf2A12)}
+	configValues[0] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2A, Value: devicechange.NewTypedValueUint(ValueLeaf2A12, 8)}
+	configValues[1] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2A, Value: devicechange.NewTypedValueUint(ValueLeaf2A12, 8)}
 	configValues[1] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2B, Value: devicechange.NewTypedValueFloat(ValueLeaf2B114)}
 
 	configValues[2] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2C, Value: devicechange.NewTypedValueString(ValueLeaf2CMyValue)}
 	configValues[3] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2C, Value: devicechange.NewTypedValueString(ValueLeaf2CMyValue)}
 	configValues[4] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2C, Value: devicechange.NewTypedValueString(ValueLeaf2CMyValue)}
-	configValues[3] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2D, Value: devicechange.NewTypedValueDecimal64(ValueLeaf2D114, 5)}
-	//configValues[4] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2E, Value: devicechange.NewTypedValueInt64(ValueLeaf2A12)}
+	configValues[3] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2D, Value: devicechange.NewTypedValueDecimal(ValueLeaf2D114, 5)}
+	//configValues[4] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2E, Value: devicechange.NewTypedValueInt(ValueLeaf2A12)}
 
 	configValues[5] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2F, Value: devicechange.NewTypedValueBytes([]byte(ValueList2A2F))}
 	configValues[6] = &devicechange.PathValue{Path: Test1Cont1ACont2ALeaf2G, Value: devicechange.NewTypedValueBool(ValueList2A2G)}
 	configValues[7] = &devicechange.PathValue{Path: Test1Cont1ALeaf1a, Value: devicechange.NewTypedValueString(ValueLeaf1AMyValue)}
 
-	configValues[8] = &devicechange.PathValue{Path: Test1Cont1AList2a1t, Value: devicechange.NewTypedValueUint64(ValueList2b1PwrT)}
-	configValues[9] = &devicechange.PathValue{Path: Test1Cont1AList2a1r, Value: devicechange.NewTypedValueUint64(ValueList2b1PwrR)}
-	configValues[10] = &devicechange.PathValue{Path: Test1Cont1AList2a2t, Value: devicechange.NewTypedValueUint64(ValueList2b2PwrT)}
-	configValues[11] = &devicechange.PathValue{Path: Test1Cont1AList2a2r, Value: devicechange.NewTypedValueUint64(ValueList2b2PwrR)}
+	configValues[8] = &devicechange.PathValue{Path: Test1Cont1AList2a1t, Value: devicechange.NewTypedValueUint(ValueList2b1PwrT, 16)}
+	configValues[9] = &devicechange.PathValue{Path: Test1Cont1AList2a1r, Value: devicechange.NewTypedValueUint(ValueList2b1PwrR, 16)}
+	configValues[10] = &devicechange.PathValue{Path: Test1Cont1AList2a2t, Value: devicechange.NewTypedValueUint(ValueList2b2PwrT, 16)}
+	configValues[11] = &devicechange.PathValue{Path: Test1Cont1AList2a2r, Value: devicechange.NewTypedValueUint(ValueList2b2PwrR, 16)}
 	// TODO add back in a double key list - but must be added to the YANG model first
 	configValues[12] = &devicechange.PathValue{Path: Test1Leaftoplevel, Value: devicechange.NewTypedValueString(ValueLeaftopWxy1234)}
 }

--- a/pkg/utils/values/gnmiValueUtil_test.go
+++ b/pkg/utils/values/gnmiValueUtil_test.go
@@ -18,6 +18,7 @@ package values
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"reflect"
 	"strings"
 	"testing"
@@ -40,7 +41,7 @@ const (
 
 func Test_GnmiStringToNative(t *testing.T) {
 	gnmiValue := gnmi.TypedValue_StringVal{StringVal: testString}
-	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue}, nil)
 	assert.NilError(t, err)
 
 	nativeString := (*devicechange.TypedString)(nativeType)
@@ -48,26 +49,38 @@ func Test_GnmiStringToNative(t *testing.T) {
 }
 
 func Test_GnmiIntToNative(t *testing.T) {
+	pathElem := modelregistry.ReadWritePathElem{
+		ReadOnlyAttrib: modelregistry.ReadOnlyAttrib{
+			ValueType: devicechange.ValueType_INT,
+			TypeOpts:  []uint8{uint8(devicechange.WidthThirtyTwo)},
+		},
+	}
 	gnmiValue := gnmi.TypedValue_IntVal{IntVal: testNegativeInt}
-	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue}, &pathElem)
 	assert.NilError(t, err)
 
-	nativeInt64 := (*devicechange.TypedInt64)(nativeType)
+	nativeInt64 := (*devicechange.TypedInt)(nativeType)
 	assert.Equal(t, nativeInt64.Int(), testNegativeInt)
 }
 
 func Test_GnmiUintToNative(t *testing.T) {
+	pathElem := modelregistry.ReadWritePathElem{
+		ReadOnlyAttrib: modelregistry.ReadOnlyAttrib{
+			ValueType: devicechange.ValueType_UINT,
+			TypeOpts:  []uint8{uint8(devicechange.WidthSixtyFour)},
+		},
+	}
 	gnmiValue := gnmi.TypedValue_UintVal{UintVal: uint64(testMaxUint)}
-	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue}, &pathElem)
 	assert.NilError(t, err)
 
-	nativeUint64 := (*devicechange.TypedUint64)(nativeType)
+	nativeUint64 := (*devicechange.TypedUint)(nativeType)
 	assert.Equal(t, nativeUint64.Uint(), testMaxUint)
 }
 
 func Test_GnmiBoolToNative(t *testing.T) {
 	gnmiValue := gnmi.TypedValue_BoolVal{BoolVal: true}
-	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue})
+	nativeType, err := GnmiTypedValueToNativeType(&gnmi.TypedValue{Value: &gnmiValue}, nil)
 	assert.NilError(t, err)
 
 	nativeBool := (*devicechange.TypedBool)(nativeType)
@@ -225,7 +238,7 @@ func Test_comparables(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		nativeType, err := GnmiTypedValueToNativeType(testCase.testValue)
+		nativeType, err := GnmiTypedValueToNativeType(testCase.testValue, nil)
 		assert.NilError(t, err)
 		assert.Assert(t, nativeType != nil)
 		assert.Equal(t, nativeType.Type, testCase.expectedType)
@@ -237,7 +250,7 @@ func Test_comparables(t *testing.T) {
 }
 
 func Test_ascii(t *testing.T) {
-	nativeType, err := GnmiTypedValueToNativeType(asciiLeafTestValue)
+	nativeType, err := GnmiTypedValueToNativeType(asciiLeafTestValue, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, nativeType != nil)
 	assert.Equal(t, nativeType.Type, devicechange.ValueType_STRING)
@@ -248,7 +261,7 @@ func Test_ascii(t *testing.T) {
 }
 
 func Test_asciiList(t *testing.T) {
-	nativeType, err := GnmiTypedValueToNativeType(asciiListTestValue)
+	nativeType, err := GnmiTypedValueToNativeType(asciiListTestValue, nil)
 	assert.NilError(t, err)
 	assert.Assert(t, nativeType != nil)
 	assert.Equal(t, nativeType.Type, devicechange.ValueType_LEAFLIST_STRING)
@@ -300,7 +313,7 @@ func Test_NativeStringToGnmi(t *testing.T) {
 }
 
 func Test_NativeIntToGnmi(t *testing.T) {
-	nativeInt := devicechange.NewTypedValueInt64(testPositiveInt)
+	nativeInt := devicechange.NewTypedValueInt(testPositiveInt, 64)
 	gnmiInt, err := NativeTypeToGnmiTypedValue(nativeInt)
 	assert.NilError(t, err)
 	_, ok := gnmiInt.Value.(*gnmi.TypedValue_IntVal)
@@ -310,7 +323,7 @@ func Test_NativeIntToGnmi(t *testing.T) {
 }
 
 func Test_NativeUintToGnmi(t *testing.T) {
-	nativeUint := devicechange.NewTypedValueUint64(testMaxUint)
+	nativeUint := devicechange.NewTypedValueUint(testMaxUint, 64)
 	gnmiUint, err := NativeTypeToGnmiTypedValue(nativeUint)
 	assert.NilError(t, err)
 	_, ok := gnmiUint.Value.(*gnmi.TypedValue_UintVal)

--- a/test/gnmi/modelstest.go
+++ b/test/gnmi/modelstest.go
@@ -42,7 +42,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 		expectedError string
 	}{
 		{description: "Unknown path", path: unknownPath, valueType: proto.StringVal, value: "123456", expectedError: "no-such-path"},
-		{description: "Read only path", path: ntpPath, valueType: proto.BoolVal, value: "false", expectedError: "read only"},
+		{description: "Read only path", path: ntpPath, valueType: proto.BoolVal, value: "false", expectedError: "unable to find RW model path"},
 		{description: "Wrong type", path: clockTimeZonePath, valueType: proto.IntVal, value: "11111", expectedError: "expect string"},
 		{description: "Constraint violation", path: hostNamePath, valueType: proto.StringVal, value: "not a host name", expectedError: "does not match regular expression pattern"},
 	}

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -130,7 +130,7 @@ func validateGnmiStateResponse(t *testing.T, resp *gpb.SubscribeResponse, device
 		validateGnmiStateSyncResponse(t, v)
 
 	default:
-		assert.Fail(t, "Unknown GNMI state response type")
+		assert.Fail(t, "WidthUnknown GNMI state response type")
 	}
 }
 

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -190,7 +190,7 @@ func validateResponse(t *testing.T, resp *gpb.SubscribeResponse, device string, 
 
 	switch v := resp.Response.(type) {
 	default:
-		assert.Fail(t, "Unknown type", v)
+		assert.Fail(t, "WidthUnknown type", v)
 	case *gpb.SubscribeResponse_Error:
 		assert.Fail(t, "Error ", v)
 	case *gpb.SubscribeResponse_SyncResponse:


### PR DESCRIPTION
In onos-config the decoding of JSON follows RFC-7951 which needs int64 and uint64 to be represented as string rather than a number. For smaller widths they can be treated as number.

When YGOT is validating it goes through the model and expects the JSON encoded data to suit the data type given.

Basically the type cannot be deduced from the value alone.

This relies on the updated onos-api v0.7.2 that uses the "TypeOpts" field of the TypedValue to hold the number width, so that it can be used at encoding time.

This requires the ModelPlugin to be consulted for every gNMI Set() operation, with the impact:
* The old method of check for RO paths is no longer needed - we check for RW paths every time
* Some of the error messages have changes
* The model plugins now have to be loaded in to all of the gnmi_tests
* Some of the `set_tests` and `subscribe_tests` had to be changed to have valid data types and values.

