### PR TITLE
Adding more checks to tests

### DIFF
--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -15,10 +15,10 @@
 package config
 
 import (
-	"testing"
-
 	gnmiutils "github.com/onosproject/onos-config/test/utils/gnmi"
 	"github.com/onosproject/onos-config/test/utils/proto"
+	"testing"
+	"time"
 )
 
 const (
@@ -34,18 +34,25 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	targetClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
 
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
 
 	// Set a value using gNMI client
 	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, devicePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
-	// Check that the value was set correctly
+	// Check that the value was set correctly, both in onos-config and on the target
 	gnmiutils.CheckGNMIValue(t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckTargetValue(t, targetClient, devicePath, tzValue)
 
 	// Remove the path we added
 	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, gnmiutils.NoPaths, devicePath, gnmiutils.SyncExtension(t))
 
-	//  Make sure it got removed
-	gnmiutils.CheckGNMIValue(t, gnmiClient, devicePath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
+	//  Make sure it got removed, both in onos-config and on the target
+	gnmiutils.CheckGNMIValue(t, gnmiClient, devicePath, "", 0,
+		"incorrect value found for path /system/clock/config/timezone-name after delete")
+
+	// FIXME: Allow some time for target to commit the change; this should not be necessary
+	time.Sleep(2 * time.Second)
+	gnmiutils.CheckTargetValueDeleted(t, targetClient, devicePath)
 }

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -460,7 +460,16 @@ func CheckTargetValue(t *testing.T, targetGnmiClient gnmiclient.Impl, targetPath
 	} else {
 		assert.Fail(t, "Failed to query target: %v", err)
 	}
+}
 
+// CheckTargetValueDeleted makes sure target path is missing when queried via GNMI
+func CheckTargetValueDeleted(t *testing.T, targetGnmiClient gnmiclient.Impl, targetPaths []protoutils.TargetPath) {
+	_, _, err := GetGNMIValue(MakeContext(), targetGnmiClient, targetPaths, gpb.Encoding_JSON)
+	if err == nil {
+		assert.Fail(t, "Path not deleted", targetPaths)
+	} else if !strings.Contains(err.Error(), "NotFound") {
+		assert.Fail(t, "Incorrect error received", err)
+	}
 }
 
 // GetTargetGNMIClientOrFail creates a GNMI client to a target. If there is an error, the test is failed


### PR DESCRIPTION
This adds checks to validate that the target was properly affected. Note that delay is required; otherwise the checks will fail. This was marked as FIXME.