### PR TITLE
AETHER 1762 Unit tests for rollback on unattached devices

### DIFF
--- a/pkg/controller/change/device/controller.go
+++ b/pkg/controller/change/device/controller.go
@@ -183,7 +183,7 @@ func (r *Reconciler) translateAndSendChange(change *devicechange.Change) error {
 	deviceTarget, err := southbound.GetTarget(topodevice.ID(change.DeviceID))
 	if err != nil {
 		log.Infof("Device %s is not connected, accepting change", change.DeviceID)
-		return fmt.Errorf("Device not connected %s, error %s", change.DeviceID, err.Error())
+		return fmt.Errorf("device not connected %s, error %s", change.DeviceID, err.Error())
 	}
 	log.Infof("Target for device %s: %v %v", change.DeviceID, deviceTarget, deviceTarget.Context())
 	setResponse, err := deviceTarget.Set(*deviceTarget.Context(), setRequest)

--- a/pkg/controller/change/network/controller_test.go
+++ b/pkg/controller/change/network/controller_test.go
@@ -26,10 +26,13 @@ import (
 	"github.com/onosproject/onos-config/pkg/southbound"
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
+	devicestore "github.com/onosproject/onos-config/pkg/store/device"
+	"github.com/onosproject/onos-config/pkg/store/device/cache"
 	leadershipstore "github.com/onosproject/onos-config/pkg/store/leadership"
 	mastershipstore "github.com/onosproject/onos-config/pkg/store/mastership"
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	southboundtest "github.com/onosproject/onos-config/pkg/test/mocks/southbound"
+	"github.com/onosproject/onos-lib-go/pkg/controller"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
@@ -40,17 +43,40 @@ import (
 	"time"
 )
 
+func setupControllers(t *testing.T, networkChanges networkchangestore.Store,
+	deviceChanges devicechangestore.Store, devices devicestore.Store,
+	deviceCache cache.Cache,
+	leadershipStore leadershipstore.Store, mastershipStore mastershipstore.Store) (
+	*controller.Controller, *controller.Controller) {
+
+	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
+	assert.NotNil(t, networkChangeController)
+
+	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
+	assert.NotNil(t, deviceChangeController)
+
+	return networkChangeController, deviceChangeController
+}
+
+func newMockTarget(t *testing.T, ctrl *gomock.Controller, id topodevice.ID) (*southboundtest.MockTargetIf, context.CancelFunc) {
+	mockTargetDevice := southboundtest.NewMockTargetIf(ctrl)
+	assert.NotNil(t, mockTargetDevice)
+	southbound.Targets[id] = mockTargetDevice
+	deviceContext, cancel := context.WithCancel(context.Background())
+	mockTargetDevice.EXPECT().Context().Return(&deviceContext).AnyTimes()
+	return mockTargetDevice, cancel
+}
+
 // Make a Network change and it propagates down to 2 Device changes
 // They get reconciled successfully
 func Test_NewController2Devices(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-
 	networkChanges, deviceChanges, devices := newStores(t, ctrl)
 	defer networkChanges.Close()
 	defer deviceChanges.Close()
 
-	deviceCache := newDeviceCache(ctrl)
+	deviceCache := newDeviceCache(ctrl, device1, device2)
 	defer deviceCache.Close()
 
 	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
@@ -61,26 +87,15 @@ func Test_NewController2Devices(t *testing.T) {
 	assert.NoError(t, err)
 	defer mastershipStore.Close()
 
-	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
-	assert.NotNil(t, networkChangeController)
+	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
+		deviceCache, leadershipStore, mastershipStore)
 
-	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
-	assert.NotNil(t, deviceChangeController)
-
-	mockTargetDevice1 := southboundtest.NewMockTargetIf(ctrl)
-	assert.NotNil(t, mockTargetDevice1)
-	southbound.Targets[topodevice.ID(device1)] = mockTargetDevice1
-	device1Context, cancel1 := context.WithCancel(context.Background())
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, topodevice.ID(device1))
 	defer cancel1()
-	mockTargetDevice1.EXPECT().Context().Return(&device1Context).AnyTimes()
 	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
-	mockTargetDevice2 := southboundtest.NewMockTargetIf(ctrl)
-	assert.NotNil(t, mockTargetDevice2)
-	southbound.Targets[topodevice.ID(device2)] = mockTargetDevice2
-	device2Context, cancel2 := context.WithCancel(context.Background())
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, topodevice.ID(device2))
 	defer cancel2()
-	mockTargetDevice2.EXPECT().Context().Return(&device2Context).AnyTimes()
 	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
 	err = networkChangeController.Start()
@@ -100,27 +115,27 @@ func Test_NewController2Devices(t *testing.T) {
 		},
 	}
 
-	err = networkChanges.Create(networkChange1)
-	assert.NoError(t, err)
-
 	// Should cause an event to be sent to the Watcher
 	// Watcher should pass it to the Reconciler (if not filtered)
 	// Reconciler should process it
 	// Verify that device changes were created
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
 
-	networkChangeChan := make(chan stream.Event)
-	ctx, err := networkChanges.Watch(networkChangeChan, networkchangestore.WithReplay())
+	change1Chan := make(chan stream.Event)
+	ctx, err := networkChanges.Watch(change1Chan, networkchangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	var wg sync.WaitGroup
-	wg.Add(4) // It takes 4 turns of the reconciler to get it right
+	eventsExpected := 4
+	wg.Add(eventsExpected) // It takes 4 turns of the reconciler to get it right
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < eventsExpected; i++ {
 		select {
-		case event := <-networkChangeChan:
+		case event := <-change1Chan:
 			change := event.Object.(*networkchange.NetworkChange)
-			t.Logf("%s event. %v", change.ID, change.Status)
+			t.Logf("%s event %d. %v", change.ID, i, change.Status)
 			assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
 			assert.Equal(t, types.Reason_NONE, change.Status.Reason)
 			switch i {
@@ -138,10 +153,12 @@ func Test_NewController2Devices(t *testing.T) {
 			}
 			wg.Done()
 		case <-time.After(500 * time.Millisecond):
+			t.Logf("timed out waiting for event from change-1")
 			t.FailNow()
 		}
 	}
 	wg.Wait()
+	t.Logf("Done waiting for %d change-1 events", eventsExpected)
 	ctx.Close()
 
 	networkChange1, err = networkChanges.Get(networkChange1.GetID())
@@ -179,7 +196,7 @@ func Test_NewController1FailsGnmiSet(t *testing.T) {
 	defer networkChanges.Close()
 	defer deviceChanges.Close()
 
-	deviceCache := newDeviceCache(ctrl)
+	deviceCache := newDeviceCache(ctrl, device1, device2)
 	defer deviceCache.Close()
 
 	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
@@ -190,26 +207,15 @@ func Test_NewController1FailsGnmiSet(t *testing.T) {
 	assert.NoError(t, err)
 	defer mastershipStore.Close()
 
-	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
-	assert.NotNil(t, networkChangeController)
+	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
+		deviceCache, leadershipStore, mastershipStore)
 
-	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
-	assert.NotNil(t, deviceChangeController)
-
-	mockTargetDevice1 := southboundtest.NewMockTargetIf(ctrl)
-	assert.NotNil(t, mockTargetDevice1)
-	southbound.Targets[topodevice.ID(device1)] = mockTargetDevice1
-	device1Context, cancel1 := context.WithCancel(context.Background())
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, topodevice.ID(device1))
 	defer cancel1()
-	mockTargetDevice1.EXPECT().Context().Return(&device1Context).AnyTimes()
 	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 
-	mockTargetDevice2 := southboundtest.NewMockTargetIf(ctrl)
-	assert.NotNil(t, mockTargetDevice2)
-	southbound.Targets[topodevice.ID(device2)] = mockTargetDevice2
-	device2Context, cancel2 := context.WithCancel(context.Background())
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, topodevice.ID(device2))
 	defer cancel2()
-	mockTargetDevice2.EXPECT().Context().Return(&device2Context).AnyTimes()
 	// First time will return an error
 	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, request *gnmi.SetRequest) (*gnmi.SetResponse, error) {
@@ -235,69 +241,67 @@ func Test_NewController1FailsGnmiSet(t *testing.T) {
 		},
 	}
 
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	// Verify that device changes were created
 	err = networkChanges.Create(networkChange1)
 	assert.NoError(t, err)
 
-	device2ChangeChan := make(chan stream.Event)
-	ctx, err := deviceChanges.Watch(device.NewVersionedID(device2, v1), device2ChangeChan, devicechangestore.WithReplay())
+	change1Chan := make(chan stream.Event)
+	ctx, err := networkChanges.Watch(change1Chan, networkchangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	device2Chan := make(chan stream.Event)
+	ctx, err = deviceChanges.Watch(device.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	var wg sync.WaitGroup
-	wg.Add(5) // It takes 5 turns of the reconciler to get it right
-	for i := 0; i < 5; i++ {
+	eventsExpectedChange1 := 4
+	eventsExpectedDevice2 := 5
+	wg.Add(eventsExpectedChange1 + eventsExpectedDevice2) // It can take several turns of the reconciler to complete the change
+	var j, k int
+	for i := 0; i < eventsExpectedChange1+eventsExpectedDevice2; i++ {
 		select {
-		case event := <-device2ChangeChan:
-			change := event.Object.(*devicechange.DeviceChange)
-			t.Logf("%s event. %v", change.ID, change.Status)
-			switch i {
-			case 0:
-				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
-				assert.Equal(t, types.State_PENDING, change.Status.State)
+		case event := <-change1Chan:
+			change := event.Object.(*networkchange.NetworkChange)
+			t.Logf("%s event %d. %v", change.ID, j, change.Status)
+			assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+			assert.Equal(t, types.State_PENDING, change.Status.State)
+			switch j {
+			case 0, 1:
 				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
 				assert.Equal(t, uint64(0), change.Status.Incarnation)
-			case 1:
-				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
-				assert.Equal(t, types.State_PENDING, change.Status.State)
+			case 2:
 				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
 				assert.Equal(t, uint64(1), change.Status.Incarnation)
-			case 2:
-				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
-				assert.Equal(t, types.State_FAILED, change.Status.State)
-				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
-				assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-2 update:{path:{elem:{name:"baz"}} val:{string_val:"Goodbye world!"}}`,
-					strings.ReplaceAll(change.Status.Message, "  ", " "))
-				assert.Equal(t, uint64(1), change.Status.Incarnation)
 			case 3:
-				assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
-				assert.Equal(t, types.State_PENDING, change.Status.State)
 				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
-				assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-2 update:{path:{elem:{name:"baz"}} val:{string_val:"Goodbye world!"}}`,
-					strings.ReplaceAll(change.Status.Message, "  ", " "))
-				assert.Equal(t, uint64(1), change.Status.Incarnation)
-			case 4:
-				assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
-				assert.Equal(t, types.State_COMPLETE, change.Status.State)
-				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
-				assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-2 update:{path:{elem:{name:"baz"}} val:{string_val:"Goodbye world!"}}`,
+				assert.Equal(t, `change rejected by device`,
 					strings.ReplaceAll(change.Status.Message, "  ", " "))
 				assert.Equal(t, uint64(1), change.Status.Incarnation)
 			default:
 				t.Errorf("unexpected event on device-1 %v", change)
 			}
+			j++
+			wg.Done()
+		case event := <-device2Chan:
+			change := event.Object.(*devicechange.DeviceChange)
+			t.Logf("%s event %d. %v", change.ID, k, change.Status)
+			k++
 			wg.Done()
 		case <-time.After(500 * time.Millisecond):
+			t.Logf("timed out waiting for event from change-1")
 			t.FailNow()
 		}
 	}
 
 	wg.Wait()
+	t.Logf("Done waiting for %d change-1 and %d device-2 events", eventsExpectedChange1, eventsExpectedDevice2)
 	ctx.Close()
 
-	// Should cause an event to be sent to the Watcher
-	// Watcher should pass it to the Reconciler (if not filtered)
-	// Reconciler should process it
-	// Verify that device changes were created
 	networkChange1, err = networkChanges.Get(networkChange1.GetID())
 	assert.NoError(t, err)
 	assert.Equal(t, types.Phase_CHANGE, networkChange1.Status.Phase)
@@ -326,20 +330,20 @@ func Test_NewController1FailsGnmiSet(t *testing.T) {
 
 	// Should give 5 attempts 20+40+80 ms
 	// Can't verify in a test though as different platforms will run at different speeds
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 }
 
 // a NetworkChange is made to 2 devices, which succeeds
 // Then rollback the network change, but one of the devices does not accept the rollback
 // The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
-func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
+func Test_ControllerDoRollbackWhichFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	networkChanges, deviceChanges, devices := newStores(t, ctrl)
 	defer networkChanges.Close()
 	defer deviceChanges.Close()
 
-	deviceCache := newDeviceCache(ctrl)
+	deviceCache := newDeviceCache(ctrl, device1, device2)
 	defer deviceCache.Close()
 
 	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
@@ -350,29 +354,15 @@ func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
 	assert.NoError(t, err)
 	defer mastershipStore.Close()
 
-	assert.Equal(t, "node-1", string(leadershipStore.NodeID()))
-	assert.Equal(t, "node-1", string(mastershipStore.NodeID()))
+	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
+		deviceCache, leadershipStore, mastershipStore)
 
-	networkChangeController := NewController(leadershipStore, deviceCache, devices, networkChanges, deviceChanges)
-	assert.NotNil(t, networkChangeController)
-
-	deviceChangeController := devicechangecontroller.NewController(mastershipStore, devices, deviceCache, deviceChanges)
-	assert.NotNil(t, deviceChangeController)
-
-	mockTargetDevice1 := southboundtest.NewMockTargetIf(ctrl)
-	assert.NotNil(t, mockTargetDevice1)
-	southbound.Targets[topodevice.ID(device1)] = mockTargetDevice1
-	device1Context, cancel1 := context.WithCancel(context.Background())
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, topodevice.ID(device1))
 	defer cancel1()
-	mockTargetDevice1.EXPECT().Context().Return(&device1Context).AnyTimes()
 	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 
-	mockTargetDevice2 := southboundtest.NewMockTargetIf(ctrl)
-	assert.NotNil(t, mockTargetDevice2)
-	southbound.Targets[topodevice.ID(device2)] = mockTargetDevice2
-	device2Context, cancel2 := context.WithCancel(context.Background())
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, topodevice.ID(device2))
 	defer cancel2()
-	mockTargetDevice2.EXPECT().Context().Return(&device2Context).AnyTimes()
 	// First time is the SET - no error
 	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 	// Second time will be a rollback but SET returns error
@@ -405,18 +395,19 @@ func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
 	err = networkChanges.Create(networkChange1)
 	assert.NoError(t, err)
 
-	deviceChangeChan := make(chan stream.Event)
-	ctx, err := deviceChanges.Watch(device.NewVersionedID(device2, v1), deviceChangeChan, devicechangestore.WithReplay())
+	device2Chan := make(chan stream.Event)
+	ctx, err := deviceChanges.Watch(device.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	var wg sync.WaitGroup
-	wg.Add(3) // It takes 5 turns of the reconciler to get it right
-	for i := 0; i < 3; i++ {
+	eventsExpected := 3
+	wg.Add(eventsExpected) // It can take several turns of the reconciler to complete the change
+	for i := 0; i < eventsExpected; i++ {
 		select {
-		case event := <-deviceChangeChan:
+		case event := <-device2Chan:
 			change := event.Object.(*devicechange.DeviceChange)
-			t.Logf("%s event. %v", change.ID, change.Status)
+			t.Logf("%s event %d. %v", change.ID, i, change.Status)
 			switch i {
 			case 0:
 				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
@@ -434,20 +425,17 @@ func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
 				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
 				assert.Equal(t, uint64(1), change.Status.Incarnation)
 			default:
-				t.Errorf("unexpected event on device-1 %v", change)
+				t.Errorf("unexpected event on device-2 %v", change)
 				t.FailNow()
 			}
 			wg.Done()
 		case <-time.After(500 * time.Millisecond):
+			t.Logf("timed out waiting for event from device-2")
 			t.FailNow()
 		}
 	}
 	wg.Wait()
-
-	// Should cause an event to be sent to the Watcher
-	// Watcher should pass it to the Reconciler (if not filtered)
-	// Reconciler should process it
-	// Verify that device changes were created
+	t.Logf("Done waiting for %d device-2 events", eventsExpected)
 
 	retryUpdate := 0
 	for { // It can happen that the controller will make another update after the GET
@@ -476,13 +464,40 @@ func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
 	}
 	assert.NoError(t, err)
 
-	wg.Add(4) // It takes 5 turns of the reconciler to get it right
-	for i := 0; i < 4; i++ {
+	change1Chan := make(chan stream.Event)
+	ctx, err = networkChanges.Watch(change1Chan, networkchangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	eventsExpectedChange1 := 2
+	eventsExpectedDevice2 := 4
+	wg.Add(eventsExpectedChange1 + eventsExpectedDevice2) // It can take several turns of the reconciler to complete the change
+	var j, k int
+	for i := 0; i < eventsExpectedChange1+eventsExpectedDevice2; i++ {
 		select {
-		case event := <-deviceChangeChan:
+		case event := <-change1Chan:
+			change := event.Object.(*networkchange.NetworkChange)
+			t.Logf("%s event %d. %v", change.ID, j, change.Status)
+			assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
+			assert.Equal(t, types.State_PENDING, change.Status.State)
+			switch j {
+			case 0:
+				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+				assert.Equal(t, `Administratively requested rollback`, change.Status.Message)
+				assert.Equal(t, uint64(2), change.Status.Incarnation)
+			case 1:
+				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
+				assert.Equal(t, `rollback rejected by device`, change.Status.Message)
+				assert.Equal(t, uint64(2), change.Status.Incarnation)
+			default:
+				t.Errorf("unexpected event on device-1 %v", change)
+			}
+			j++
+			wg.Done()
+		case event := <-device2Chan:
 			change := event.Object.(*devicechange.DeviceChange)
-			t.Logf("%s event. %v", change.ID, change.Status)
-			switch i {
+			t.Logf("%s event %d. %v", change.ID, k, change.Status)
+			switch k {
 			case 0:
 				assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
 				assert.Equal(t, types.State_PENDING, change.Status.State)
@@ -510,15 +525,18 @@ func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
 					strings.ReplaceAll(change.Status.Message, "  ", " "))
 				assert.Equal(t, uint64(2), change.Status.Incarnation)
 			default:
-				t.Errorf("unexpected event on device-1 %v", change)
+				t.Errorf("unexpected event on device-2 %v", change)
 				t.FailNow()
 			}
+			k++
 			wg.Done()
 		case <-time.After(500 * time.Millisecond):
+			t.Logf("timed out waiting for event from device-2")
 			t.FailNow()
 		}
 	}
 	wg.Wait()
+	t.Logf("Done waiting for %d change-1 and %d device-2 events", eventsExpectedChange1, eventsExpectedDevice2)
 	ctx.Close()
 
 	networkChange1, err = networkChanges.Get(networkChange1.GetID())
@@ -549,5 +567,221 @@ func Test_NewControllerDoRollbackWhichFails(t *testing.T) {
 
 	// Should give 5 attempts 20+40+80 ms
 	// Can't verify in a test though as different platforms will run at different speeds
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+}
+
+// A Network Change is made to 2 devices.
+// But neither of the devices are connected - not in the device cache
+// We want to rollback this NetworkChange, rolling back the devicechange on both devices,
+// in the end leaving both devices unchanged.
+// The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
+func Test_ControllerRollbackOnPending(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	deviceCache := newDeviceCache(ctrl)
+	defer deviceCache.Close()
+
+	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer leadershipStore.Close()
+
+	mastershipStore, err := mastershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer mastershipStore.Close()
+
+	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
+		deviceCache, leadershipStore, mastershipStore)
+
+	err = networkChangeController.Start()
+	assert.NoError(t, err)
+	defer networkChangeController.Stop()
+
+	err = deviceChangeController.Start()
+	assert.NoError(t, err)
+	defer deviceChangeController.Stop()
+
+	// Create a network change
+	networkChange1 := &networkchange.NetworkChange{
+		ID: "change-1",
+		Changes: []*devicechange.Change{
+			&deviceChange1,
+			&deviceChange2,
+		},
+	}
+
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
+
+	change1Chan := make(chan stream.Event)
+	ctx, err := networkChanges.Watch(change1Chan, networkchangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	device2Chan := make(chan stream.Event)
+	ctx, err = deviceChanges.Watch(device.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	var wg sync.WaitGroup
+	eventsExpectedChange1 := 3
+	eventsExpectedDevice2 := 2
+	wg.Add(eventsExpectedChange1 + eventsExpectedDevice2) // It can take several turns of the reconciler to complete the change
+	var j, k int
+	for i := 0; i < eventsExpectedChange1+eventsExpectedDevice2; i++ {
+		select {
+		case event := <-change1Chan:
+			change := event.Object.(*networkchange.NetworkChange)
+			t.Logf("%s event %d. %v", change.ID, j, change.Status)
+			assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+			assert.Equal(t, types.State_PENDING, change.Status.State)
+			assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+			switch j {
+			case 0, 1:
+				assert.Equal(t, uint64(0), change.Status.Incarnation)
+			case 2:
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			default:
+				t.Errorf("unexpected event on change-1 %v", change)
+			}
+			j++
+			wg.Done()
+		case event := <-device2Chan:
+			change := event.Object.(*devicechange.DeviceChange)
+			t.Logf("%s event %d. %v", change.ID, k, change.Status)
+			assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+			assert.Equal(t, types.State_PENDING, change.Status.State)
+			assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+			switch k {
+			case 0:
+				assert.Equal(t, uint64(0), change.Status.Incarnation)
+			case 1:
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			default:
+				t.Errorf("unexpected event on device-2 %v", change)
+				t.FailNow()
+			}
+			k++
+			wg.Done()
+		case <-time.After(500 * time.Millisecond):
+			t.Logf("timed out waiting for event from change-1 and device-2")
+			t.FailNow()
+		}
+	}
+
+	wg.Wait()
+	t.Logf("Done waiting for %d change-1 and %d device-2 events", eventsExpectedChange1, eventsExpectedDevice2)
+
+	// Now try to do a rollback of these changes after a moment
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	time.Sleep(50 * time.Millisecond)
+	retryUpdate := 0
+	for { // It can happen that the controller will make another update after the GET
+		t.Logf("Trying to do a Rollback %d", retryUpdate)
+		changeRollback, errGet := networkChanges.Get(change1)
+		assert.NoError(t, errGet)
+		if errGet != nil {
+			t.FailNow()
+		}
+		assert.NotNil(t, changeRollback)
+		changeRollback.Status.Incarnation++
+		changeRollback.Status.Phase = types.Phase_ROLLBACK
+		changeRollback.Status.State = types.State_PENDING
+		changeRollback.Status.Reason = types.Reason_NONE
+		changeRollback.Status.Message = "Administratively requested rollback"
+
+		err = networkChanges.Update(changeRollback)
+		// It might fail with "write condition failed" - retry up to 10 times
+		if err != nil && err.Error() == "write condition failed" && retryUpdate < 10 {
+			time.Sleep(10 * time.Millisecond)
+			t.Logf("Retrying update (#%d) after '%s'", retryUpdate, err.Error())
+			retryUpdate++
+			continue
+		}
+		break
+	}
+	assert.NoError(t, err)
+
+	eventsExpectedChange1 = 2
+	eventsExpectedDevice2 = 1
+	wg.Add(eventsExpectedChange1 + eventsExpectedDevice2) // It can take several turns of the reconciler to complete the change
+	j = 0
+	k = 0
+	for i := 0; i < eventsExpectedChange1+eventsExpectedDevice2; i++ {
+		select {
+		case event := <-change1Chan:
+			change := event.Object.(*networkchange.NetworkChange)
+			t.Logf("%s event %d. %v", change.ID, j, change.Status)
+			assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
+			assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+			assert.Equal(t, `Administratively requested rollback`, change.Status.Message)
+			assert.Equal(t, uint64(2), change.Status.Incarnation)
+			switch j {
+			case 0:
+				assert.Equal(t, types.State_PENDING, change.Status.State)
+			case 1:
+				assert.Equal(t, types.State_COMPLETE, change.Status.State)
+			default:
+				t.Errorf("unexpected event on change-1 %v", change)
+			}
+			j++
+			wg.Done()
+		case event := <-device2Chan:
+			change := event.Object.(*devicechange.DeviceChange)
+			t.Logf("%s event %d. %v", change.ID, k, change.Status)
+			switch k {
+			case 0:
+				assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
+				assert.Equal(t, types.State_COMPLETE, change.Status.State)
+				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+				assert.Equal(t, uint64(2), change.Status.Incarnation)
+			default:
+				t.Errorf("unexpected event on device-2 %v", change)
+				t.FailNow()
+			}
+			k++
+			wg.Done()
+		case <-time.After(500 * time.Millisecond):
+			t.Logf("timed out waiting for event from change-1 after rollback")
+			t.FailNow()
+		}
+	}
+
+	wg.Wait()
+	t.Logf("Done waiting for %d change-1 and %d events", eventsExpectedChange1, eventsExpectedDevice2)
+	ctx.Close()
+
+	// Verify that device changes were created
+	networkChange1, err = networkChanges.Get(networkChange1.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, types.Phase_ROLLBACK, networkChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, networkChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, networkChange1.Status.Reason)
+	assert.Equal(t, "Administratively requested rollback", networkChange1.Status.Message)
+	assert.Equal(t, uint64(2), networkChange1.Status.Incarnation)
+
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange1)
+	assert.Equal(t, types.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange1.Status.Reason)
+	assert.Equal(t, "", deviceChange1.Status.Message)
+	assert.Equal(t, uint64(2), deviceChange1.Status.Incarnation)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange2)
+	assert.Equal(t, types.Phase_ROLLBACK, deviceChange2.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange2.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange2.Status.Reason)
+	assert.Equal(t, "", deviceChange2.Status.Message)
+	assert.Equal(t, uint64(2), deviceChange2.Status.Incarnation)
+
+	// Should not repeat indefinitely
+	time.Sleep(50 * time.Millisecond)
 }

--- a/pkg/controller/change/network/reconciler_test.go
+++ b/pkg/controller/change/network/reconciler_test.go
@@ -127,7 +127,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 
 	// Reconcile the network change again
 	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "waiting for device change(s) to complete change-1")
 	assert.Nil(t, requeue.Requeue.Value)
 
 	// Verify the network change was not completed
@@ -181,7 +181,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 
 	// Reconcile the rollback again
 	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "waiting for device change(s) to complete change-1")
 	assert.Nil(t, requeue.Requeue.Value)
 
 	// Verify that the rollback is running
@@ -192,7 +192,7 @@ func TestReconcilerChangeRollback(t *testing.T) {
 
 	// Reconcile the rollback again
 	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "waiting for device change(s) to complete change-1")
 	assert.Nil(t, requeue.Requeue.Value)
 
 	// Verify that device change states were changed to PENDING
@@ -284,7 +284,7 @@ func TestReconcilerError(t *testing.T) {
 
 	// Reconcile the network change again
 	requeue, err = reconciler.Reconcile(controller.NewID(string(networkChange.ID)))
-	assert.NoError(t, err)
+	assert.EqualError(t, err, "waiting for device change(s) to complete change-1")
 	assert.Nil(t, requeue.Requeue.Value)
 
 	// Verify the network change was not completed
@@ -410,18 +410,14 @@ func newStores(t *testing.T, ctrl *gomock.Controller) (networkchanges.Store, dev
 	return networkChanges, deviceChanges, devices
 }
 
-func newDeviceCache(ctrl *gomock.Controller) *mockcache.MockCache {
-	cachedDevices := []*cache.Info{
-		{
-			DeviceID: device1,
+func newDeviceCache(ctrl *gomock.Controller, ids ...device.ID) *mockcache.MockCache {
+	cachedDevices := make([]*cache.Info, 0, len(ids))
+	for _, id := range ids {
+		cachedDevices = append(cachedDevices, &cache.Info{
+			DeviceID: id,
 			Type:     stratumType,
 			Version:  v1,
-		},
-		{
-			DeviceID: device2,
-			Type:     stratumType,
-			Version:  v1,
-		},
+		})
 	}
 
 	deviceCache := mockcache.NewMockCache(ctrl)


### PR DESCRIPTION
https://jira.opennetworking.org/browse/AETHER-1762

If a network change to a device or devices has not been applied - because none of the devices are connected, then it should be possible to rollback that network change

Integration tests are passing