### PR TITLE
Add missing watchers to configuration controller

### DIFF
--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -51,8 +51,12 @@ func NewController(topo topo.Store, conns gnmi.ConnManager, configurations confi
 	})
 
 	c.Watch(&TopoWatcher{
-		topo:           topo,
-		configurations: configurations,
+		topo: topo,
+	})
+
+	c.Watch(&ConnWatcher{
+		conns: conns,
+		topo:  topo,
 	})
 
 	c.Reconcile(&Reconciler{

--- a/pkg/controller/transaction/controller.go
+++ b/pkg/controller/transaction/controller.go
@@ -28,7 +28,6 @@ import (
 
 	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
 	"github.com/onosproject/onos-config/pkg/store/configuration"
-	"github.com/onosproject/onos-config/pkg/store/topo"
 	"github.com/onosproject/onos-config/pkg/store/transaction"
 	"github.com/onosproject/onos-lib-go/pkg/controller"
 	"github.com/onosproject/onos-lib-go/pkg/logging"
@@ -39,7 +38,7 @@ const defaultTimeout = 30 * time.Second
 var log = logging.GetLogger("controller", "transaction")
 
 // NewController returns a new control relation  controller
-func NewController(topo topo.Store, transactions transaction.Store, configurations configuration.Store, pluginRegistry *pluginregistry.PluginRegistry) *controller.Controller {
+func NewController(transactions transaction.Store, configurations configuration.Store, pluginRegistry *pluginregistry.PluginRegistry) *controller.Controller {
 	c := controller.NewController("transaction")
 
 	c.Watch(&Watcher{
@@ -53,7 +52,6 @@ func NewController(topo topo.Store, transactions transaction.Store, configuratio
 
 	c.Reconcile(&Reconciler{
 		transactions:   transactions,
-		topo:           topo,
 		configurations: configurations,
 		pluginRegistry: pluginRegistry,
 	})
@@ -63,7 +61,6 @@ func NewController(topo topo.Store, transactions transaction.Store, configuratio
 
 // Reconciler reconciles transactions
 type Reconciler struct {
-	topo           topo.Store
 	transactions   transaction.Store
 	configurations configuration.Store
 	pluginRegistry *pluginregistry.PluginRegistry

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -148,8 +148,8 @@ func (m *Manager) startConfigurationController(topo topo.Store, conns sb.ConnMan
 	return configurationController.Start()
 }
 
-func (m *Manager) startTransactionController(topo topo.Store, configurations configuration.Store, transactions transaction.Store, pluginRegistry *pluginregistry.PluginRegistry) error {
-	transactionController := transactioncontroller.NewController(topo, transactions, configurations, pluginRegistry)
+func (m *Manager) startTransactionController(configurations configuration.Store, transactions transaction.Store, pluginRegistry *pluginregistry.PluginRegistry) error {
+	transactionController := transactioncontroller.NewController(transactions, configurations, pluginRegistry)
 	return transactionController.Start()
 
 }
@@ -205,7 +205,7 @@ func (m *Manager) Start() error {
 		return err
 	}
 
-	err = m.startTransactionController(topoStore, configurations, transactions, m.pluginRegistry)
+	err = m.startTransactionController(configurations, transactions, m.pluginRegistry)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Because reconciliation in the `Configuration` controller depends on the master relation and connection, the configuration controller should be triggered on changes to controls relations and connections.