### PR TITLE
AETHER-1290: prevent setting invalid index value in list

### DIFF
--- a/pkg/modelregistry/modelregistryTestDevice1_test.go
+++ b/pkg/modelregistry/modelregistryTestDevice1_test.go
@@ -63,10 +63,14 @@ func Test_SchemaTestDevice1(t *testing.T) {
 
 	l2bIdxVt, l2bIdxVtOk := cont1b["/list2b[index=*]/index"]
 	assert.Assert(t, l2bIdxVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/index")
+	assert.Assert(t, l2bIdxVt.IsAKey)
+	assert.Equal(t, l2bIdxVt.AttrName, "index")
 	assert.Equal(t, l2bIdxVt.ValueType, devicechange.ValueType_UINT)
 
 	l2bLeaf3cVt, l2bLeaf3cVtOk := cont1b["/list2b[index=*]/leaf3c"]
 	assert.Assert(t, l2bLeaf3cVtOk, "expected /cont1b-state to have subpath /list2b[index[*]/leaf3c")
+	assert.Equal(t, l2bLeaf3cVt.AttrName, "leaf3c")
+	assert.Assert(t, !l2bLeaf3cVt.IsAKey)
 	assert.Equal(t, l2bLeaf3cVt.ValueType, devicechange.ValueType_STRING)
 
 	////////////////////////////////////////////////////


### PR DESCRIPTION
https://jira.opennetworking.org/browse/AETHER-1290

When setting an item in a list the index value can be set like any other value - but it must agree with the corresponding Key value in the list - otherwise it's an invalid index

This is passing the gnmi suite in helmit tests