### PR TITLE
network/controller - handle failures and adding more unit tests

### DIFF
--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,4 +1,4 @@
-FROM onosproject/config-model-build:v0.4.2 AS build
+FROM onosproject/config-model-build:v0.4.5 AS build
 
 ENV GO111MODULE=on
 ARG ONOS_MAKE_TARGET=build
@@ -12,7 +12,7 @@ COPY pkg/ /build/pkg/
 
 RUN make ${ONOS_MAKE_TARGET}
 
-FROM alpine:3.11
+FROM alpine:3.13
 RUN apk add libc6-compat
 
 USER nobody

--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -122,6 +122,7 @@ func (r *Reconciler) reconcileChange(change *devicechange.DeviceChange) (control
 
 	// Update the change status in the store
 	if err := r.changes.Update(change); err != nil {
+		log.Warnf("error updating device change %s %v", err.Error(), change)
 		return controller.Result{}, err
 	}
 	return controller.Result{}, nil
@@ -148,6 +149,7 @@ func (r *Reconciler) reconcileRollback(change *devicechange.DeviceChange) (contr
 
 	// Update the change status in the store
 	if err := r.changes.Update(change); err != nil {
+		log.Warnf("error updating device change %s %v", err.Error(), change)
 		return controller.Result{}, err
 	}
 	return controller.Result{}, nil

--- a/pkg/controller/change/network/controller_test.go
+++ b/pkg/controller/change/network/controller_test.go
@@ -16,353 +16,334 @@ package network
 
 import (
 	"context"
-	"fmt"
 	"github.com/golang/mock/gomock"
-	"github.com/onosproject/onos-api/go/onos/config/change"
+	types "github.com/onosproject/onos-api/go/onos/config/change"
 	devicechange "github.com/onosproject/onos-api/go/onos/config/change/device"
 	networkchange "github.com/onosproject/onos-api/go/onos/config/change/network"
-	"github.com/onosproject/onos-api/go/onos/config/device"
-	"github.com/onosproject/onos-api/go/onos/topo"
-	devicetopo "github.com/onosproject/onos-config/pkg/device"
-	devicechanges "github.com/onosproject/onos-config/pkg/store/change/device"
-	networkchanges "github.com/onosproject/onos-config/pkg/store/change/network"
-	devicestore "github.com/onosproject/onos-config/pkg/store/device"
-	"github.com/onosproject/onos-config/pkg/test/mocks"
-	"github.com/onosproject/onos-lib-go/pkg/controller"
+	devicechangecontroller "github.com/onosproject/onos-config/pkg/controller/change/device"
+	topodevice "github.com/onosproject/onos-config/pkg/device"
+	"github.com/onosproject/onos-config/pkg/southbound"
+	leadershipstore "github.com/onosproject/onos-config/pkg/store/leadership"
+	mastershipstore "github.com/onosproject/onos-config/pkg/store/mastership"
+	southboundtest "github.com/onosproject/onos-config/pkg/test/mocks/southbound"
+	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"strings"
 	"testing"
+	"time"
 )
 
-const (
-	device1     = device.ID("device-1")
-	device2     = device.ID("device-2")
-	v1          = "1.0.0"
-	stratumType = "Stratum"
-)
-
-const (
-	change1 = networkchange.ID("change-1")
-)
-
-// TestReconcilerChangeRollback tests applying and then rolling back a change
-func TestReconcilerChangeRollback(t *testing.T) {
-	networkChanges, deviceChanges, devices := newStores(t)
-	defer networkChanges.Close()
-	defer deviceChanges.Close()
-
-	reconciler := &Reconciler{
-		networkChanges: networkChanges,
-		deviceChanges:  deviceChanges,
-		devices:        devices,
-	}
-
-	// Create a network change
-	networkChange := newChange(change1, device1, device2)
-	err := networkChanges.Create(networkChange)
-	assert.NoError(t, err)
-
-	// Reconcile the network change
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that device changes were created
-	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// The reconciler should have changed its state to RUNNING
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// But device change states should remain in PENDING state
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that device change states were changed to RUNNING
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Complete one of the devices
-	deviceChange1.Status.State = change.State_COMPLETE
-	err = deviceChanges.Update(deviceChange1)
-	assert.NoError(t, err)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify the network change was not completed
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// Complete the other device
-	deviceChange2.Status.State = change.State_COMPLETE
-	err = deviceChanges.Update(deviceChange2)
-	assert.NoError(t, err)
-
-	// Reconcile the network change one more time
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify the network change is complete
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_COMPLETE, networkChange.Status.State)
-
-	// Set the change to the ROLLBACK phase
-	networkChange.Status.Phase = change.Phase_ROLLBACK
-	networkChange.Status.State = change.State_PENDING
-	err = networkChanges.Update(networkChange)
-	assert.NoError(t, err)
-
-	// Reconcile the rollback
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that the rollback is running
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// Verify that device change phases were changed to ROLLBACK
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Reconcile the rollback again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that the rollback is running
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// Reconcile the rollback again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that device change states were changed to RUNNING
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-}
-
-// TestReconcilerError tests an error reverting a change to PENDING
-func TestReconcilerError(t *testing.T) {
-	networkChanges, deviceChanges, devices := newStores(t)
-	defer networkChanges.Close()
-	defer deviceChanges.Close()
-
-	reconciler := &Reconciler{
-		networkChanges: networkChanges,
-		deviceChanges:  deviceChanges,
-		devices:        devices,
-	}
-
-	// Create a network change
-	networkChange := newChange(change1, device1, device2)
-	err := networkChanges.Create(networkChange)
-	assert.NoError(t, err)
-
-	// Reconcile the network change
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that device changes were created
-	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// The reconciler should have changed its state to RUNNING
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// But device change states should remain in PENDING state
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that device change states were changed to RUNNING
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Complete one of the devices
-	deviceChange1.Status.State = change.State_COMPLETE
-	err = deviceChanges.Update(deviceChange1)
-	assert.NoError(t, err)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify the network change was not completed
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// Fail the other device
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	deviceChange2.Status.State = change.State_FAILED
-	deviceChange2.Status.Reason = change.Reason_ERROR
-	err = deviceChanges.Update(deviceChange2)
-	assert.NoError(t, err)
-
-	// Reconcile the network change again
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify the network change is still PENDING
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-
-	// Verify the change to device-1 is being rolled back
-	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
-	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
-	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
-
-	// Set the device-1 change rollback to COMPLETE
-	deviceChange1.Status.State = change.State_COMPLETE
-	err = deviceChanges.Update(deviceChange1)
-	assert.NoError(t, err)
-
-	// Reconcile the network change
-	_, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
-
-	// Verify that the network change returned to PENDING
-	networkChange, err = networkChanges.Get(change1)
-	assert.NoError(t, err)
-	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
-	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
-}
-
-func newStores(t *testing.T) (networkchanges.Store, devicechanges.Store, devicestore.Store) {
-	networkChanges, err := networkchanges.NewLocalStore()
-	assert.NoError(t, err)
-	deviceChanges, err := devicechanges.NewLocalStore()
-	assert.NoError(t, err)
+func Test_NewController2Devices(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	client := mocks.NewMockTopoClient(ctrl)
-	client.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, request *topo.GetRequest) (*topo.GetResponse, error) {
-		return &topo.GetResponse{
-			Object: devicetopo.ToObject(&devicetopo.Device{
-				ID:      devicetopo.ID(request.ID),
-				Version: v1,
-				Type:    stratumType,
-				Address: fmt.Sprintf("%s:5150", request.ID),
-				Protocols: []*topo.ProtocolState{
-					{
-						Protocol:          topo.Protocol_GNMI,
-						ChannelState:      topo.ChannelState_CONNECTED,
-						ConnectivityState: topo.ConnectivityState_REACHABLE,
-					},
-				},
-			}),
-		}, nil
-	}).AnyTimes()
-	devices, err := devicestore.NewStore(client)
+	defer ctrl.Finish()
+
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	deviceCache := newDeviceCache(ctrl)
+	defer deviceCache.Close()
+
+	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
 	assert.NoError(t, err)
-	return networkChanges, deviceChanges, devices
+	defer leadershipStore.Close()
+
+	mastershipStore, err := mastershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer mastershipStore.Close()
+
+	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
+	assert.NotNil(t, networkChangeController)
+
+	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
+	assert.NotNil(t, deviceChangeController)
+
+	mockTargetDevice1 := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice1)
+	southbound.Targets[topodevice.ID(device1)] = mockTargetDevice1
+	device1Context, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	mockTargetDevice1.EXPECT().Context().Return(&device1Context).AnyTimes()
+	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	mockTargetDevice2 := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice2)
+	southbound.Targets[topodevice.ID(device2)] = mockTargetDevice2
+	device2Context, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	mockTargetDevice2.EXPECT().Context().Return(&device2Context).AnyTimes()
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	err = networkChangeController.Start()
+	assert.NoError(t, err)
+	defer networkChangeController.Stop()
+
+	err = deviceChangeController.Start()
+	assert.NoError(t, err)
+	defer deviceChangeController.Stop()
+
+	// Create a network change
+	networkChange1 := &networkchange.NetworkChange{
+		ID: "change-1",
+		Changes: []*devicechange.Change{
+			&deviceChange1,
+			&deviceChange2,
+		},
+	}
+
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
+
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	// Verify that device changes were created
+	time.Sleep(300 * time.Millisecond)
+	networkChange1, err = networkChanges.Get(networkChange1.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, types.Phase_CHANGE, networkChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, networkChange1.Status.State)
+	assert.Equal(t, uint64(1), networkChange1.Status.Incarnation)
+
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange1)
+	assert.Equal(t, types.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange1.Status.Reason)
+	assert.Equal(t, "", deviceChange1.Status.Message)
+	assert.Equal(t, uint64(1), deviceChange1.Status.Incarnation)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange2)
+	assert.Equal(t, types.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange2.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange2.Status.Reason)
+	assert.Equal(t, "", deviceChange2.Status.Message)
+	assert.Equal(t, uint64(1), deviceChange2.Status.Incarnation)
 }
 
-func newChange(id networkchange.ID, devices ...device.ID) *networkchange.NetworkChange {
-	changes := make([]*devicechange.Change, len(devices))
-	for i, device := range devices {
-		changes[i] = &devicechange.Change{
-			DeviceID:      device,
-			DeviceVersion: "1.0.0",
-			DeviceType:    "Stratum",
-			Values: []*devicechange.ChangeValue{
-				{
-					Path: "foo",
-					Value: &devicechange.TypedValue{
-						Bytes: []byte("Hello world!"),
-						Type:  devicechange.ValueType_STRING,
-					},
-				},
-			},
-		}
+// a NetworkChange is made to 2 devices. One of the devices returns an error on Set
+// and so the NetworkChange is rolled back, rolling back the devicechange on both devices,
+// in the end leaving both devices unchanged.
+// The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
+func Test_NewController1FailsGnmiSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	deviceCache := newDeviceCache(ctrl)
+	defer deviceCache.Close()
+
+	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer leadershipStore.Close()
+
+	mastershipStore, err := mastershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer mastershipStore.Close()
+
+	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
+	assert.NotNil(t, networkChangeController)
+
+	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
+	assert.NotNil(t, deviceChangeController)
+
+	mockTargetDevice1 := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice1)
+	southbound.Targets[topodevice.ID(device1)] = mockTargetDevice1
+	device1Context, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	mockTargetDevice1.EXPECT().Context().Return(&device1Context).AnyTimes()
+	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+
+	mockTargetDevice2 := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice2)
+	southbound.Targets[topodevice.ID(device2)] = mockTargetDevice2
+	device2Context, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	mockTargetDevice2.EXPECT().Context().Return(&device2Context).AnyTimes()
+	// First time will return an error
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *gnmi.SetRequest) (*gnmi.SetResponse, error) {
+			return nil, status.Errorf(codes.Internal, "simulated error in device-2 %s", request)
+		}).Times(1)
+	// Second time will be a rollback when SET is not possible - no error
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	err = networkChangeController.Start()
+	assert.NoError(t, err)
+	defer networkChangeController.Stop()
+
+	err = deviceChangeController.Start()
+	assert.NoError(t, err)
+	defer deviceChangeController.Stop()
+
+	// Create a network change
+	networkChange1 := &networkchange.NetworkChange{
+		ID: "change-1",
+		Changes: []*devicechange.Change{
+			&deviceChange1,
+			&deviceChange2,
+		},
 	}
-	return &networkchange.NetworkChange{
-		ID:      id,
-		Changes: changes,
+
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
+
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	// Verify that device changes were created
+	time.Sleep(500 * time.Millisecond) // Should give 5 attempts 20+40+80+160+320 ms
+	networkChange1, err = networkChanges.Get(networkChange1.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, types.Phase_CHANGE, networkChange1.Status.Phase)
+	assert.Equal(t, types.State_PENDING, networkChange1.Status.State)
+	assert.Equal(t, types.Reason_ERROR, networkChange1.Status.Reason)
+	assert.Equal(t, "change rejected by device", networkChange1.Status.Message)
+	assert.Equal(t, uint64(1), networkChange1.Status.Incarnation)
+
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange1)
+	assert.Equal(t, types.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange1.Status.Reason)
+	assert.Equal(t, "", deviceChange1.Status.Message)
+	assert.Equal(t, uint64(1), deviceChange1.Status.Incarnation)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange2)
+	assert.Equal(t, types.Phase_ROLLBACK, deviceChange2.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange2.Status.State)
+	assert.Equal(t, types.Reason_ERROR, deviceChange2.Status.Reason)
+	assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-2 update:{path:{elem:{name:"baz"}} val:{string_val:"Goodbye world!"}}`,
+		strings.ReplaceAll(deviceChange2.Status.Message, "  ", " "))
+	assert.Equal(t, uint64(1), deviceChange2.Status.Incarnation)
+}
+
+// a NetworkChange is made to 2 devices, which succeeds
+// Then rollback the network change
+// The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
+func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	deviceCache := newDeviceCache(ctrl)
+	defer deviceCache.Close()
+
+	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer leadershipStore.Close()
+
+	mastershipStore, err := mastershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer mastershipStore.Close()
+
+	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
+	assert.NotNil(t, networkChangeController)
+
+	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
+	assert.NotNil(t, deviceChangeController)
+
+	mockTargetDevice1 := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice1)
+	southbound.Targets[topodevice.ID(device1)] = mockTargetDevice1
+	device1Context, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	mockTargetDevice1.EXPECT().Context().Return(&device1Context).AnyTimes()
+	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
+
+	mockTargetDevice2 := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice2)
+	southbound.Targets[topodevice.ID(device2)] = mockTargetDevice2
+	device2Context, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	mockTargetDevice2.EXPECT().Context().Return(&device2Context).AnyTimes()
+	// First time is the SET - no error
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+	// Second time will be a rollback but SET returns error
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *gnmi.SetRequest) (*gnmi.SetResponse, error) {
+			return nil, status.Errorf(codes.Internal, "simulated error on rollback in device-2 %s", request)
+		}).Times(1)
+	// Third time will be a roll forward but here too SET returns error
+	//mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *gnmi.SetRequest) (*gnmi.SetResponse, error) {
+			return nil, status.Errorf(codes.Internal, "simulated error on undoing rollback in device-2 %s", request)
+		}).Times(1)
+
+	err = networkChangeController.Start()
+	assert.NoError(t, err)
+	defer networkChangeController.Stop()
+
+	err = deviceChangeController.Start()
+	assert.NoError(t, err)
+	defer deviceChangeController.Stop()
+
+	// Create a network change
+	networkChange1 := &networkchange.NetworkChange{
+		ID: "change-1",
+		Changes: []*devicechange.Change{
+			&deviceChange1,
+			&deviceChange2,
+		},
 	}
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
+
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	// Verify that device changes were created
+	time.Sleep(50 * time.Millisecond)
+
+	// Now try a rollback
+	changeRollback, errGet := networkChanges.Get(change1)
+	assert.NoError(t, errGet)
+	assert.NotNil(t, changeRollback)
+	changeRollback.Status.Incarnation++
+	changeRollback.Status.Phase = types.Phase_ROLLBACK
+	changeRollback.Status.State = types.State_PENDING
+	changeRollback.Status.Reason = types.Reason_NONE
+	changeRollback.Status.Message = "Administratively requested rollback"
+	err = networkChanges.Update(changeRollback)
+	assert.NoError(t, err)
+	time.Sleep(500 * time.Millisecond) // Should give 5 attempts 20+40+80+160+320 ms
+
+	networkChange1, err = networkChanges.Get(networkChange1.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, types.Phase_ROLLBACK, networkChange1.Status.Phase)
+	assert.Equal(t, types.State_PENDING, networkChange1.Status.State)
+	assert.Equal(t, types.Reason_ERROR, networkChange1.Status.Reason)
+	assert.Equal(t, "rollback rejected by device", networkChange1.Status.Message)
+	assert.Equal(t, uint64(2), networkChange1.Status.Incarnation)
+
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange1)
+	assert.Equal(t, types.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange1.Status.Reason)
+	assert.Equal(t, "", deviceChange1.Status.Message)
+	assert.Equal(t, uint64(2), deviceChange1.Status.Incarnation)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange2)
+	assert.Equal(t, types.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, types.State_FAILED, deviceChange2.Status.State)
+	assert.Equal(t, types.Reason_ERROR, deviceChange2.Status.Reason)
+	assert.Equal(t, `rpc error: code = Internal desc = simulated error on undoing rollback in device-2 update:{path:{elem:{name:"baz"}} val:{string_val:"Goodbye world!"}}`,
+		strings.ReplaceAll(deviceChange2.Status.Message, "  ", " "))
+	assert.Equal(t, uint64(2), deviceChange2.Status.Incarnation)
 }

--- a/pkg/controller/change/network/reconciler_test.go
+++ b/pkg/controller/change/network/reconciler_test.go
@@ -1,0 +1,465 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"github.com/golang/mock/gomock"
+	"github.com/onosproject/onos-api/go/onos/config/change"
+	devicechange "github.com/onosproject/onos-api/go/onos/config/change/device"
+	networkchange "github.com/onosproject/onos-api/go/onos/config/change/network"
+	"github.com/onosproject/onos-api/go/onos/config/device"
+	"github.com/onosproject/onos-api/go/onos/topo"
+	devicetopo "github.com/onosproject/onos-config/pkg/device"
+	devicechanges "github.com/onosproject/onos-config/pkg/store/change/device"
+	networkchanges "github.com/onosproject/onos-config/pkg/store/change/network"
+	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
+	"github.com/onosproject/onos-config/pkg/store/stream"
+	"github.com/onosproject/onos-config/pkg/test/mocks"
+	mockcache "github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
+	"github.com/onosproject/onos-lib-go/pkg/controller"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+const (
+	device1     = device.ID("device-1")
+	device2     = device.ID("device-2")
+	v1          = "1.0.0"
+	stratumType = "Stratum"
+)
+
+const (
+	change1 = networkchange.ID("change-1")
+)
+
+// TestReconcilerChangeRollback tests applying and then rolling back a change
+func TestReconcilerChangeRollback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	reconciler := &Reconciler{
+		networkChanges: networkChanges,
+		deviceChanges:  deviceChanges,
+		devices:        devices,
+	}
+
+	var requeue controller.Result
+
+	// Create a network change
+	networkChange := newChange(change1, device1, device2)
+	err := networkChanges.Create(networkChange)
+	assert.NoError(t, err)
+
+	// Reconcile the network change
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Equal(t, "change-1", requeue.Requeue.String())
+
+	// Verify that device changes were created
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// The reconciler should have changed its state to PENDING
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// But device change states should remain in PENDING state
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify that device change states were changed to PENDING
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Complete one of the devices
+	deviceChange1.Status.State = change.State_COMPLETE
+	err = deviceChanges.Update(deviceChange1)
+	assert.NoError(t, err)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify the network change was not completed
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// Complete the other device
+	deviceChange2.Status.State = change.State_COMPLETE
+	err = deviceChanges.Update(deviceChange2)
+	assert.NoError(t, err)
+
+	// Reconcile the network change one more time
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify the network change is complete
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_COMPLETE, networkChange.Status.State)
+
+	// Set the change to the ROLLBACK phase
+	networkChange.Status.Phase = change.Phase_ROLLBACK
+	networkChange.Status.State = change.State_PENDING
+	err = networkChanges.Update(networkChange)
+	assert.NoError(t, err)
+
+	// Reconcile the rollback
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify that the rollback is running
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// Verify that device change phases were changed to ROLLBACK
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Reconcile the rollback again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify that the rollback is running
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// Reconcile the rollback again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify that device change states were changed to PENDING
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+}
+
+// TestReconcilerError tests an error reverting a change to PENDING
+func TestReconcilerError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	reconciler := &Reconciler{
+		networkChanges: networkChanges,
+		deviceChanges:  deviceChanges,
+		devices:        devices,
+	}
+	var requeue controller.Result
+
+	// Create a network change
+	networkChange := newChange(change1, device1, device2)
+	err := networkChanges.Create(networkChange)
+	assert.NoError(t, err)
+
+	// Reconcile the network change
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Equal(t, "change-1", requeue.Requeue.String())
+
+	// Verify that device changes were created
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// The reconciler should have changed its state to PENDING
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// But device change states should remain in PENDING state
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify that device change states were changed to PENDING
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Complete one of the devices
+	deviceChange1.Status.State = change.State_COMPLETE
+	err = deviceChanges.Update(deviceChange1)
+	assert.NoError(t, err)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.NoError(t, err)
+	assert.Nil(t, requeue.Requeue.Value)
+
+	// Verify the network change was not completed
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// Fail the other device
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	deviceChange2.Status.State = change.State_FAILED
+	deviceChange2.Status.Reason = change.Reason_ERROR
+	deviceChange2.Status.Message = "failed for test"
+	err = deviceChanges.Update(deviceChange2)
+	assert.NoError(t, err)
+
+	// Reconcile the network change again
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.Error(t, err) // Will trigger retry with exp backoff
+
+	// Verify the network change is still PENDING
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+
+	// Verify the change to device-1 is being rolled back
+	deviceChange1, err = deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange1.Status.State)
+	deviceChange2, err = deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_ROLLBACK, deviceChange2.Status.Phase)
+	assert.Equal(t, change.State_PENDING, deviceChange2.Status.State)
+
+	// Set the device-1 change rollback to COMPLETE
+	deviceChange1.Status.State = change.State_COMPLETE
+	err = deviceChanges.Update(deviceChange1)
+	assert.NoError(t, err)
+
+	// Reconcile the network change
+	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
+	assert.Error(t, err) // Will trigger retry with exp backoff
+
+	// Verify that the network change returned to PENDING
+	networkChange, err = networkChanges.Get(change1)
+	assert.NoError(t, err)
+	assert.Equal(t, change.Phase_CHANGE, networkChange.Status.Phase)
+	assert.Equal(t, change.State_PENDING, networkChange.Status.State)
+	assert.Equal(t, change.Reason_ERROR, networkChange.Status.Reason)
+	assert.Equal(t, "change rejected by device", networkChange.Status.Message)
+}
+
+func newStores(t *testing.T, ctrl *gomock.Controller) (networkchanges.Store, devicechanges.Store, devicestore.Store) {
+	networkChanges, err := networkchanges.NewLocalStore()
+	assert.NoError(t, err)
+	deviceChanges, err := devicechanges.NewLocalStore()
+	assert.NoError(t, err)
+	client := mocks.NewMockTopoClient(ctrl)
+	client.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, request *topo.WatchRequest) (topo.Topo_WatchClient, error) {
+		listClient := mocks.NewMockTopo_WatchClient(ctrl)
+		listClient.EXPECT().Recv().Return(&topo.WatchResponse{
+			Event: topo.Event{
+				Type: topo.EventType_NONE,
+				Object: *devicetopo.ToObject(&devicetopo.Device{
+					ID:      devicetopo.ID(device1),
+					Type:    stratumType,
+					Version: v1,
+					Address: fmt.Sprintf("%s:1234", device1),
+					Protocols: []*topo.ProtocolState{
+						{
+							Protocol:          topo.Protocol_GNMI,
+							ChannelState:      topo.ChannelState_CONNECTED,
+							ConnectivityState: topo.ConnectivityState_REACHABLE,
+						},
+					},
+				}),
+			},
+		}, nil)
+		listClient.EXPECT().Recv().Return(&topo.WatchResponse{
+			Event: topo.Event{
+				Type: topo.EventType_NONE,
+				Object: *devicetopo.ToObject(&devicetopo.Device{
+					ID:      devicetopo.ID(device2),
+					Type:    stratumType,
+					Version: v1,
+					Address: fmt.Sprintf("%s:1234", device2),
+					Protocols: []*topo.ProtocolState{
+						{
+							Protocol:          topo.Protocol_GNMI,
+							ChannelState:      topo.ChannelState_CONNECTED,
+							ConnectivityState: topo.ConnectivityState_REACHABLE,
+						},
+					},
+				}),
+			},
+		}, nil)
+		listClient.EXPECT().Recv().Return(nil, io.EOF)
+		return listClient, nil
+	}).AnyTimes()
+	client.EXPECT().Get(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, request *topo.GetRequest) (*topo.GetResponse, error) {
+		return &topo.GetResponse{
+			Object: devicetopo.ToObject(&devicetopo.Device{
+				ID:      devicetopo.ID(request.ID),
+				Version: v1,
+				Type:    stratumType,
+				Address: fmt.Sprintf("%s:5150", request.ID),
+				Protocols: []*topo.ProtocolState{
+					{
+						Protocol:          topo.Protocol_GNMI,
+						ChannelState:      topo.ChannelState_CONNECTED,
+						ConnectivityState: topo.ConnectivityState_REACHABLE,
+					},
+				},
+			}),
+		}, nil
+	}).AnyTimes()
+	devices, err := devicestore.NewStore(client)
+	assert.NoError(t, err)
+
+	return networkChanges, deviceChanges, devices
+}
+
+func newDeviceCache(ctrl *gomock.Controller) *mockcache.MockCache {
+	cachedDevices := []*cache.Info{
+		{
+			DeviceID: device1,
+			Type:     stratumType,
+			Version:  v1,
+		},
+		{
+			DeviceID: device2,
+			Type:     stratumType,
+			Version:  v1,
+		},
+	}
+
+	deviceCache := mockcache.NewMockCache(ctrl)
+	deviceCache.EXPECT().Watch(gomock.Any(), true).DoAndReturn(
+		func(ch chan<- stream.Event, replay bool) (stream.Context, error) {
+			go func() {
+				for _, di := range cachedDevices {
+					event := stream.Event{
+						Type:   stream.Created,
+						Object: di,
+					}
+					ch <- event
+				}
+				close(ch)
+			}()
+			return stream.NewContext(func() {}), nil
+		}).AnyTimes()
+	deviceCache.EXPECT().Close().Return(nil).AnyTimes()
+	return deviceCache
+}
+
+func newChange(id networkchange.ID, devices ...device.ID) *networkchange.NetworkChange {
+	changes := make([]*devicechange.Change, len(devices))
+	for i, device := range devices {
+		changes[i] = &devicechange.Change{
+			DeviceID:      device,
+			DeviceVersion: v1,
+			DeviceType:    stratumType,
+			Values: []*devicechange.ChangeValue{
+				{
+					Path:  "foo",
+					Value: devicechange.NewTypedValueString(fmt.Sprintf("Hello %s!", device)),
+				},
+			},
+		}
+	}
+	return &networkchange.NetworkChange{
+		ID:      id,
+		Changes: changes,
+	}
+}

--- a/pkg/store/change/device/state/store.go
+++ b/pkg/store/change/device/state/store.go
@@ -195,7 +195,7 @@ func (s *deviceChangeStoreStateStore) processNetworkRollback(networkChange *netw
 		}
 		if netChange.Status.Phase == changetype.Phase_CHANGE {
 			for _, devChange := range netChange.Changes {
-				state, ok := s.devices[devChange.GetVersionedDeviceID()]
+				state, ok := states[devChange.GetVersionedDeviceID()]
 				if ok {
 					for _, value := range devChange.Values {
 						if value.Removed {

--- a/test/gnmi/transactiontest.go
+++ b/test/gnmi/transactiontest.go
@@ -104,9 +104,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	assert.Contains(t, rollbackResponse.Message, changeID, "rollbackResponse message does not contain change ID")
 
 	// Check that the values were really rolled back in onos-config
-	// TODO - this is actually wrong, the value we read back should be {initValue1, initValue2}
-	// Need to investigate why
-	expectedValuesAfterRollback := []string{"", ""}
+	expectedValuesAfterRollback := []string{initValue1, initValue2}
 	gnmi.CheckGNMIValues(t, gnmiClient, devicePathsForGet, expectedValuesAfterRollback, 0, "Query after rollback returned the wrong value")
 
 	// Check that the values were rolled back on the devices


### PR DESCRIPTION
I moved existing `network/controller_test.go` to `network/reconciler_test.go`

Then I created a new `network/controller_test.go` to contain tests of the Controller - especially with delays

2 scenarios now work with exponential backoff:

- Network change, where one device Set fails and other is rolled back
- Network rollback, where one device Set fails and other has rollback undone

Also fixed error in rollbacked back config (device state on northbound)