### PR TITLE
Improve algorithms in transaction controller

### DIFF
--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -83,7 +83,7 @@ func (r *Reconciler) Reconcile(id controller.ID) (controller.Result, error) {
 	defer cancel()
 
 	configurationID := id.Value.(configapi.ConfigurationID)
-	config, err := r.configurations.Get(ctx, configapi.TargetID(configurationID))
+	config, err := r.configurations.Get(ctx, configurationID)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			log.Warnf("Failed to reconcile configuration %s, %s", configurationID, err)

--- a/pkg/controller/configuration/watcher.go
+++ b/pkg/controller/configuration/watcher.go
@@ -102,7 +102,6 @@ func (w *TopoWatcher) Start(ch chan<- controller.ID) error {
 				err = event.Object.GetAspect(&topoapi.Configurable{})
 				if err == nil {
 					ch <- controller.NewID(configapi.ConfigurationID(event.Object.GetID()))
-
 				}
 			}
 		}

--- a/pkg/controller/transaction/watcher.go
+++ b/pkg/controller/transaction/watcher.go
@@ -55,21 +55,7 @@ func (w *ConfigurationWatcher) Start(ch chan<- controller.ID) error {
 	w.cancel = cancel
 	go func() {
 		for event := range eventCh {
-			configTransactionIndex := event.Configuration.Status.TransactionIndex
-			configSyncIndex := event.Configuration.Status.SyncIndex
-			configTransaction, err := w.transactions.GetByIndex(ctx, configTransactionIndex)
-			if err != nil {
-				log.Warn(err)
-				continue
-			}
-			configSyncTransaction, err := w.transactions.GetByIndex(ctx, configSyncIndex)
-			if err != nil {
-				log.Warn(err)
-				continue
-			}
-
-			ch <- controller.NewID(configTransaction.ID)
-			ch <- controller.NewID(configSyncTransaction.ID)
+			ch <- controller.NewID(event.Configuration.Status.TransactionIndex)
 		}
 	}()
 	return nil
@@ -111,7 +97,7 @@ func (w *Watcher) Start(ch chan<- controller.ID) error {
 	w.cancel = cancel
 	go func() {
 		for event := range eventCh {
-			ch <- controller.NewID(event.Transaction.ID)
+			ch <- controller.NewID(event.Transaction.Index)
 		}
 	}()
 

--- a/pkg/northbound/admin/configuration.go
+++ b/pkg/northbound/admin/configuration.go
@@ -25,7 +25,8 @@ import (
 // GetConfiguration returns response with the requested configuration
 func (s Server) GetConfiguration(ctx context.Context, req *admin.GetConfigurationRequest) (*admin.GetConfigurationResponse, error) {
 	log.Infof("Received GetConfiguration request: %+v", req)
-	conf, err := s.configurationsStore.Get(ctx, req.TargetID)
+	// TODO: Add target type and version to configuration ID
+	conf, err := s.configurationsStore.Get(ctx, configuration.NewID(req.TargetID, "", ""))
 	if err != nil {
 		log.Warnf("GetConfiguration %+v failed: %v", req, err)
 		return nil, errors.Status(err).Err()

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/onosproject/onos-config/pkg/store/configuration"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -110,7 +111,8 @@ func (s *Server) getUpdate(ctx context.Context, targetInfo targetInfo, prefix *g
 		pathAsString = utils.StrPath(prefix) + pathAsString
 	}
 
-	targetConfig, err := s.configurations.Get(ctx, targetInfo.targetID)
+	// TODO: Add target type and version to configuration ID
+	targetConfig, err := s.configurations.Get(ctx, configuration.NewID(targetID, "", ""))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/configuration/configuration.go
+++ b/pkg/store/configuration/configuration.go
@@ -16,7 +16,6 @@ package configuration
 
 import (
 	"context"
-
 	"github.com/atomix/atomix-go-framework/pkg/atomix/meta"
 
 	"github.com/golang/protobuf/proto"
@@ -32,10 +31,15 @@ import (
 
 var log = logging.GetLogger("store", "configuration")
 
+// NewID returns a new Configuration ID for the given target/type/version
+func NewID(targetID configapi.TargetID, targetType configapi.TargetType, targetVersion configapi.TargetVersion) configapi.ConfigurationID {
+	return configapi.ConfigurationID(targetID)
+}
+
 // Store configuration store interface
 type Store interface {
 	// Get gets the configuration intended for a given target ID
-	Get(ctx context.Context, id configapi.TargetID) (*configapi.Configuration, error)
+	Get(ctx context.Context, id configapi.ConfigurationID) (*configapi.Configuration, error)
 
 	// Create creates a configuration
 	Create(ctx context.Context, configuration *configapi.Configuration) error
@@ -103,7 +107,7 @@ func WithConfigurationID(id configapi.ConfigurationID) WatchOption {
 	return watchIDOption{id: id}
 }
 
-func (s *configurationStore) Get(ctx context.Context, id configapi.TargetID) (*configapi.Configuration, error) {
+func (s *configurationStore) Get(ctx context.Context, id configapi.ConfigurationID) (*configapi.Configuration, error) {
 	log.Debugf("Getting configuration %s", id)
 	entry, err := s.configurations.Get(ctx, string(id))
 	if err != nil {

--- a/pkg/store/configuration/configuration_test.go
+++ b/pkg/store/configuration/configuration_test.go
@@ -95,7 +95,7 @@ func TestConfigurationStore(t *testing.T) {
 	assert.NotEqual(t, configapi.Revision(0), target2Config.Revision)
 
 	// Get the configuration
-	target1Config, err = store2.Get(context.TODO(), target1)
+	target1Config, err = store2.Get(context.TODO(), configapi.ConfigurationID(target1))
 	assert.NoError(t, err)
 	assert.NotNil(t, target1Config)
 	assert.Equal(t, configapi.ConfigurationID(target1), target1Config.ID)
@@ -128,7 +128,7 @@ func TestConfigurationStore(t *testing.T) {
 	assert.Equal(t, 2, len(configurationList))
 
 	// Read and then update the configuration
-	target2Config, err = store2.Get(context.TODO(), target2)
+	target2Config, err = store2.Get(context.TODO(), configapi.ConfigurationID(target2))
 	assert.NoError(t, err)
 	assert.NotNil(t, target2Config)
 	target2Config.Status.State = configapi.ConfigurationState_CONFIGURATION_COMPLETE
@@ -142,9 +142,9 @@ func TestConfigurationStore(t *testing.T) {
 	assert.Equal(t, target2Config.Revision, event.Configuration.Revision)
 
 	// Verify that concurrent updates fail
-	target1Config11, err := store1.Get(context.TODO(), target1)
+	target1Config11, err := store1.Get(context.TODO(), configapi.ConfigurationID(target1))
 	assert.NoError(t, err)
-	target1Config12, err := store2.Get(context.TODO(), target1)
+	target1Config12, err := store2.Get(context.TODO(), configapi.ConfigurationID(target1))
 	assert.NoError(t, err)
 
 	target1Config11.Status.State = configapi.ConfigurationState_CONFIGURATION_COMPLETE
@@ -166,7 +166,7 @@ func TestConfigurationStore(t *testing.T) {
 	// Delete a configuration
 	err = store1.Delete(context.TODO(), target2Config)
 	assert.NoError(t, err)
-	configuration, err := store2.Get(context.TODO(), target2)
+	configuration, err := store2.Get(context.TODO(), configapi.ConfigurationID(target2))
 	assert.Error(t, err)
 	assert.True(t, errors.IsNotFound(err))
 	assert.Nil(t, configuration)


### PR DESCRIPTION
This PR fixes some bugs in the `Transaction` controller:
* Initialize `Configuration` when not present
* Reconcile `Transaction`s by index
* Trigger `Transaction` reconciliation on `Configuration` updates by `TransactionIndex`
* Version configurations by target+type+version `ConfigurationID`
* Add rollback handling

The `Configuration` store has a new `NewID` function that creates a `ConfigurationID` from target, type, and version, but it currently ignores the type and version. Some future code changes will be required to support target types/versions.