### PR TITLE
AETHER-1817 synchronizer should only send gNMI changes to device of same version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/openconfig/goyang v0.2.2
 	github.com/openconfig/ygot v0.10.5
 	github.com/pelletier/go-toml v1.4.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -741,7 +741,6 @@ golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200128174031-69ecbb4d6d5d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073 h1:xMPOj6Pz6UipU1wXLkrtqpHbR0AVFnyPEQq/wRWz9lM=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -791,7 +790,6 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -841,7 +839,6 @@ golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -901,7 +898,6 @@ google.golang.org/genproto v0.0.0-20190716160619-c506a9f90610/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20190801165951-fa694d86fc64/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200519141106-08726f379972/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
-google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 h1:+kGHl1aib/qcwaRi1CbqBZ1rk19r85MNUf8HaBghugY=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201113130914-ce600e9a6f9e h1:jRAe+6EDD0LNrVzmjx7FxBivivOZTKnXMbH5lvmxLP8=
 google.golang.org/genproto v0.0.0-20201113130914-ce600e9a6f9e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=

--- a/pkg/controller/change/device/controller_test.go
+++ b/pkg/controller/change/device/controller_test.go
@@ -16,7 +16,6 @@ package device
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/golang/mock/gomock"
 	types "github.com/onosproject/onos-api/go/onos/config"
@@ -38,6 +37,7 @@ import (
 	southboundmock "github.com/onosproject/onos-config/pkg/test/mocks/southbound"
 	storemock "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	"github.com/onosproject/onos-lib-go/pkg/controller"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -594,7 +594,7 @@ func mockTargetDevice(t *testing.T, name devicetype.ID, ctrl *gomock.Controller)
 	deviceChangeStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(deviceID devicetype.VersionedID, c chan<- *devicechange.DeviceChange) (stream.Context, error) {
 			ctx := stream.NewContext(func() {})
-			return ctx, errors.New("no Configuration found")
+			return ctx, errors.NewNotFound("no Configuration found")
 		}).AnyTimes()
 	_, err := synchronizer.New(context.Background(), &mockDevice,
 		make(chan<- events.OperationalStateEvent), make(chan<- events.DeviceResponse),

--- a/pkg/controller/change/network/controller_test.go
+++ b/pkg/controller/change/network/controller_test.go
@@ -20,9 +20,8 @@ import (
 	types "github.com/onosproject/onos-api/go/onos/config/change"
 	devicechange "github.com/onosproject/onos-api/go/onos/config/change/device"
 	networkchange "github.com/onosproject/onos-api/go/onos/config/change/network"
-	"github.com/onosproject/onos-api/go/onos/config/device"
+	devicetype "github.com/onosproject/onos-api/go/onos/config/device"
 	devicechangecontroller "github.com/onosproject/onos-config/pkg/controller/change/device"
-	topodevice "github.com/onosproject/onos-config/pkg/device"
 	"github.com/onosproject/onos-config/pkg/southbound"
 	devicechangestore "github.com/onosproject/onos-config/pkg/store/change/device"
 	networkchangestore "github.com/onosproject/onos-config/pkg/store/change/network"
@@ -58,7 +57,7 @@ func setupControllers(t *testing.T, networkChanges networkchangestore.Store,
 	return networkChangeController, deviceChangeController
 }
 
-func newMockTarget(t *testing.T, ctrl *gomock.Controller, id topodevice.ID) (*southboundtest.MockTargetIf, context.CancelFunc) {
+func newMockTarget(t *testing.T, ctrl *gomock.Controller, id devicetype.VersionedID) (*southboundtest.MockTargetIf, context.CancelFunc) {
 	mockTargetDevice := southboundtest.NewMockTargetIf(ctrl)
 	assert.NotNil(t, mockTargetDevice)
 	southbound.Targets[id] = mockTargetDevice
@@ -90,11 +89,11 @@ func Test_NewController2Devices(t *testing.T) {
 	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
 		deviceCache, leadershipStore, mastershipStore)
 
-	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, topodevice.ID(device1))
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device1, v1))
 	defer cancel1()
 	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
-	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, topodevice.ID(device2))
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device2, v1))
 	defer cancel2()
 	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
 
@@ -183,13 +182,171 @@ func Test_NewController2Devices(t *testing.T) {
 	assert.Equal(t, types.Reason_NONE, deviceChange2.Status.Reason)
 	assert.Equal(t, "", deviceChange2.Status.Message)
 	assert.Equal(t, uint64(1), deviceChange2.Status.Incarnation)
+
+	// Should give 5 attempts 20+40+80 ms
+	// Can't verify in a test though as different platforms will run at different speeds
+	time.Sleep(50 * time.Millisecond)
+}
+
+// Make a Network change and it propagates down to 2 Device changes
+// One device is not contactable - we retry with exponential backoff
+// The other one is applied immediately
+// TODO Figure out if this behaviour is OK. Should we push to device-1 at all
+//  if we know in advance that device-2 is not contactable
+func Test_Controller2Devices1NotReady(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	deviceCache := newDeviceCache(ctrl, device1)
+	defer deviceCache.Close()
+
+	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer leadershipStore.Close()
+
+	mastershipStore, err := mastershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer mastershipStore.Close()
+
+	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
+		deviceCache, leadershipStore, mastershipStore)
+
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device1, v1))
+	defer cancel1()
+	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device2, v1))
+	defer cancel2()
+	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	err = networkChangeController.Start()
+	assert.NoError(t, err)
+	defer networkChangeController.Stop()
+
+	err = deviceChangeController.Start()
+	assert.NoError(t, err)
+	defer deviceChangeController.Stop()
+
+	// Create a network change
+	networkChange1 := &networkchange.NetworkChange{
+		ID: "change-1",
+		Changes: []*devicechange.Change{
+			&deviceChange1,
+			&deviceChange2,
+		},
+	}
+
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	// Verify that device changes were created
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
+
+	change1Chan := make(chan stream.Event)
+	ctx, err := networkChanges.Watch(change1Chan, networkchangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	device1Chan := make(chan stream.Event)
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	device2Chan := make(chan stream.Event)
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	var wg sync.WaitGroup
+	eventsExpectedChange1 := 3
+	eventsExpectedDevice1 := 2
+	eventsExpectedDevice2 := 3
+	wg.Add(eventsExpectedChange1 + eventsExpectedDevice1 + eventsExpectedDevice2) // It takes 4 turns of the reconciler to get it right
+	var j, k, l int
+	for i := 0; i < eventsExpectedChange1+eventsExpectedDevice1+eventsExpectedDevice2; i++ {
+		select {
+		case event := <-change1Chan:
+			change := event.Object.(*networkchange.NetworkChange)
+			t.Logf("%s event %d. %v", change.ID, j, change.Status)
+			assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+			assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+			switch j {
+			case 0, 1:
+				assert.Equal(t, types.State_PENDING, change.Status.State)
+				assert.Equal(t, uint64(0), change.Status.Incarnation)
+			case 2:
+				assert.Equal(t, types.State_PENDING, change.Status.State)
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			case 3:
+				assert.Equal(t, types.State_COMPLETE, change.Status.State)
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			default:
+				t.Errorf("unexpected event on change-1 %v", change)
+			}
+			j++
+			wg.Done()
+		case event := <-device1Chan:
+			change := event.Object.(*devicechange.DeviceChange)
+			t.Logf("%s event %d. %v", change.ID, k, change.Status)
+			k++
+			wg.Done()
+		case event := <-device2Chan:
+			change := event.Object.(*devicechange.DeviceChange)
+			t.Logf("%s event %d. %v", change.ID, l, change.Status)
+			l++
+			wg.Done()
+		case <-time.After(5 * time.Second):
+			t.Logf("timed out waiting for event from change-1")
+			t.FailNow()
+		}
+	}
+	wg.Wait()
+	t.Logf("Done waiting for %d change-1, %d device-1 and %d device-2 events", eventsExpectedChange1, eventsExpectedDevice1, eventsExpectedDevice2)
+	ctx.Close()
+
+	networkChange1, err = networkChanges.Get(networkChange1.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, types.Phase_CHANGE, networkChange1.Status.Phase)
+	assert.Equal(t, types.State_PENDING, networkChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, networkChange1.Status.Reason)
+	assert.Equal(t, uint64(1), networkChange1.Status.Incarnation)
+
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange1)
+	assert.Equal(t, types.Phase_CHANGE, deviceChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange1.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange1.Status.Reason)
+	assert.Equal(t, "", deviceChange1.Status.Message)
+	assert.Equal(t, uint64(1), deviceChange1.Status.Incarnation)
+	deviceChange2, err := deviceChanges.Get("change-1:device-2:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange2)
+	assert.Equal(t, types.Phase_CHANGE, deviceChange2.Status.Phase)
+	assert.Equal(t, types.State_PENDING, deviceChange2.Status.State)
+	assert.Equal(t, types.Reason_NONE, deviceChange2.Status.Reason)
+	assert.Equal(t, "", deviceChange2.Status.Message)
+	assert.Equal(t, uint64(1), deviceChange2.Status.Incarnation)
+
+	// Should give 5 attempts 20+40+80 ms
+	// Can't verify in a test though as different platforms will run at different speeds
+	time.Sleep(50 * time.Millisecond)
 }
 
 // a NetworkChange is made to 2 devices. One of the devices returns an error on Set
 // and so the NetworkChange is rolled back, rolling back the devicechange on both devices,
 // in the end leaving both devices unchanged.
 // The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
-func Test_Controller1FailsGnmiSet(t *testing.T) {
+// See Test_ControllerSingleDeviceFailsGnmiSet below for a test of the single device scenario
+// TODO: Figure out if this is the best approach. When there are 2 devices and one cannot
+//  take the change then it is a good idea to rollback the other. Ideally the failed
+//  device should keep retrying, and if it eventually succeeds then the other one can be replayed
+//  See https://jira.opennetworking.org/browse/AETHER-1815
+func Test_Controller2Devices1FailsGnmiSet(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	networkChanges, deviceChanges, devices := newStores(t, ctrl)
@@ -210,11 +367,11 @@ func Test_Controller1FailsGnmiSet(t *testing.T) {
 	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
 		deviceCache, leadershipStore, mastershipStore)
 
-	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, topodevice.ID(device1))
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device1, v1))
 	defer cancel1()
 	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 
-	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, topodevice.ID(device2))
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device2, v1))
 	defer cancel2()
 	// First time will return an error
 	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -254,12 +411,12 @@ func Test_Controller1FailsGnmiSet(t *testing.T) {
 	assert.NotNil(t, ctx)
 
 	device1Chan := make(chan stream.Event)
-	ctx, err = deviceChanges.Watch(device.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	device2Chan := make(chan stream.Event)
-	ctx, err = deviceChanges.Watch(device.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
@@ -344,6 +501,179 @@ func Test_Controller1FailsGnmiSet(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
+// Similar to Test_Controller2Devices1FailsGnmiSet above, but for 1 device it's a different flow
+// a NetworkChange is made to 1 devices. But the device returns an error on Set
+// and so the NetworkChange is rolled back, rolling back the devicechange on both devices,
+// in the end leaving both devices unchanged.
+// The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
+// TODO: figure out if this is really the best behaviour - for a single device this rollback
+//  should not be necessary - it's not affecting any other device so it can just sit there
+//  retrying until the device is fixed
+//  See https://jira.opennetworking.org/browse/AETHER-1815
+func Test_ControllerSingleDeviceFailsGnmiSet(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	networkChanges, deviceChanges, devices := newStores(t, ctrl)
+	defer networkChanges.Close()
+	defer deviceChanges.Close()
+
+	deviceCache := newDeviceCache(ctrl, device1, device2)
+	defer deviceCache.Close()
+
+	leadershipStore, err := leadershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer leadershipStore.Close()
+
+	mastershipStore, err := mastershipstore.NewLocalStore("cluster-1", "node-1")
+	assert.NoError(t, err)
+	defer mastershipStore.Close()
+
+	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
+		deviceCache, leadershipStore, mastershipStore)
+
+	mockTargetDevice1, cancel2 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device1, v1))
+	defer cancel2()
+	// First time will return an error
+	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, request *gnmi.SetRequest) (*gnmi.SetResponse, error) {
+			return nil, status.Errorf(codes.Internal, "simulated error in device-1 %s", request)
+		}).Times(1)
+	// Second time will be a rollback when SET is not possible - no error
+	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
+
+	err = networkChangeController.Start()
+	assert.NoError(t, err)
+	defer networkChangeController.Stop()
+
+	err = deviceChangeController.Start()
+	assert.NoError(t, err)
+	defer deviceChangeController.Stop()
+
+	// Create a network change
+	networkChange1 := &networkchange.NetworkChange{
+		ID: "change-1",
+		Changes: []*devicechange.Change{
+			&deviceChange1,
+		},
+	}
+
+	// Should cause an event to be sent to the Watcher
+	// Watcher should pass it to the Reconciler (if not filtered)
+	// Reconciler should process it
+	// Verify that device changes were created
+	err = networkChanges.Create(networkChange1)
+	assert.NoError(t, err)
+
+	change1Chan := make(chan stream.Event)
+	ctx, err := networkChanges.Watch(change1Chan, networkchangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	device1Chan := make(chan stream.Event)
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
+	assert.NoError(t, err)
+	assert.NotNil(t, ctx)
+
+	var wg sync.WaitGroup
+	eventsExpectedChange1 := 4
+	eventsExpectedDevice1 := 5
+	wg.Add(eventsExpectedChange1 + eventsExpectedDevice1) // It can take several turns of the reconciler to complete the change
+	var j, k int
+	for i := 0; i < eventsExpectedChange1+eventsExpectedDevice1; i++ {
+		select {
+		case event := <-change1Chan:
+			change := event.Object.(*networkchange.NetworkChange)
+			t.Logf("%s event %d. %v", change.ID, j, change.Status)
+			assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+			assert.Equal(t, types.State_PENDING, change.Status.State)
+			switch j {
+			case 0, 1:
+				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+				assert.Equal(t, uint64(0), change.Status.Incarnation)
+			case 2:
+				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			case 3:
+				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
+				assert.Equal(t, `change rejected by device`,
+					strings.ReplaceAll(change.Status.Message, "  ", " "))
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			default:
+				t.Errorf("unexpected event on device-1 %v", change)
+			}
+			j++
+			wg.Done()
+		case event := <-device1Chan:
+			change := event.Object.(*devicechange.DeviceChange)
+			t.Logf("%s event %d. %v", change.ID, k, change.Status)
+			switch k {
+			case 0:
+				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+				assert.Equal(t, types.State_PENDING, change.Status.State)
+				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+				assert.Equal(t, uint64(0), change.Status.Incarnation)
+			case 1:
+				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+				assert.Equal(t, types.State_PENDING, change.Status.State)
+				assert.Equal(t, types.Reason_NONE, change.Status.Reason)
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			case 2:
+				assert.Equal(t, types.Phase_CHANGE, change.Status.Phase)
+				assert.Equal(t, types.State_FAILED, change.Status.State)
+				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
+				assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-1 update:{path:{elem:{name:"foo"}} val:{string_val:"Hello world!"}} update:{path:{elem:{name:"bar"}} val:{string_val:"Hello world again!"}}`,
+					strings.ReplaceAll(change.Status.Message, "  ", " "))
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			case 3:
+				assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
+				assert.Equal(t, types.State_PENDING, change.Status.State)
+				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
+				assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-1 update:{path:{elem:{name:"foo"}} val:{string_val:"Hello world!"}} update:{path:{elem:{name:"bar"}} val:{string_val:"Hello world again!"}}`,
+					strings.ReplaceAll(change.Status.Message, "  ", " "))
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			case 4:
+				assert.Equal(t, types.Phase_ROLLBACK, change.Status.Phase)
+				assert.Equal(t, types.State_COMPLETE, change.Status.State)
+				assert.Equal(t, types.Reason_ERROR, change.Status.Reason)
+				assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-1 update:{path:{elem:{name:"foo"}} val:{string_val:"Hello world!"}} update:{path:{elem:{name:"bar"}} val:{string_val:"Hello world again!"}}`,
+					strings.ReplaceAll(change.Status.Message, "  ", " "))
+				assert.Equal(t, uint64(1), change.Status.Incarnation)
+			}
+			k++
+			wg.Done()
+		case <-time.After(5 * time.Second):
+			t.Logf("timed out waiting for event")
+			t.FailNow()
+		}
+	}
+
+	wg.Wait()
+	t.Logf("Done waiting for %d change-1 and %d device-1 events", eventsExpectedChange1, eventsExpectedDevice1)
+	ctx.Close()
+
+	networkChange1, err = networkChanges.Get(networkChange1.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, types.Phase_CHANGE, networkChange1.Status.Phase)
+	assert.Equal(t, types.State_PENDING, networkChange1.Status.State)
+	assert.Equal(t, types.Reason_ERROR, networkChange1.Status.Reason)
+	assert.Equal(t, "change rejected by device", networkChange1.Status.Message)
+	assert.Equal(t, uint64(1), networkChange1.Status.Incarnation)
+
+	deviceChange1, err := deviceChanges.Get("change-1:device-1:1.0.0")
+	assert.NoError(t, err)
+	assert.NotNil(t, deviceChange1)
+	assert.Equal(t, types.Phase_ROLLBACK, deviceChange1.Status.Phase)
+	assert.Equal(t, types.State_COMPLETE, deviceChange1.Status.State)
+	assert.Equal(t, types.Reason_ERROR, deviceChange1.Status.Reason)
+	assert.Equal(t, `rpc error: code = Internal desc = simulated error in device-1 update:{path:{elem:{name:"foo"}} val:{string_val:"Hello world!"}} update:{path:{elem:{name:"bar"}} val:{string_val:"Hello world again!"}}`,
+		strings.ReplaceAll(deviceChange1.Status.Message, "  ", " "))
+	assert.Equal(t, uint64(1), deviceChange1.Status.Incarnation)
+
+	// Should give 5 attempts 20+40+80 ms
+	// Can't verify in a test though as different platforms will run at different speeds
+	time.Sleep(50 * time.Millisecond)
+}
+
 // a NetworkChange is made to 2 devices, which succeeds
 // Then rollback the network change, but one of the devices does not accept the rollback
 // The Network and Device changes sit there in COMPLETED state in the ROLLBACK phase.
@@ -368,11 +698,11 @@ func Test_ControllerDoRollbackWhichFails(t *testing.T) {
 	networkChangeController, deviceChangeController := setupControllers(t, networkChanges, deviceChanges, devices,
 		deviceCache, leadershipStore, mastershipStore)
 
-	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, topodevice.ID(device1))
+	mockTargetDevice1, cancel1 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device1, v1))
 	defer cancel1()
 	mockTargetDevice1.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 
-	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, topodevice.ID(device2))
+	mockTargetDevice2, cancel2 := newMockTarget(t, ctrl, devicetype.NewVersionedID(device2, v1))
 	defer cancel2()
 	// First time is the SET - no error
 	mockTargetDevice2.EXPECT().Set(gomock.Any(), gomock.Any()).Return(nil, nil).Times(1)
@@ -412,12 +742,12 @@ func Test_ControllerDoRollbackWhichFails(t *testing.T) {
 	assert.NotNil(t, ctx)
 
 	device1Chan := make(chan stream.Event)
-	ctx, err = deviceChanges.Watch(device.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	device2Chan := make(chan stream.Event)
-	ctx, err = deviceChanges.Watch(device.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
@@ -673,12 +1003,12 @@ func Test_ControllerRollbackOnPending(t *testing.T) {
 	assert.NotNil(t, ctx)
 
 	device1Chan := make(chan stream.Event)
-	ctx, err = deviceChanges.Watch(device.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device1, v1), device1Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 
 	device2Chan := make(chan stream.Event)
-	ctx, err = deviceChanges.Watch(device.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
+	ctx, err = deviceChanges.Watch(devicetype.NewVersionedID(device2, v1), device2Chan, devicechangestore.WithReplay())
 	assert.NoError(t, err)
 	assert.NotNil(t, ctx)
 

--- a/pkg/controller/change/network/watcher.go
+++ b/pkg/controller/change/network/watcher.go
@@ -173,7 +173,7 @@ func (w *DeviceWatcher) updateWatch(topodevice *devicetopo.Device, ch chan<- con
 	}
 	w.streams[deviceID] = ctx
 
-	log.Infof("Watching device %v", deviceID)
+	log.Infof("Watching device %v (%s)", deviceID, topodevice.Type)
 
 	w.wg.Add(1)
 	go func() {

--- a/pkg/manager/manager_deep_test.go
+++ b/pkg/manager/manager_deep_test.go
@@ -17,6 +17,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	devicetype "github.com/onosproject/onos-api/go/onos/config/device"
 	"github.com/onosproject/onos-api/go/onos/topo"
 	"github.com/onosproject/onos-config/pkg/modelregistry"
 	"io/ioutil"
@@ -165,7 +166,7 @@ func setUpDeepTest(t *testing.T) (*Manager, *AllMocks) {
 
 	mockTargetCreationfn := func() southbound.TargetIf {
 		mockTarget := southboundmocks.NewMockTargetIf(ctrl)
-		southbound.Targets[topodevice.ID(device1)] = mockTarget
+		southbound.Targets[devicetype.NewVersionedID(device1, deviceVersion1)] = mockTarget
 
 		mockTarget.EXPECT().CapabilitiesWithString(
 			gomock.Any(),

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -15,7 +15,6 @@
 package manager
 
 import (
-	"errors"
 	"github.com/golang/mock/gomock"
 	changetypes "github.com/onosproject/onos-api/go/onos/config/change"
 	devicechange "github.com/onosproject/onos-api/go/onos/config/change/device"
@@ -29,6 +28,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	mockcache "github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/openconfig/ygot/ygot"
@@ -222,7 +222,7 @@ func setUp(t *testing.T) (*Manager, *AllMocks) {
 			if len(changes) != 0 {
 				return ctx, nil
 			}
-			return ctx, errors.New("no Configuration found")
+			return ctx, errors.NewNotFound("no Configuration found")
 		}).AnyTimes()
 	_ = mockDeviceChangesStore.Create(deviceChange1)
 
@@ -245,7 +245,7 @@ func setUp(t *testing.T) (*Manager, *AllMocks) {
 				},
 			}, nil
 		}
-		return nil, errors.New("no Configuration found")
+		return nil, errors.NewNotFound("no Configuration found")
 	}).AnyTimes()
 
 	// Mock Device Store

--- a/pkg/northbound/admin/admin.go
+++ b/pkg/northbound/admin/admin.go
@@ -27,9 +27,9 @@ import (
 	"github.com/onosproject/onos-config/pkg/manager"
 	streams "github.com/onosproject/onos-config/pkg/store/stream"
 	"github.com/onosproject/onos-config/pkg/utils"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/onosproject/onos-lib-go/pkg/northbound"
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 )
 
@@ -53,12 +53,12 @@ type Server struct {
 // UploadRegisterModel uploads and registers a new model plugin.
 // Deprecated: models should only be loaded at startup
 func (s Server) UploadRegisterModel(stream admin.ConfigAdminService_UploadRegisterModelServer) error {
-	return errors.New("not implemented")
+	return errors.NewNotSupported("not implemented")
 }
 
 // ListRegisteredModels lists the registered models..
 func (s Server) ListRegisteredModels(req *admin.ListModelsRequest, stream admin.ConfigAdminService_ListRegisteredModelsServer) error {
-	return errors.New("not implemented")
+	return errors.NewNotSupported("not implemented")
 }
 
 // RollbackNetworkChange rolls back a named atomix-based network change.
@@ -203,5 +203,5 @@ func (s Server) CompactChanges(ctx context.Context, request *admin.CompactChange
 			return &admin.CompactChangesResponse{}, nil
 		}
 	}
-	return nil, errors.New("snapshot state unknown")
+	return nil, errors.NewInvalid("snapshot state unknown")
 }

--- a/pkg/northbound/admin/admin_test.go
+++ b/pkg/northbound/admin/admin_test.go
@@ -16,7 +16,6 @@ package admin
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/golang/mock/gomock"
 	"github.com/onosproject/onos-api/go/onos/config/admin"
@@ -28,6 +27,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/stream"
 	mockstore "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	"github.com/onosproject/onos-config/pkg/test/mocks/store/cache"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 	"gotest.tools/assert"
@@ -100,7 +100,7 @@ func Test_RollbackNetworkChange_BadName(t *testing.T) {
 	mockNwChStore, ok := mgrTest.NetworkChangesStore.(*mockstore.MockNetworkChangesStore)
 	assert.Assert(t, ok, "casting mock store")
 
-	mockNwChStore.EXPECT().Get(gomock.Any()).Return(nil, errors.New("Rollback aborted. Network change BAD CHANGE not found"))
+	mockNwChStore.EXPECT().Get(gomock.Any()).Return(nil, errors.NewNotFound("Rollback aborted. Network change BAD CHANGE not found"))
 	_, err := client.RollbackNetworkChange(context.Background(), &admin.RollbackRequest{Name: "BAD CHANGE"})
 	assert.ErrorContains(t, err, "Rollback aborted. Network change BAD CHANGE not found")
 }
@@ -113,7 +113,7 @@ func Test_RollbackNetworkChange_NoChange(t *testing.T) {
 	mockNwChStore, ok := mgrTest.NetworkChangesStore.(*mockstore.MockNetworkChangesStore)
 	assert.Assert(t, ok, "casting mock store")
 
-	mockNwChStore.EXPECT().Get(gomock.Any()).Return(nil, errors.New("change is not specified"))
+	mockNwChStore.EXPECT().Get(gomock.Any()).Return(nil, errors.NewNotFound("change is not specified"))
 	_, err := client.RollbackNetworkChange(context.Background(), &admin.RollbackRequest{Name: ""})
 	assert.ErrorContains(t, err, "is empty")
 }

--- a/pkg/southbound/clientManager_test.go
+++ b/pkg/southbound/clientManager_test.go
@@ -17,6 +17,7 @@ package southbound
 import (
 	"context"
 	"github.com/golang/protobuf/proto"
+	devicetype "github.com/onosproject/onos-api/go/onos/config/device"
 	topodevice "github.com/onosproject/onos-config/pkg/device"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/openconfig/gnmi/client"
@@ -138,13 +139,13 @@ func tearDown() {
 	GnmiBaseClientFactory = saveGnmiBaseClientFactory
 }
 
-func getDevice1Target(t *testing.T) (*Target, topodevice.ID, context.Context) {
+func getDevice1Target(t *testing.T) (*Target, devicetype.VersionedID, context.Context) {
 	target := &Target{}
 	ctx := context.Background()
 	key, err := target.ConnectTarget(ctx, device)
 	assert.NoError(t, err)
 	assert.NotNil(t, target.clt)
-	assert.Equal(t, string(key), "localhost-1")
+	assert.Equal(t, "localhost-1", string(key.GetID()))
 	assert.NotNil(t, target.ctx)
 	return target, key, ctx
 }
@@ -164,7 +165,7 @@ func Test_ConnectTarget(t *testing.T) {
 func Test_BadTarget(t *testing.T) {
 	setUp(t)
 
-	key := topodevice.ID("no such target")
+	key := devicetype.NewVersionedID("no such target", "0.0.0")
 	_, fetchError := GetTarget(key)
 	assert.Error(t, fetchError)
 	assert.Contains(t, fetchError.Error(), "does not exist")

--- a/pkg/southbound/defs.go
+++ b/pkg/southbound/defs.go
@@ -16,6 +16,7 @@ package southbound
 
 import (
 	"context"
+	devicetype "github.com/onosproject/onos-api/go/onos/config/device"
 	topodevice "github.com/onosproject/onos-config/pkg/device"
 	"github.com/openconfig/gnmi/client"
 	gpb "github.com/openconfig/gnmi/proto/gnmi"
@@ -28,7 +29,7 @@ var TargetGenerator func() TargetIf = NewTarget
 
 // TargetIf defines the API for Target
 type TargetIf interface {
-	ConnectTarget(ctx context.Context, device topodevice.Device) (topodevice.ID, error)
+	ConnectTarget(ctx context.Context, device topodevice.Device) (devicetype.VersionedID, error)
 	//Capabilities(ctx context.Context, request *gpb.CapabilityRequest) (*gpb.CapabilityResponse, error)
 	CapabilitiesWithString(ctx context.Context, request string) (*gpb.CapabilityResponse, error)
 	Get(ctx context.Context, request *gpb.GetRequest) (*gpb.GetResponse, error)

--- a/pkg/southbound/synchronizer/device_update.go
+++ b/pkg/southbound/synchronizer/device_update.go
@@ -15,7 +15,7 @@
 package synchronizer
 
 import (
-	"errors"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -61,7 +61,7 @@ func (s *Session) updateDevice(connectivity topo.ConnectivityState, channel topo
 
 	// Do not update the state of a device if the node encounters a mastership term greater than its own
 	if uint64(s.mastershipState.Term) < currentTerm {
-		return backoff.Permanent(errors.New("device mastership term is greater than node mastership term"))
+		return backoff.Permanent(errors.NewInvalid("device mastership term is greater than node mastership term"))
 	}
 
 	topoDevice.MastershipTerm = uint64(s.mastershipState.Term)

--- a/pkg/southbound/synchronizer/session.go
+++ b/pkg/southbound/synchronizer/session.go
@@ -111,7 +111,7 @@ func (s *Session) open() error {
 
 // connect connects to a device using a gNMI session
 func (s *Session) connect() error {
-	log.Infof("Connecting to device: %s at %s", s.device.ID, s.device.Address)
+	log.Infof("Connecting to device: %s:%s at %s", s.device.ID, s.device.Version, s.device.Address)
 	count := 0
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = backoffInterval
@@ -122,7 +122,8 @@ func (s *Session) connect() error {
 
 	notify := func(err error, t time.Duration) {
 		count++
-		log.Infof("Failed to connect to %s. Retry after %v Attempt %d", s.device.ID, b.GetElapsedTime(), count)
+		log.Infof("Failed to connect to %s:%s. Retry after %v Attempt %d",
+			s.device.ID, s.device.Version, b.GetElapsedTime(), count)
 	}
 
 	err := backoff.RetryNotify(s.synchronize, b, notify)
@@ -146,7 +147,7 @@ func (s *Session) synchronize() error {
 	plugin, err := s.modelRegistry.GetPlugin(modelName)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			log.Warnf("Model Plugin not available for device", s.device.ID, s.device.Version)
+			log.Warnf("Model Plugin not available for device %s:%s", s.device.ID, s.device.Version)
 		} else {
 			s.mu.RUnlock()
 			log.Error(err)

--- a/pkg/southbound/synchronizer/session_manager_test.go
+++ b/pkg/southbound/synchronizer/session_manager_test.go
@@ -15,7 +15,7 @@
 package synchronizer
 
 import (
-	"errors"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"sync"
 	"testing"
 
@@ -45,7 +45,7 @@ func createSessionManager(t *testing.T) *SessionManager {
 	deviceChangeStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(deviceID devicetype.VersionedID, c chan<- *devicechange.DeviceChange) (stream.Context, error) {
 			ctx := stream.NewContext(func() {})
-			return ctx, errors.New("no Configuration found")
+			return ctx, errors.NewNotFound("no Configuration found")
 		}).AnyTimes()
 
 	deviceStore.EXPECT().Watch(gomock.Any()).AnyTimes()

--- a/pkg/southbound/synchronizer/synchronizer.go
+++ b/pkg/southbound/synchronizer/synchronizer.go
@@ -18,6 +18,7 @@ package synchronizer
 import (
 	"context"
 	"fmt"
+	devicetype "github.com/onosproject/onos-api/go/onos/config/device"
 	configmodel "github.com/onosproject/onos-config-model/pkg/model"
 	"regexp"
 	"strings"
@@ -49,7 +50,7 @@ type Synchronizer struct {
 	context.Context
 	*topodevice.Device
 	operationalStateChan chan<- events.OperationalStateEvent
-	key                  topodevice.ID
+	key                  devicetype.VersionedID
 	query                client.Query
 	modelReadOnlyPaths   modelregistry.ReadOnlyPathMap
 	operationalCache     devicechange.TypedValueMap

--- a/pkg/southbound/synchronizer/synchronizer_test.go
+++ b/pkg/southbound/synchronizer/synchronizer_test.go
@@ -16,7 +16,6 @@ package synchronizer
 
 import (
 	context2 "context"
-	"errors"
 	"fmt"
 	"github.com/golang/mock/gomock"
 	devicechange "github.com/onosproject/onos-api/go/onos/config/change/device"
@@ -32,6 +31,7 @@ import (
 	storemock "github.com/onosproject/onos-config/pkg/test/mocks/store"
 	"github.com/onosproject/onos-config/pkg/utils"
 	"github.com/onosproject/onos-config/pkg/utils/values"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -100,7 +100,7 @@ func synchronizerSetUp(t *testing.T) (synchronizerParameters, error) {
 	deviceChangeStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(deviceID devicetype.VersionedID, c chan<- *devicechange.DeviceChange) (stream.Context, error) {
 			ctx := stream.NewContext(func() {})
-			return ctx, errors.New("no Configuration found")
+			return ctx, errors.NewNotFound("no Configuration found")
 		}).AnyTimes()
 
 	return synchronizerParameters{
@@ -707,7 +707,7 @@ func Test_LikeStratum(t *testing.T) {
 	deviceChangeStore.EXPECT().List(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(deviceID devicetype.VersionedID, c chan<- *devicechange.DeviceChange) (stream.Context, error) {
 			ctx := stream.NewContext(func() {})
-			return ctx, errors.New("no Configuration found")
+			return ctx, errors.NewNotFound("no Configuration found")
 		}).AnyTimes()
 	s, err := New(context2.Background(), &mockDevice1,
 		opstateChan, responseChan, opStateCache, roPathMap, mockTarget,

--- a/pkg/southbound/synchronizer/synchronizer_test.go
+++ b/pkg/southbound/synchronizer/synchronizer_test.go
@@ -166,7 +166,7 @@ func TestNew(t *testing.T) {
 	mockTarget.EXPECT().ConnectTarget(
 		gomock.Any(),
 		mockDevice1,
-	).Return(topodevice.ID(mock1NameStr), nil)
+	).Return(devicetype.NewVersionedID(devicetype.ID(mockDevice1.ID), devicetype.Version(mockDevice1.Version)), nil)
 
 	mockTarget.EXPECT().CapabilitiesWithString(
 		gomock.Any(),
@@ -365,7 +365,7 @@ func TestNewWithExistingConfig(t *testing.T) {
 	mockTarget.EXPECT().ConnectTarget(
 		gomock.Any(),
 		*device1,
-	).Return(device1.ID, nil)
+	).Return(devicetype.NewVersionedID(devicetype.ID(device1.ID), devicetype.Version(device1.Version)), nil)
 
 	mockTarget.EXPECT().CapabilitiesWithString(
 		gomock.Any(),
@@ -562,7 +562,7 @@ func TestNewWithExistingConfigError(t *testing.T) {
 	mockTarget.EXPECT().ConnectTarget(
 		gomock.Any(),
 		*device1,
-	).Return(device1.ID, nil)
+	).Return(devicetype.NewVersionedID(devicetype.ID(device1.ID), devicetype.Version(device1.Version)), nil)
 
 	mockTarget.EXPECT().CapabilitiesWithString(
 		gomock.Any(),
@@ -686,7 +686,7 @@ func Test_LikeStratum(t *testing.T) {
 	mockTarget.EXPECT().ConnectTarget(
 		gomock.Any(),
 		mockDevice1,
-	).Return(topodevice.ID(mock1NameStr), nil)
+	).Return(devicetype.NewVersionedID(devicetype.ID(mockDevice1.ID), devicetype.Version(mockDevice1.Version)), nil)
 
 	mockTarget.EXPECT().CapabilitiesWithString(
 		gomock.Any(),

--- a/pkg/test/mocks/southbound/target_mock.go
+++ b/pkg/test/mocks/southbound/target_mock.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	southbound "github.com/onosproject/onos-config/pkg/southbound"
+	devicetype "github.com/onosproject/onos-api/go/onos/config/device"
 	topodevice "github.com/onosproject/onos-config/pkg/device"
 	client "github.com/openconfig/gnmi/client"
 	gnmi "github.com/openconfig/gnmi/proto/gnmi"
@@ -38,10 +39,10 @@ func (m *MockTargetIf) EXPECT() *MockTargetIfMockRecorder {
 }
 
 // ConnectTarget mocks base method
-func (m *MockTargetIf) ConnectTarget(ctx context.Context, device topodevice.Device) (topodevice.ID, error) {
+func (m *MockTargetIf) ConnectTarget(ctx context.Context, device topodevice.Device) (devicetype.VersionedID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConnectTarget", ctx, device)
-	ret0, _ := ret[0].(topodevice.ID)
+	ret0, _ := ret[0].(devicetype.VersionedID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -17,9 +17,9 @@ package gnmi
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/onosproject/onos-api/go/onos/topo"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"io"
 	"strconv"
 	"strings"
@@ -119,7 +119,7 @@ func AwaitDeviceState(simulator *helm.HelmRelease, predicate func(object *topo.O
 		}
 		time.Sleep(time.Second)
 	}
-	return errors.New("device wait timed out")
+	return errors.NewTimeout("device wait timed out")
 }
 
 // NewDeviceEntity :
@@ -521,7 +521,7 @@ func GetDestination() (client.Destination, error) {
 
 	configService, err := configClient.CoreV1().Services().Get("onos-config")
 	if err != nil || configService == nil {
-		return client.Destination{}, errors.New("can't find service for onos-config")
+		return client.Destination{}, errors.NewNotFound("can't find service for onos-config")
 	}
 
 	return client.Destination{


### PR DESCRIPTION
Also added a couple of new network/controller tests

and tidied up usage of "errors" package - harmonizing on the one from "onos-lib-go"