### PR TITLE
Fix device state in integration tests

### DIFF
--- a/test/gnmi/offlinedevicetest.go
+++ b/test/gnmi/offlinedevicetest.go
@@ -57,7 +57,7 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 
 	simulator := gnmi.CreateSimulatorWithName(t, offlineDeviceName)
 	// Wait for config to connect to the device
-	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), 10*time.Second)
+	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
 	gnmi.CheckGNMIValue(t, gnmiClient, devicePath, modValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value was set properly on the device

--- a/test/gnmi/singlestatetest.go
+++ b/test/gnmi/singlestatetest.go
@@ -36,7 +36,7 @@ func (s *TestSuite) TestSingleState(t *testing.T) {
 	simulator := gnmi.CreateSimulator(t)
 
 	// Wait for config to connect to the device
-	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), 30*time.Second)
+	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmi.GetGNMIClientOrFail(t)

--- a/test/gnmi/subscribestatediagstest.go
+++ b/test/gnmi/subscribestatediagstest.go
@@ -49,7 +49,7 @@ func (s *TestSuite) TestSubscribeStateDiags(t *testing.T) {
 	deviceID := device.ID(deviceName)
 
 	// Wait for config to connect to the device
-	gnmi.WaitForDeviceAvailable(t, deviceID, 10*time.Second)
+	gnmi.WaitForDeviceAvailable(t, deviceID, time.Minute)
 
 	// Make an opstate diags client
 	opstateClient, err := gnmi.NewOpStateDiagsClient()

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -47,7 +47,7 @@ func (s *TestSuite) TestSubscribeStateGnmi(t *testing.T) {
 	deviceID := device.ID(deviceName)
 
 	// Wait for config to connect to the device
-	gnmi.WaitForDeviceAvailable(t, deviceID, 10*time.Second)
+	gnmi.WaitForDeviceAvailable(t, deviceID, time.Minute)
 
 	// Make a GNMI client to use for subscribe
 	subC := client.BaseClient{}

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -42,7 +42,7 @@ func (s *TestSuite) TestSubscribeOnce(t *testing.T) {
 	simulator := gnmi.CreateSimulator(t)
 
 	// Wait for config to connect to the device
-	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), 10*time.Second)
+	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
 
 	// Make a GNMI client to use for subscribe
 	subC := client.BaseClient{}
@@ -88,7 +88,7 @@ func (s *TestSuite) TestSubscribe(t *testing.T) {
 	simulator := gnmi.CreateSimulator(t)
 
 	// Wait for config to connect to the device
-	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), 10*time.Second)
+	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
 
 	// Make a GNMI client to use for subscribe
 	subC := client.BaseClient{}

--- a/test/gnmi/transactiontest.go
+++ b/test/gnmi/transactiontest.go
@@ -51,8 +51,8 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	devices[1] = device2.Name()
 
 	// Wait for config to connect to the devices
-	gnmi.WaitForDeviceAvailable(t, device.ID(device1.Name()), 10*time.Second)
-	gnmi.WaitForDeviceAvailable(t, device.ID(device2.Name()), 10*time.Second)
+	gnmi.WaitForDeviceAvailable(t, device.ID(device1.Name()), time.Minute)
+	gnmi.WaitForDeviceAvailable(t, device.ID(device2.Name()), time.Minute)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmi.GetGNMIClientOrFail(t)

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -139,12 +139,6 @@ func NewDevice(simulator *helm.HelmRelease, deviceType string, version string) (
 			Plain:    true,
 			Insecure: true,
 		},
-		Protocols: []*topo.ProtocolState{{
-			Protocol:          topo.Protocol_GNMI,
-			ConnectivityState: topo.ConnectivityState_REACHABLE,
-			ChannelState:      topo.ChannelState_DISCONNECTED,
-			ServiceState:      topo.ServiceState_UNKNOWN_SERVICE_STATE,
-		}},
 	}, nil
 }
 
@@ -250,8 +244,7 @@ func WaitForDeviceAvailable(t *testing.T, deviceID device.ID, timeout time.Durat
 				return true
 			}
 		}
-		// TODO: Investigate why device events are not working properly
-		return true
+		return false
 	}, timeout)
 }
 


### PR DESCRIPTION
Fixes a bug causing a race condition in integration tests wherein tests did not properly wait for device availability.