### PR TITLE
Using locally vendored modules in the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,16 +18,11 @@ mod-lint: mod-update # @HELP ensure that the required dependencies are in place
 	# dependencies are vendored, but not committed, go.sum is the only thing we need to check
 	bash -c "diff -u <(echo -n) <(git diff go.sum)"
 
-local-protos: # @HELP Copies a local version of the onos-api dependency into the vendor directory
-ifdef LOCAL_PROTOS
-	rm -rf vendor/github.com/onosproject/onos-api/go
-	mkdir -p vendor/github.com/onosproject/onos-api/go
-	cp -r ${LOCAL_PROTOS}/go/* vendor/github.com/onosproject/onos-api/go
-	rm -rf vendor/github.com/onosproject/onos-api/go/vendor
-endif
+local-deps: # @HELP imports local deps in the vendor folder
+local-deps: local-helmit local-onos-api local-onos-lib-go local-onos-ric-sdk-go local-onos-test local-onos-topo
 
 build: # @HELP build the Go binaries and run all validations (default)
-build: mod-update local-protos
+build: mod-update local-deps
 	go build -mod=vendor -o build/_output/onos-config ./cmd/onos-config
 
 test: # @HELP run the unit tests and source code validation producing a golang style report
@@ -46,7 +41,7 @@ helmit-rbac: integration-test-namespace # @HELP run helmit gnmi tests locally
 
 integration-tests: helmit-config helmit-rbac # @HELP run helmit integration tests locally
 
-onos-config-docker: mod-update local-protos # @HELP build onos-config base Docker image
+onos-config-docker: mod-update local-deps # @HELP build onos-config base Docker image
 	docker build . -f build/onos-config/Dockerfile \
 		-t ${DOCKER_REPOSITORY}onos-config:${ONOS_CONFIG_VERSION}
 
@@ -75,4 +70,44 @@ clean:: # @HELP remove all the build artifacts
 	rm -rf ./build/_output ./vendor ./cmd/onos-config/onos-config ./cmd/onos/onos
 	go clean -testcache github.com/onosproject/onos-config/...
 
+local-helmit: # @HELP Copies a local version of the helmit dependency into the vendor directory
+ifdef LOCAL_HELMIT
+	rm -rf vendor/github.com/onosproject/helmit/go
+	mkdir -p vendor/github.com/onosproject/helmit/go
+	cp -r ${LOCAL_HELMIT}/go/* vendor/github.com/onosproject/helmit/go
+endif
 
+local-onos-api: # @HELP Copies a local version of the onos-api dependency into the vendor directory
+ifdef LOCAL_ONOS_API
+	rm -rf vendor/github.com/onosproject/onos-api/go
+	mkdir -p vendor/github.com/onosproject/onos-api/go
+	cp -r ${LOCAL_ONOS_API}/go/* vendor/github.com/onosproject/onos-api/go
+endif
+
+local-onos-lib-go: # @HELP Copies a local version of the onos-lib-go dependency into the vendor directory
+ifdef LOCAL_ONOS_LIB_GO
+	rm -rf vendor/github.com/onosproject/onos-lib-go
+	mkdir -p vendor/github.com/onosproject/onos-lib-go
+	cp -r ${LOCAL_ONOS_LIB_GO}/* vendor/github.com/onosproject/onos-lib-go
+endif
+
+local-onos-ric-sdk-go: # @HELP Copies a local version of the onos-ric-sdk-go dependency into the vendor directory
+ifdef LOCAL_ONOS_RIC_SDK
+	rm -rf vendor/github.com/onosproject/onos-ric-sdk-go
+	mkdir -p vendor/github.com/onosproject/onos-ric-sdk-go
+	cp -r ${LOCAL_ONOS_RIC_SDK}/* vendor/github.com/onosproject/onos-ric-sdk-go
+endif
+
+local-onos-topo: # @HELP Copies a local version of the onos-topo dependency into the vendor directory
+ifdef LOCAL_ONOS_TOPO
+	rm -rf vendor/github.com/onosproject/onos-topo
+	mkdir -p vendor/github.com/onosproject/onos-topo
+	cp -r ${LOCAL_ONOS_TOPO}/* vendor/github.com/onosproject/onos-topo
+endif
+
+local-onos-test: # @HELP Copies a local version of the onos-test dependency into the vendor directory
+ifdef LOCAL_ONOS_TEST
+	rm -rf vendor/github.com/onosproject/onos-test
+	mkdir -p vendor/github.com/onosproject/onos-test
+	cp -r ${LOCAL_ONOS_TEST}/* vendor/github.com/onosproject/onos-test
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = bash -e -o pipefail
+
 export CGO_ENABLED=1
 export GO111MODULE=on
 
@@ -8,16 +10,32 @@ ONOS_CONFIG_VERSION ?= latest
 build-tools:=$(shell if [ ! -d "./build/build-tools" ]; then cd build && git clone https://github.com/onosproject/build-tools.git; fi)
 include ./build/build-tools/make/onf-common.mk
 
+mod-update: # @HELP Download the dependencies to the vendor folder
+	go mod tidy
+	go mod vendor
+
+mod-lint: mod-update # @HELP ensure that the required dependencies are in place
+	# dependencies are vendored, but not committed, go.sum is the only thing we need to check
+	bash -c "diff -u <(echo -n) <(git diff go.sum)"
+
+local-protos: # @HELP Copies a local version of the onos-api dependency into the vendor directory
+ifdef LOCAL_PROTOS
+	rm -rf vendor/github.com/onosproject/onos-api/go
+	mkdir -p vendor/github.com/onosproject/onos-api/go
+	cp -r ${LOCAL_PROTOS}/go/* vendor/github.com/onosproject/onos-api/go
+	rm -rf vendor/github.com/onosproject/onos-api/go/vendor
+endif
+
 build: # @HELP build the Go binaries and run all validations (default)
-build:
-	go build -o build/_output/onos-config ./cmd/onos-config
+build: mod-update local-protos
+	go build -mod=vendor -o build/_output/onos-config ./cmd/onos-config
 
 test: # @HELP run the unit tests and source code validation producing a golang style report
-test: build deps license_check linters
+test: mod-lint build license_check linters
 	go test -race github.com/onosproject/onos-config/...
 
 jenkins-test: # @HELP run the unit tests and source code validation producing a junit style report for Jenkins
-jenkins-test: build deps license_check linters
+jenkins-test: mod-lint build license_check linters
 	TEST_PACKAGES=github.com/onosproject/onos-config/... ./build/build-tools/build/jenkins/make-unit
 
 helmit-config: integration-test-namespace # @HELP run helmit gnmi tests locally
@@ -28,13 +46,12 @@ helmit-rbac: integration-test-namespace # @HELP run helmit gnmi tests locally
 
 integration-tests: helmit-config helmit-rbac # @HELP run helmit integration tests locally
 
-onos-config-docker: # @HELP build onos-config base Docker image
+onos-config-docker: mod-update local-protos # @HELP build onos-config base Docker image
 	docker build . -f build/onos-config/Dockerfile \
-		--build-arg ONOS_MAKE_TARGET=build \
 		-t ${DOCKER_REPOSITORY}onos-config:${ONOS_CONFIG_VERSION}
 
 images: # @HELP build all Docker images
-images: build onos-config-docker
+images: onos-config-docker
 
 kind: # @HELP build Docker images and add them to the currently configured kind cluster
 kind: images kind-only

--- a/build/onos-config/Dockerfile
+++ b/build/onos-config/Dockerfile
@@ -1,17 +1,17 @@
 FROM onosproject/config-model-build:v1.0 AS build
 
 ENV GO111MODULE=on
-ARG ONOS_MAKE_TARGET=build
+WORKDIR /build
 
-COPY Makefile go.mod go.sum /build/
-RUN go mod download -x
+# copy only the files that are needed for the build, exclude everything else to make better use of the docker cache
+COPY ./cmd /build/cmd
+COPY ./pkg /build/pkg
+COPY ./vendor /build/vendor
+COPY ./go.mod /build
+COPY ./go.sum /build
 
-COPY Makefile /build/
-COPY cmd/ /build/cmd/
-COPY pkg/ /build/pkg/
-COPY build/build-tools /build/build/build-tools/
-
-RUN make ${ONOS_MAKE_TARGET}
+# build the executable
+RUN go build -mod=vendor -o build/_output/onos-config ./cmd/onos-config
 
 FROM alpine:3.13
 RUN apk add libc6-compat


### PR DESCRIPTION
This is an hybrid approach in which `modules` are not committed in the repo, but downloaded on the host file-system and then mounted in the container.

* Modules are not stored in the repo, they are downloaded before the Docker build (or the regular build)
* After modules are downloaded, if LOCAL_PROTOS is set, the onos-api library is replaced with a local copy
* Only the files required for the build are mounted in the Docker container to optimize the cache usage