### PR TITLE
AETHER-2110 In Topo Entity to Device mapping - type should be taken from Configurable (not Kind)

### DIFF
--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -230,7 +230,7 @@ func ToDevice(object *topo.Object) (*Device, error) {
 		ID:          ID(object.ID),
 		Revision:    object.Revision,
 		Protocols:   protocolStates,
-		Type:        typeKindID,
+		Type:        Type(configurable.Type),
 		Role:        Role(asset.Role),
 		Displayname: asset.Name,
 		Address:     configurable.Address,
@@ -247,6 +247,9 @@ func ToDevice(object *topo.Object) (*Device, error) {
 		MastershipTerm: mastership.Term,
 		MasterKey:      mastership.NodeId,
 		Object:         object,
+	}
+	if configurable.Type == "" {
+		d.Type = typeKindID
 	}
 	return d, nil
 }

--- a/pkg/device/device_test.go
+++ b/pkg/device/device_test.go
@@ -24,7 +24,8 @@ import (
 const (
 	deviceName    = "device-1"
 	deviceDisplay = "Device 1"
-	deviceType    = "devicesim"
+	deviceKind    = "devicesim" // Kind can only be lowercase
+	deviceType    = "Devicesim" // Type must be Titlecase to match Model Plugin
 	deviceAddress = "devicesim-1:10161"
 	deviceVersion = "1.0.0"
 )
@@ -35,7 +36,7 @@ func Test_ObjectToDevice(t *testing.T) {
 		Type: topo.Object_ENTITY,
 		Obj: &topo.Object_Entity{
 			Entity: &topo.Entity{
-				KindID: topo.ID(deviceType),
+				KindID: topo.ID(deviceKind),
 			},
 		},
 	}
@@ -86,7 +87,7 @@ func Test_ObjectToDevice_error(t *testing.T) {
 		Type: topo.Object_ENTITY,
 		Obj: &topo.Object_Entity{
 			Entity: &topo.Entity{
-				KindID: topo.ID(deviceType),
+				KindID: topo.ID(deviceKind),
 			},
 		},
 	}


### PR DESCRIPTION
In the [topo.yaml](https://github.com/onosproject/sdran-helm-charts/blob/master/aether-roc-umbrella/templates/topo.yaml) the `Entity` has a `Kind` which is given in all lowercase as `aether` - it has to be lowercase - nothing else will be accepted

The same `Entity` has a `Configurable` aspect which has a `Type` attribute, and this is titlecase `Aether`.

When `onos-config` synchronizes from `onos-topo` it converts this `Entity` in to a `Device`, but it sets the `Type` of the `Device` to the `Kind` value, but should be the `Configurable/Type` value, so that it can match the `Modelplugin` type i.e. `Aether`