### PR TITLE
synchronizer: subscription to OpState needs its own context

### DIFF
--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -18,6 +18,7 @@ package device
 
 import (
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	"github.com/onosproject/onos-api/go/onos/topo"
 	"time"
 )
@@ -109,6 +110,19 @@ const (
 	// ListResponseREMOVED obviously
 	ListResponseREMOVED ListResponseType = 3
 )
+
+// ListresponsetypeName - map of enumerations
+var ListresponsetypeName = map[int32]string{
+	0: "NONE",
+	1: "ADDED",
+	2: "UPDATED",
+	3: "REMOVED",
+}
+
+// String - convert to string
+func (x ListResponseType) String() string {
+	return proto.EnumName(ListresponsetypeName, int32(x))
+}
 
 func setAttribute(o *topo.Object, k string, v string) {
 	if len(v) > 0 {

--- a/pkg/southbound/synchronizer/session.go
+++ b/pkg/southbound/synchronizer/session.go
@@ -118,7 +118,7 @@ func (s *Session) open() error {
 
 // connect connects to a device using a gNMI session
 func (s *Session) connect() error {
-	log.Info("Connecting to device:", s.device)
+	log.Infof("Connecting to device: %s at %s", s.device.ID, s.device.Address)
 	count := 0
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = backoffInterval

--- a/pkg/southbound/synchronizer/session_manager.go
+++ b/pkg/southbound/synchronizer/session_manager.go
@@ -150,7 +150,7 @@ func (sm *SessionManager) Start() error {
 // processDeviceEvents process incoming device events
 func (sm *SessionManager) processDeviceEvents(ch <-chan *topodevice.ListResponse) {
 	for event := range ch {
-		log.Infof("Received event type %v for device %v", event.Type, event.Device)
+		log.Infof("Received event type %s for device %v", event.Type, event.Device)
 		err := sm.processDeviceEvent(event)
 		if err != nil {
 			log.Errorf("Error updating session %v", event.Device.ID, err)

--- a/test/gnmi/compactChanges.go
+++ b/test/gnmi/compactChanges.go
@@ -57,6 +57,8 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	// Create 2 simulators
 	simulator1 := gnmi.CreateSimulator(t)
 	simulator2 := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator1)
+	defer gnmi.DeleteSimulator(t, simulator2)
 
 	gnmi.WaitForDeviceAvailable(t, device.ID(simulator1.Name()), 2*time.Minute)
 	gnmi.WaitForDeviceAvailable(t, device.ID(simulator2.Name()), 2*time.Minute)

--- a/test/gnmi/deletetest.go
+++ b/test/gnmi/deletetest.go
@@ -40,6 +40,7 @@ func (s *TestSuite) TestDelete(t *testing.T) {
 
 	// Get the configured devices from the environment.
 	device1 := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, device1)
 	devices := make([]string, 1)
 	devices[0] = device1.Name()
 

--- a/test/gnmi/devicestatetest.go
+++ b/test/gnmi/devicestatetest.go
@@ -26,8 +26,10 @@ import (
 // TestDeviceState tests that a device is connected and available.
 func (s *TestSuite) TestDeviceState(t *testing.T) {
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
+
 	assert.NotNil(t, simulator)
-	found := gnmi.WaitForDevice(t, func(d *device.Device) bool {
+	found := gnmi.WaitForDevice(t, func(d *device.Device, eventType topo.EventType) bool {
 		return len(d.Protocols) > 0 &&
 			d.Protocols[0].Protocol == topo.Protocol_GNMI &&
 			d.Protocols[0].ConnectivityState == topo.ConnectivityState_REACHABLE &&

--- a/test/gnmi/modelstest.go
+++ b/test/gnmi/modelstest.go
@@ -32,6 +32,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 	)
 
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Data to run the test cases
 	testCases := []struct {
@@ -61,7 +62,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 				value := thisTestCase.value
 				valueType := thisTestCase.valueType
 				expectedError := thisTestCase.expectedError
-				t.Parallel()
+				// t.Parallel() -- would delete simulator before tests
 
 				t.Logf("testing %q", description)
 

--- a/test/gnmi/multiplesettest.go
+++ b/test/gnmi/multiplesettest.go
@@ -37,6 +37,7 @@ func generateTimezoneName() string {
 func (s *TestSuite) TestMultipleSet(t *testing.T) {
 	// Create a simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmi.GetGNMIClientOrFail(t)
@@ -70,6 +71,4 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 		complete := gnmi.WaitForNetworkChangeComplete(t, changeID, 5*time.Second)
 		assert.True(t, complete, "Set never completed")
 	}
-	// Shut down the device we created
-	gnmi.DeleteSimulator(t, simulator)
 }

--- a/test/gnmi/offlinedevicetest.go
+++ b/test/gnmi/offlinedevicetest.go
@@ -55,7 +55,10 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 	devicePath := gnmi.GetDevicePathWithValue(offlineDeviceName, modPath, modValue, proto.StringVal)
 	networkChangeID := gnmi.SetGNMIValueOrFail(t, gnmiClient, devicePath, gnmi.NoPaths, extensions)
 
+	// Bring device online
 	simulator := gnmi.CreateSimulatorWithName(t, offlineDeviceName)
+	defer gnmi.DeleteSimulator(t, simulator)
+
 	// Wait for config to connect to the device
 	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
 	gnmi.CheckGNMIValue(t, gnmiClient, devicePath, modValue, 0, "Query after set returned the wrong value")
@@ -64,6 +67,4 @@ func (s *TestSuite) TestOfflineDevice(t *testing.T) {
 	gnmi.WaitForNetworkChangeComplete(t, networkChangeID, 10*time.Second)
 	deviceGnmiClient := gnmi.GetDeviceGNMIClientOrFail(t, simulator)
 	gnmi.CheckDeviceValue(t, deviceGnmiClient, devicePath, modValue)
-
-	gnmi.DeleteSimulator(t, simulator)
 }

--- a/test/gnmi/oneliveonedeadtest.go
+++ b/test/gnmi/oneliveonedeadtest.go
@@ -44,6 +44,7 @@ func (s *TestSuite) TestOneLiveOneDeadDevice(t *testing.T) {
 
 	// Create an online device
 	onlineSimulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, onlineSimulator)
 
 	// Set a value to the online device
 	onlineDevicePath := gnmi.GetDevicePathWithValue(onlineSimulator.Name(), modPath, modValue, proto.StringVal)

--- a/test/gnmi/singlepathtest.go
+++ b/test/gnmi/singlepathtest.go
@@ -29,6 +29,7 @@ const (
 func (s *TestSuite) TestSinglePath(t *testing.T) {
 	// Create a simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmi.GetGNMIClientOrFail(t)
@@ -46,7 +47,4 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 
 	//  Make sure it got removed
 	gnmi.CheckGNMIValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
-
-	// Shut down the device we created
-	gnmi.DeleteSimulator(t, simulator)
 }

--- a/test/gnmi/singlestatetest.go
+++ b/test/gnmi/singlestatetest.go
@@ -34,6 +34,7 @@ const (
 func (s *TestSuite) TestSingleState(t *testing.T) {
 	// Create a simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Wait for config to connect to the device
 	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
@@ -62,7 +63,4 @@ func (s *TestSuite) TestSingleState(t *testing.T) {
 		break
 	}
 	assert.Equal(t, true, success, "state value was not found")
-
-	// Shut down the device we created
-	gnmi.DeleteSimulator(t, simulator)
 }

--- a/test/gnmi/subscribestatediagstest.go
+++ b/test/gnmi/subscribestatediagstest.go
@@ -45,6 +45,8 @@ func (s *TestSuite) TestSubscribeStateDiags(t *testing.T) {
 
 	// Bring up a new simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
+
 	deviceName := simulator.Name()
 	deviceID := device.ID(deviceName)
 

--- a/test/gnmi/subscribestategnmitest.go
+++ b/test/gnmi/subscribestategnmitest.go
@@ -43,6 +43,8 @@ func (s *TestSuite) TestSubscribeStateGnmi(t *testing.T) {
 
 	// Bring up a new simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
+
 	deviceName := simulator.Name()
 	deviceID := device.ID(deviceName)
 
@@ -109,14 +111,6 @@ func (s *TestSuite) TestSubscribeStateGnmi(t *testing.T) {
 		defer subC.Close()
 
 	}()
-
-	select {
-	case <-done:
-		gnmi.DeleteSimulator(t, simulator)
-	case <-time.After(timeOut * time.Second):
-		assert.FailNow(t, "timed out; the request should be processed under %d:", timeOut)
-	}
-
 }
 
 func validateGnmiStateResponse(t *testing.T, resp *gpb.SubscribeResponse, device string) {

--- a/test/gnmi/subscribetest.go
+++ b/test/gnmi/subscribetest.go
@@ -31,7 +31,6 @@ import (
 )
 
 const (
-	timeOut            = 10
 	expectedNumUpdates = 2
 	expectedNumSyncs   = 2
 )
@@ -40,6 +39,7 @@ const (
 func (s *TestSuite) TestSubscribeOnce(t *testing.T) {
 	// Create a simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Wait for config to connect to the device
 	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
@@ -79,13 +79,13 @@ func (s *TestSuite) TestSubscribeOnce(t *testing.T) {
 	err = subC.Subscribe(gnmi.MakeContext(), *q, "gnmi")
 	defer subC.Close()
 	assert.NoError(t, err)
-	gnmi.DeleteSimulator(t, simulator)
 }
 
 // TestSubscribe tests a stream subscription to updates to a device
 func (s *TestSuite) TestSubscribe(t *testing.T) {
 	// Create a simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Wait for config to connect to the device
 	gnmi.WaitForDeviceAvailable(t, device.ID(simulator.Name()), time.Minute)
@@ -174,14 +174,6 @@ func (s *TestSuite) TestSubscribe(t *testing.T) {
 
 	//  Make sure it got removed
 	gnmi.CheckGNMIValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
-
-	select {
-	case <-done:
-		gnmi.DeleteSimulator(t, simulator)
-	case <-time.After(timeOut * time.Second):
-		assert.FailNow(t, "timed out; the request should be processed under %d:", timeOut)
-	}
-
 }
 
 func validateResponse(t *testing.T, resp *gpb.SubscribeResponse, device string, delete bool) {

--- a/test/gnmi/treepathtest.go
+++ b/test/gnmi/treepathtest.go
@@ -33,6 +33,7 @@ const (
 func (s *TestSuite) TestTreePath(t *testing.T) {
 	// Make a simulated device
 	simulator := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmi.GetGNMIClientOrFail(t)
@@ -66,7 +67,4 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 
 	//  Make sure new root got removed
 	gnmi.CheckGNMIValue(t, gnmiClient, getPath, "", 0, "New root was not removed")
-
-	// Shut down the device we created
-	gnmi.DeleteSimulator(t, simulator)
 }

--- a/test/gnmi/updatedeletetest.go
+++ b/test/gnmi/updatedeletetest.go
@@ -33,6 +33,7 @@ const (
 func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	// Get the first configured device from the environment.
 	device := gnmi.CreateSimulator(t)
+	defer gnmi.DeleteSimulator(t, device)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmi.GetGNMIClientOrFail(t)

--- a/test/ha/session_failover.go
+++ b/test/ha/session_failover.go
@@ -40,7 +40,7 @@ func (s *TestSuite) TestSessionFailOver(t *testing.T) {
 	assert.NotNil(t, simulator)
 	var currentTerm int
 	var masterNode string
-	found := gnmi.WaitForDevice(t, func(d *device.Device) bool {
+	found := gnmi.WaitForDevice(t, func(d *device.Device, eventType topo.EventType) bool {
 		currentTerm, _ = strconv.Atoi(d.Attributes[mastershipTermKey])
 		masterNode = d.Attributes[mastershipMasterKey]
 		return currentTerm == 1 && len(d.Protocols) > 0 &&
@@ -57,7 +57,7 @@ func (s *TestSuite) TestSessionFailOver(t *testing.T) {
 
 	// Waits for a new master to be elected (i.e. the term will be increased), it establishes a connection to the device
 	// and updates the device state
-	found = gnmi.WaitForDevice(t, func(d *device.Device) bool {
+	found = gnmi.WaitForDevice(t, func(d *device.Device, t topo.EventType) bool {
 		currentTerm, _ = strconv.Atoi(d.Attributes[mastershipTermKey])
 		return currentTerm == 2 && len(d.Protocols) > 0 &&
 			d.Protocols[0].Protocol == topo.Protocol_GNMI &&

--- a/test/utils/charts/umbrella.go
+++ b/test/utils/charts/umbrella.go
@@ -24,7 +24,7 @@ func CreateUmbrellaRelease() *helm.HelmRelease {
 	return helm.Chart("onos-umbrella", onostest.OnosChartRepo).
 		Release("onos-umbrella").
 		Set("import.onos-gui.enabled", false).
-		Set("onos-cli.image.tag", "latest").
+		Set("import.onos-cli.enabled", false). // not needed - can enabled be through Helm for investigations
 		Set("onos-topo.image.tag", "latest").
 		Set("onos-config.image.tag", "latest")
 }


### PR DESCRIPTION
It was giving error `rpc error: code = Internal desc = transport: transport: the stream is done or WriteHeader was already called`

Also clean up of simulator after each test