### PR TITLE
Refactoring of integration test utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,10 @@ jenkins-test: build deps license_check linters
 helmit-config: integration-test-namespace # @HELP run helmit gnmi tests locally
 	helmit test -n test ./cmd/onos-config-tests --suite config
 
-helmit-cli: integration-test-namespace # @HELP run helmit cli tests locally
-	helmit test -n test ./cmd/onos-config-tests --suite cli
-
 helmit-rbac: integration-test-namespace # @HELP run helmit gnmi tests locally
 	helmit test -n test ./cmd/onos-config-tests --suite rbac --secret keycloak-password=${keycloak_password}
 
-integration-tests: helmit-config helmit-cli helmit-rbac # @HELP run helmit integration tests locally
+integration-tests: helmit-config helmit-rbac # @HELP run helmit integration tests locally
 
 onos-config-docker: # @HELP build onos-config base Docker image
 	docker build . -f build/onos-config/Dockerfile \

--- a/benchmark/gnmi/getbench.go
+++ b/benchmark/gnmi/getbench.go
@@ -17,16 +17,16 @@ package gnmi
 import (
 	"context"
 	"github.com/onosproject/helmit/pkg/benchmark"
-	"github.com/onosproject/onos-config/test/utils/gnmi"
+	gnmiutils "github.com/onosproject/onos-config/test/utils/gnmi"
 	gbp "github.com/openconfig/gnmi/proto/gnmi"
 	"time"
 )
 
 // BenchmarkGet tests get of GNMI paths
 func (s *BenchmarkSuite) BenchmarkGet(b *benchmark.Benchmark) error {
-	devicePath := gnmi.GetTargetPath(s.simulator.Name(), "/system/config/motd-banner")
+	devicePath := gnmiutils.GetTargetPath(s.simulator.Name(), "/system/config/motd-banner")
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
-	_, _, err := gnmi.GetGNMIValue(ctx, s.client, devicePath, gbp.Encoding_PROTO)
+	_, _, err := gnmiutils.GetGNMIValue(ctx, s.client, devicePath, gnmiutils.NoExtensions, gbp.Encoding_PROTO)
 	return err
 }

--- a/benchmark/gnmi/suite.go
+++ b/benchmark/gnmi/suite.go
@@ -72,7 +72,7 @@ var _ benchmark.SetupWorker = &BenchmarkSuite{}
 func getGNMIClient() (*client.Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	dest, err := gnmi.GetOnosConfigDestination()
+	dest, err := gnmi.GetOnosConfigDestination(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/test/config/compactChanges.go
+++ b/test/config/compactChanges.go
@@ -173,7 +173,7 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 		[]proto.TargetPath{
 			sim1Path4[0], sim1Path2[0], sim1Path3[0], sim1Path5[0],
 			sim2Path1[0], sim2Path2[0], sim2Path3[0], sim2Path4[0],
-		}, gpb.Encoding_PROTO)
+		}, gnmiutils.NoExtensions, gpb.Encoding_PROTO)
 	assert.NoError(t, err)
 	for _, expectedValue := range expectedValues {
 		switch expectedValue.TargetName + "," + expectedValue.Path {

--- a/test/config/compactChanges.go
+++ b/test/config/compactChanges.go
@@ -94,7 +94,7 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	t.Logf("Testing CompactChanges - nw changes %s, %s on %s AND %s on %s AND %s on both",
 		sim1nwTransactionID1, sim1nwTransactionID2, simulator1.Name(), sim2nwTransactionID2, simulator2.Name(), bothSimNwTransactionID)
 
-	adminClient, err := gnmiutils.NewAdminServiceClient()
+	adminClient, err := gnmiutils.NewAdminServiceClient(ctx)
 	assert.NoError(t, err)
 
 	// Now try compacting changes

--- a/test/config/compactChanges.go
+++ b/test/config/compactChanges.go
@@ -57,6 +57,9 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	const domainNameSim1 = "sim1.domain.name"
 	const domainNameSim2 = "sim2.domain.name"
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Create 2 simulators
 	simulator1 := gnmiutils.CreateSimulator(t)
 	simulator2 := gnmiutils.CreateSimulator(t)
@@ -66,27 +69,27 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	gnmiutils.WaitForTargetAvailable(t, topo.ID(simulator1.Name()), 2*time.Minute)
 	gnmiutils.WaitForTargetAvailable(t, topo.ID(simulator2.Name()), 2*time.Minute)
 
-	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	// Make a GNMI client to use for request
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Set a value using gNMI client
 	sim1Path1 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), tzPath, tzValue, proto.StringVal)
-	sim1nwTransactionID1, _ := gnmiutils.SetGNMIValueOrFail(t, gnmiClient, sim1Path1, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	sim1nwTransactionID1, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, sim1Path1, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	sim1Path2 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), motdPath, motdValue1, proto.StringVal)
-	sim1nwTransactionID2, _ := gnmiutils.SetGNMIValueOrFail(t, gnmiClient, sim1Path2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	sim1nwTransactionID2, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, sim1Path2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Make a triple path change to Sim2
 	sim2Path1 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), tzPath, tzParis, proto.StringVal)
 	sim2Path2 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), motdPath, motdValue2, proto.StringVal)
 	sim2Path3 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), domainNamePath, domainNameSim2, proto.StringVal)
 
-	sim2nwTransactionID2, _ := gnmiutils.SetGNMIValueOrFail(t, gnmiClient, []proto.TargetPath{sim2Path1[0], sim2Path2[0], sim2Path3[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	sim2nwTransactionID2, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim2Path1[0], sim2Path2[0], sim2Path3[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Finally make a change to both devices
 	sim1Path3 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), loginBnrPath, loginBnr1, proto.StringVal)
 	sim2Path4 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), loginBnrPath, loginBnr2, proto.StringVal)
-	bothSimNwTransactionID, _ := gnmiutils.SetGNMIValueOrFail(t, gnmiClient, []proto.TargetPath{sim1Path3[0], sim2Path4[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	bothSimNwTransactionID, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim1Path3[0], sim2Path4[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	t.Logf("Testing CompactChanges - nw changes %s, %s on %s AND %s on %s AND %s on both",
 		sim1nwTransactionID1, sim1nwTransactionID2, simulator1.Name(), sim2nwTransactionID2, simulator2.Name(), bothSimNwTransactionID)
@@ -163,10 +166,10 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	// Set a value using gNMI client
 	sim1Path4 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), tzPath, tzMilan, proto.StringVal)
 	sim1Path5 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), domainNamePath, domainNameSim1, proto.StringVal)
-	_, _ = gnmiutils.SetGNMIValueOrFail(t, gnmiClient, []proto.TargetPath{sim1Path4[0], sim1Path5[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	_, _ = gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim1Path4[0], sim1Path5[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Now check every value for both sim1 and sim2
-	expectedValues, _, err := gnmiutils.GetGNMIValue(gnmiutils.MakeContext(), gnmiClient,
+	expectedValues, _, err := gnmiutils.GetGNMIValue(ctx, gnmiClient,
 		[]proto.TargetPath{
 			sim1Path4[0], sim1Path2[0], sim1Path3[0], sim1Path5[0],
 			sim2Path1[0], sim2Path2[0], sim2Path3[0], sim2Path4[0],

--- a/test/config/compactChanges.go
+++ b/test/config/compactChanges.go
@@ -70,26 +70,26 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	gnmiutils.WaitForTargetAvailable(t, topo.ID(simulator2.Name()), 2*time.Minute)
 
 	// Make a GNMI client to use for request
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Set a value using gNMI client
 	sim1Path1 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), tzPath, tzValue, proto.StringVal)
-	sim1nwTransactionID1, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, sim1Path1, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	sim1nwTransactionID1, _ := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, sim1Path1, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	sim1Path2 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), motdPath, motdValue1, proto.StringVal)
-	sim1nwTransactionID2, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, sim1Path2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	sim1nwTransactionID2, _ := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, sim1Path2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Make a triple path change to Sim2
 	sim2Path1 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), tzPath, tzParis, proto.StringVal)
 	sim2Path2 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), motdPath, motdValue2, proto.StringVal)
 	sim2Path3 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), domainNamePath, domainNameSim2, proto.StringVal)
 
-	sim2nwTransactionID2, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim2Path1[0], sim2Path2[0], sim2Path3[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	sim2nwTransactionID2, _ := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim2Path1[0], sim2Path2[0], sim2Path3[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Finally make a change to both devices
 	sim1Path3 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), loginBnrPath, loginBnr1, proto.StringVal)
 	sim2Path4 := gnmiutils.GetTargetPathWithValue(simulator2.Name(), loginBnrPath, loginBnr2, proto.StringVal)
-	bothSimNwTransactionID, _ := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim1Path3[0], sim2Path4[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	bothSimNwTransactionID, _ := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim1Path3[0], sim2Path4[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	t.Logf("Testing CompactChanges - nw changes %s, %s on %s AND %s on %s AND %s on both",
 		sim1nwTransactionID1, sim1nwTransactionID2, simulator1.Name(), sim2nwTransactionID2, simulator2.Name(), bothSimNwTransactionID)
@@ -166,7 +166,7 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	// Set a value using gNMI client
 	sim1Path4 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), tzPath, tzMilan, proto.StringVal)
 	sim1Path5 := gnmiutils.GetTargetPathWithValue(simulator1.Name(), domainNamePath, domainNameSim1, proto.StringVal)
-	_, _ = gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim1Path4[0], sim1Path5[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, []proto.TargetPath{sim1Path4[0], sim1Path5[0]}, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Now check every value for both sim1 and sim2
 	expectedValues, _, err := gnmiutils.GetGNMIValue(ctx, gnmiClient,

--- a/test/config/compactChanges.go
+++ b/test/config/compactChanges.go
@@ -61,13 +61,13 @@ func (s *TestSuite) TestCompactChanges(t *testing.T) {
 	defer cancel()
 
 	// Create 2 simulators
-	simulator1 := gnmiutils.CreateSimulator(t)
-	simulator2 := gnmiutils.CreateSimulator(t)
+	simulator1 := gnmiutils.CreateSimulator(ctx, t)
+	simulator2 := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, simulator1)
 	defer gnmiutils.DeleteSimulator(t, simulator2)
 
-	gnmiutils.WaitForTargetAvailable(t, topo.ID(simulator1.Name()), 2*time.Minute)
-	gnmiutils.WaitForTargetAvailable(t, topo.ID(simulator2.Name()), 2*time.Minute)
+	gnmiutils.WaitForTargetAvailable(ctx, t, topo.ID(simulator1.Name()), 2*time.Minute)
+	gnmiutils.WaitForTargetAvailable(ctx, t, topo.ID(simulator2.Name()), 2*time.Minute)
 
 	// Make a GNMI client to use for request
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)

--- a/test/config/configrestarttest.go
+++ b/test/config/configrestarttest.go
@@ -36,22 +36,22 @@ func (s *TestSuite) TestGetOperationAfterNodeRestart(t *testing.T) {
 	defer cancel()
 
 	// Make a GNMI client to use for onos-config requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)
 
 	targetPath := gnmiutils.GetTargetPathWithValue(simulator.Name(), restartTzPath, restartTzValue, proto.StringVal)
 
 	// Set a value using onos-config
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Restart onos-config
 	configPod := hautils.FindPodWithPrefix(t, "onos-config")
 	hautils.CrashPodOrFail(t, configPod)
 
 	// Check that the value was set correctly in the new onos-config instance
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after restart returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after restart returned the wrong value")
 
 	// Check that the value is set on the target
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
@@ -68,7 +68,7 @@ func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
 	defer cancel()
 
 	// Make a GNMI client to use for onos-config requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)
 
 	targetPath := gnmiutils.GetTargetPathWithValue(simulator.Name(), restartTzPath, restartTzValue, proto.StringVal)
 
@@ -77,10 +77,10 @@ func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
 	hautils.CrashPodOrFail(t, configPod)
 
 	// Set a value using onos-config
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value is set on the target
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)

--- a/test/config/configrestarttest.go
+++ b/test/config/configrestarttest.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"context"
 	gnmiutils "github.com/onosproject/onos-config/test/utils/gnmi"
 	hautils "github.com/onosproject/onos-config/test/utils/ha"
 	"github.com/onosproject/onos-config/test/utils/proto"
@@ -33,28 +32,30 @@ func (s *TestSuite) TestGetOperationAfterNodeRestart(t *testing.T) {
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Make a GNMI client to use for onos-config requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(context.Background(), t, gnmiutils.WithRetry)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
 
 	targetPath := gnmiutils.GetTargetPathWithValue(simulator.Name(), restartTzPath, restartTzValue, proto.StringVal)
 
 	// Set a value using onos-config
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValue(t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Restart onos-config
 	configPod := hautils.FindPodWithPrefix(t, "onos-config")
 	hautils.CrashPodOrFail(t, configPod)
 
 	// Check that the value was set correctly in the new onos-config instance
-	gnmiutils.CheckGNMIValue(t, gnmiClient, targetPath, restartTzValue, 0, "Query after restart returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after restart returned the wrong value")
 
 	// Check that the value is set on the target
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
-	gnmiutils.CheckTargetValue(t, targetGnmiClient, targetPath, restartTzValue)
-
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, restartTzValue)
 }
 
 // TestSetOperationAfterNodeRestart tests a Set operation after restarting the onos-config node
@@ -63,8 +64,11 @@ func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Make a GNMI client to use for onos-config requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(context.Background(), t, gnmiutils.WithRetry)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
 
 	targetPath := gnmiutils.GetTargetPathWithValue(simulator.Name(), restartTzPath, restartTzValue, proto.StringVal)
 
@@ -73,12 +77,12 @@ func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
 	hautils.CrashPodOrFail(t, configPod)
 
 	// Set a value using onos-config
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValue(t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value is set on the target
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
-	gnmiutils.CheckTargetValue(t, targetGnmiClient, targetPath, restartTzValue)
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, restartTzValue)
 }

--- a/test/config/configrestarttest.go
+++ b/test/config/configrestarttest.go
@@ -44,18 +44,18 @@ func (s *TestSuite) TestGetOperationAfterNodeRestart(t *testing.T) {
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Restart onos-config
 	configPod := hautils.FindPodWithPrefix(t, "onos-config")
 	hautils.CrashPodOrFail(t, configPod)
 
 	// Check that the value was set correctly in the new onos-config instance
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after restart returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, restartTzValue, 0, "Query after restart returned the wrong value")
 
 	// Check that the value is set on the target
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
-	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, restartTzValue)
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, gnmiutils.NoExtensions, restartTzValue)
 }
 
 // TestSetOperationAfterNodeRestart tests a Set operation after restarting the onos-config node
@@ -80,9 +80,9 @@ func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value is set on the target
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
-	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, restartTzValue)
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, gnmiutils.NoExtensions, restartTzValue)
 }

--- a/test/config/configrestarttest.go
+++ b/test/config/configrestarttest.go
@@ -54,7 +54,7 @@ func (s *TestSuite) TestGetOperationAfterNodeRestart(t *testing.T) {
 	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after restart returned the wrong value")
 
 	// Check that the value is set on the target
-	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, restartTzValue)
 }
 
@@ -83,6 +83,6 @@ func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
 	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, restartTzValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value is set on the target
-	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, restartTzValue)
 }

--- a/test/config/configrestarttest.go
+++ b/test/config/configrestarttest.go
@@ -28,12 +28,12 @@ const (
 
 // TestGetOperationAfterNodeRestart tests a Get operation after restarting the onos-config node
 func (s *TestSuite) TestGetOperationAfterNodeRestart(t *testing.T) {
-	// Create a simulated target
-	simulator := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
+
+	// Create a simulated target
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for onos-config requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)
@@ -60,12 +60,12 @@ func (s *TestSuite) TestGetOperationAfterNodeRestart(t *testing.T) {
 
 // TestSetOperationAfterNodeRestart tests a Set operation after restarting the onos-config node
 func (s *TestSuite) TestSetOperationAfterNodeRestart(t *testing.T) {
-	// Create a simulated target
-	simulator := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
+
+	// Create a simulated target
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for onos-config requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)

--- a/test/config/createremovetargettest.go
+++ b/test/config/createremovetargettest.go
@@ -76,7 +76,7 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	ready = gnmiutils.WaitForTargetAvailable(t, createRemoveTargetModTargetName, 2*time.Minute)
 	assert.True(t, ready)
 
-	err := gnmiutils.WaitForConfigurationCompleteOrFail(t, configapi.ConfigurationID(simulator.Name()), time.Minute)
+	err := gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 	// Check that the value was set correctly
 	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, createRemoveTargetModValue2, 0, "Query after set 2 returns wrong value")

--- a/test/config/createremovetargettest.go
+++ b/test/config/createremovetargettest.go
@@ -52,11 +52,11 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, c, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, createRemoveTargetModValue1, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, gnmiutils.NoExtensions, createRemoveTargetModValue1, 0, "Query after set returned the wrong value")
 
 	// interrogate the target to check that the value was set properly
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
-	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, createRemoveTargetModValue1)
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, gnmiutils.NoExtensions, createRemoveTargetModValue1)
 
 	//  Shut down the simulator
 	gnmiutils.DeleteSimulator(t, simulator)
@@ -79,11 +79,11 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	err := gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, createRemoveTargetModValue2, 0, "Query after set 2 returns wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, gnmiutils.NoExtensions, createRemoveTargetModValue2, 0, "Query after set 2 returns wrong value")
 
 	// interrogate the target to check that the value was set properly
 	targetGnmiClient2 := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
-	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient2, targetPath, createRemoveTargetModValue2)
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient2, targetPath, gnmiutils.NoExtensions, createRemoveTargetModValue2)
 	gnmiutils.DeleteSimulator(t, simulator)
 
 }

--- a/test/config/createremovetargettest.go
+++ b/test/config/createremovetargettest.go
@@ -55,7 +55,7 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	gnmiutils.CheckGNMIValueWithContext(ctx, t, c, targetPath, createRemoveTargetModValue1, 0, "Query after set returned the wrong value")
 
 	// interrogate the target to check that the value was set properly
-	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, createRemoveTargetModValue1)
 
 	//  Shut down the simulator
@@ -82,7 +82,7 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	gnmiutils.CheckGNMIValueWithContext(ctx, t, c, targetPath, createRemoveTargetModValue2, 0, "Query after set 2 returns wrong value")
 
 	// interrogate the target to check that the value was set properly
-	targetGnmiClient2 := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetGnmiClient2 := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient2, targetPath, createRemoveTargetModValue2)
 	gnmiutils.DeleteSimulator(t, simulator)
 

--- a/test/config/createremovetargettest.go
+++ b/test/config/createremovetargettest.go
@@ -48,11 +48,11 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	targetPath := gnmiutils.GetTargetPathWithValue(createRemoveTargetModTargetName, createRemoveTargetModPath, createRemoveTargetModValue1, proto.StringVal)
 
 	// Set a value using gNMI client - target is up
-	c := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
-	_, _ = gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, c, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	c := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
+	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, c, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, c, targetPath, createRemoveTargetModValue1, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, createRemoveTargetModValue1, 0, "Query after set returned the wrong value")
 
 	// interrogate the target to check that the value was set properly
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
@@ -66,7 +66,7 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	// Set a value using gNMI client - target is down
 	setPath2 := gnmiutils.GetTargetPathWithValue(createRemoveTargetModTargetName, createRemoveTargetModPath, createRemoveTargetModValue2, proto.StringVal)
 
-	_, _ = gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, c, setPath2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, c, setPath2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	//  Restart simulated target
 	simulator = gnmiutils.CreateSimulatorWithName(t, createRemoveTargetModTargetName, false)
@@ -79,7 +79,7 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	err := gnmiutils.WaitForConfigurationCompleteOrFail(t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 	// Check that the value was set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, c, targetPath, createRemoveTargetModValue2, 0, "Query after set 2 returns wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, c, targetPath, createRemoveTargetModValue2, 0, "Query after set 2 returns wrong value")
 
 	// interrogate the target to check that the value was set properly
 	targetGnmiClient2 := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)

--- a/test/config/createremovetargettest.go
+++ b/test/config/createremovetargettest.go
@@ -35,14 +35,14 @@ const (
 
 // TestCreatedRemovedTarget tests set/query of a single GNMI path to a single target that is created, removed, then created again
 func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
-	simulator := gnmiutils.CreateSimulatorWithName(t, createRemoveTargetModTargetName, true)
-	assert.NotNil(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
 
+	simulator := gnmiutils.CreateSimulatorWithName(ctx, t, createRemoveTargetModTargetName, true)
+	assert.NotNil(t, simulator)
+
 	// Wait for config to connect to the target
-	ready := gnmiutils.WaitForTargetAvailable(t, createRemoveTargetModTargetName, 1*time.Minute)
+	ready := gnmiutils.WaitForTargetAvailable(ctx, t, createRemoveTargetModTargetName, 1*time.Minute)
 	assert.True(t, ready)
 
 	targetPath := gnmiutils.GetTargetPathWithValue(createRemoveTargetModTargetName, createRemoveTargetModPath, createRemoveTargetModValue1, proto.StringVal)
@@ -60,7 +60,7 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 
 	//  Shut down the simulator
 	gnmiutils.DeleteSimulator(t, simulator)
-	unavailable := gnmiutils.WaitForTargetUnavailable(t, createRemoveTargetModTargetName, 2*time.Minute)
+	unavailable := gnmiutils.WaitForTargetUnavailable(ctx, t, createRemoveTargetModTargetName, 2*time.Minute)
 	assert.True(t, unavailable)
 
 	// Set a value using gNMI client - target is down
@@ -69,11 +69,11 @@ func (s *TestSuite) TestCreatedRemovedTarget(t *testing.T) {
 	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, c, setPath2, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	//  Restart simulated target
-	simulator = gnmiutils.CreateSimulatorWithName(t, createRemoveTargetModTargetName, false)
+	simulator = gnmiutils.CreateSimulatorWithName(ctx, t, createRemoveTargetModTargetName, false)
 	assert.NotNil(t, simulator)
 
 	// Wait for config to connect to the target
-	ready = gnmiutils.WaitForTargetAvailable(t, createRemoveTargetModTargetName, 2*time.Minute)
+	ready = gnmiutils.WaitForTargetAvailable(ctx, t, createRemoveTargetModTargetName, 2*time.Minute)
 	assert.True(t, ready)
 
 	err := gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(simulator.Name()), time.Minute)

--- a/test/config/deletetest.go
+++ b/test/config/deletetest.go
@@ -44,13 +44,13 @@ func (s *TestSuite) TestDeleteAndRollback(t *testing.T) {
 	defer cancel()
 
 	// Get the configured targets from the environment.
-	target1 := gnmiutils.CreateSimulator(t)
+	target1 := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, target1)
 	targets := make([]string, 1)
 	targets[0] = target1.Name()
 
 	// Wait for config to connect to the target
-	gnmiutils.WaitForTargetAvailable(t, topo.ID(target1.Name()), 10*time.Second)
+	gnmiutils.WaitForTargetAvailable(ctx, t, topo.ID(target1.Name()), 10*time.Second)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)

--- a/test/config/deletetest.go
+++ b/test/config/deletetest.go
@@ -53,11 +53,11 @@ func (s *TestSuite) TestDeleteAndRollback(t *testing.T) {
 	gnmiutils.WaitForTargetAvailable(t, topo.ID(target1.Name()), 10*time.Second)
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Set values
 	var targetPathsForSet = gnmiutils.GetTargetPathsWithValues(targets, newPaths, newValues)
-	_, transactionIndex := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPathsForSet, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	_, transactionIndex := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForSet, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	targetPathsForGet := gnmiutils.GetTargetPaths(targets, newPaths)
 

--- a/test/config/deletetest.go
+++ b/test/config/deletetest.go
@@ -70,14 +70,14 @@ func (s *TestSuite) TestDeleteAndRollback(t *testing.T) {
 	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], newValue)
 
 	// Now rollback the change
-	adminClient, err := gnmiutils.NewAdminServiceClient()
+	adminClient, err := gnmiutils.NewAdminServiceClient(ctx)
 	assert.NoError(t, err)
 	rollbackResponse, rollbackError := adminClient.RollbackTransaction(context.Background(), &admin.RollbackRequest{Index: transactionIndex})
 
 	assert.NoError(t, rollbackError, "Rollback returned an error")
 	assert.NotNil(t, rollbackResponse, "Response for rollback is nil")
 
-	err = gnmiutils.WaitForConfigurationCompleteOrFail(t, configapi.ConfigurationID(target1.Name()), time.Minute)
+	err = gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(target1.Name()), time.Minute)
 	assert.NoError(t, err)
 
 	// Check that the value was really rolled back- should be an error here since the node was deleted

--- a/test/config/deletetest.go
+++ b/test/config/deletetest.go
@@ -66,7 +66,7 @@ func (s *TestSuite) TestDeleteAndRollback(t *testing.T) {
 	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, expectedValues, 0, "Query after set returned the wrong value")
 
 	// Check that the values are set on the targets
-	target1GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, target1)
+	target1GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, target1)
 	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], newValue)
 
 	// Now rollback the change

--- a/test/config/deletetest.go
+++ b/test/config/deletetest.go
@@ -63,11 +63,11 @@ func (s *TestSuite) TestDeleteAndRollback(t *testing.T) {
 
 	// Check that the values were set correctly
 	expectedValues := []string{newValue}
-	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, expectedValues, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, expectedValues, 0, "Query after set returned the wrong value")
 
 	// Check that the values are set on the targets
 	target1GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, target1)
-	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], newValue)
+	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], gnmiutils.NoExtensions, newValue)
 
 	// Now rollback the change
 	adminClient, err := gnmiutils.NewAdminServiceClient(ctx)
@@ -81,6 +81,6 @@ func (s *TestSuite) TestDeleteAndRollback(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that the value was really rolled back- should be an error here since the node was deleted
-	_, _, err = gnmiutils.GetGNMIValue(ctx, target1GnmiClient, targetPathsForGet, gbp.Encoding_PROTO)
+	_, _, err = gnmiutils.GetGNMIValue(ctx, target1GnmiClient, targetPathsForGet, gnmiutils.NoExtensions, gbp.Encoding_PROTO)
 	assert.Error(t, err)
 }

--- a/test/config/modelstest.go
+++ b/test/config/modelstest.go
@@ -53,7 +53,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 	// Make a GNMI client to use for requests
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Run the test cases
 	for _, testCase := range testCases {

--- a/test/config/modelstest.go
+++ b/test/config/modelstest.go
@@ -32,7 +32,10 @@ func (s *TestSuite) TestModels(t *testing.T) {
 		clockTimeZonePath = "/system/clock/config/timezone-name"
 	)
 
-	simulator := gnmiutils.CreateSimulator(t)
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
+	simulator := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Data to run the test cases
@@ -51,8 +54,6 @@ func (s *TestSuite) TestModels(t *testing.T) {
 	}
 
 	// Make a GNMI client to use for requests
-	ctx, cancel := gnmiutils.MakeContext()
-	defer cancel()
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Run the test cases

--- a/test/config/modelstest.go
+++ b/test/config/modelstest.go
@@ -51,7 +51,9 @@ func (s *TestSuite) TestModels(t *testing.T) {
 	}
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Run the test cases
 	for _, testCase := range testCases {
@@ -66,7 +68,7 @@ func (s *TestSuite) TestModels(t *testing.T) {
 				t.Logf("testing %q", description)
 
 				setResult := gnmiutils.GetTargetPathWithValue(simulator.Name(), path, value, valueType)
-				msg, _, err := gnmiutils.SetGNMIValue(gnmiutils.MakeContext(), gnmiClient, setResult, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+				msg, _, err := gnmiutils.SetGNMIValue(ctx, gnmiClient, setResult, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 				assert.NotNil(t, err, "Set operation for %s does not generate an error", description)
 				assert.Contains(t, status.Convert(err).Message(), expectedError,
 					"set operation for %s generates wrong error %s", description, msg)

--- a/test/config/multiplesettest.go
+++ b/test/config/multiplesettest.go
@@ -41,7 +41,7 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 	targetClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 
 	for i := 0; i < 10; i++ {
@@ -50,18 +50,18 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 
 		// Set a value using gNMI client
 		targetPath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, msValue, proto.StringVal)
-		transactionID, transactionIndex := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+		transactionID, transactionIndex := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 		assert.NotNil(t, transactionID, transactionIndex)
 
 		// Check that the value was set correctly, both in onos-config and the target
-		gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, msValue, 0, "Query after set returned the wrong value")
+		gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, msValue, 0, "Query after set returned the wrong value")
 		gnmiutils.CheckTargetValue(ctx, t, targetClient, targetPath, msValue)
 
 		// Remove the path we added
-		gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.SyncExtension(t))
+		gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.SyncExtension(t))
 
 		//  Make sure it got removed, both from onos-config and the target
-		gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
+		gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
 		gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, targetPath)
 	}
 }

--- a/test/config/multiplesettest.go
+++ b/test/config/multiplesettest.go
@@ -33,12 +33,15 @@ func generateTimezoneName() string {
 func (s *TestSuite) TestMultipleSet(t *testing.T) {
 	generateTimezoneName()
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Create a simulated device
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 	targetClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
 
 	for i := 0; i < 10; i++ {
@@ -47,18 +50,18 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 
 		// Set a value using gNMI client
 		targetPath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, msValue, proto.StringVal)
-		transactionID, transactionIndex := gnmiutils.SetGNMIValueOrFail(t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+		transactionID, transactionIndex := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 		assert.NotNil(t, transactionID, transactionIndex)
 
 		// Check that the value was set correctly, both in onos-config and the target
-		gnmiutils.CheckGNMIValue(t, gnmiClient, targetPath, msValue, 0, "Query after set returned the wrong value")
-		gnmiutils.CheckTargetValue(t, targetClient, targetPath, msValue)
+		gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, msValue, 0, "Query after set returned the wrong value")
+		gnmiutils.CheckTargetValue(ctx, t, targetClient, targetPath, msValue)
 
 		// Remove the path we added
-		gnmiutils.SetGNMIValueOrFail(t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.SyncExtension(t))
+		gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.SyncExtension(t))
 
 		//  Make sure it got removed, both from onos-config and the target
-		gnmiutils.CheckGNMIValue(t, gnmiClient, targetPath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
-		gnmiutils.CheckTargetValueDeleted(t, targetClient, targetPath)
+		gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
+		gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, targetPath)
 	}
 }

--- a/test/config/multiplesettest.go
+++ b/test/config/multiplesettest.go
@@ -54,14 +54,14 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 		assert.NotNil(t, transactionID, transactionIndex)
 
 		// Check that the value was set correctly, both in onos-config and the target
-		gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, msValue, 0, "Query after set returned the wrong value")
-		gnmiutils.CheckTargetValue(ctx, t, targetClient, targetPath, msValue)
+		gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, msValue, 0, "Query after set returned the wrong value")
+		gnmiutils.CheckTargetValue(ctx, t, targetClient, targetPath, gnmiutils.NoExtensions, msValue)
 
 		// Remove the path we added
 		gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.SyncExtension(t))
 
 		//  Make sure it got removed, both from onos-config and the target
-		gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
-		gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, targetPath)
+		gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, "", 0, "incorrect value found for path /system/clock/config/timezone-name after delete")
+		gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, targetPath, gnmiutils.NoExtensions)
 	}
 }

--- a/test/config/multiplesettest.go
+++ b/test/config/multiplesettest.go
@@ -42,7 +42,7 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
-	targetClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 
 	for i := 0; i < 10; i++ {
 

--- a/test/config/multiplesettest.go
+++ b/test/config/multiplesettest.go
@@ -37,7 +37,7 @@ func (s *TestSuite) TestMultipleSet(t *testing.T) {
 	defer cancel()
 
 	// Create a simulated device
-	simulator := gnmiutils.CreateSimulator(t)
+	simulator := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests

--- a/test/config/offlinetargettest.go
+++ b/test/config/offlinetargettest.go
@@ -60,11 +60,11 @@ func (s *TestSuite) TestOfflineTarget(t *testing.T) {
 	err := gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, modValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, modValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value was set properly on the target, wait for configuration gets completed
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
-	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, modValue)
+	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, gnmiutils.NoExtensions, modValue)
 }
 
 func createOfflineTarget(t *testing.T, targetID topoapi.ID, targetType string, targetVersion string, targetAddress string) {

--- a/test/config/offlinetargettest.go
+++ b/test/config/offlinetargettest.go
@@ -63,7 +63,7 @@ func (s *TestSuite) TestOfflineTarget(t *testing.T) {
 	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, modValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value was set properly on the target, wait for configuration gets completed
-	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 	gnmiutils.CheckTargetValue(ctx, t, targetGnmiClient, targetPath, modValue)
 }
 

--- a/test/config/offlinetargettest.go
+++ b/test/config/offlinetargettest.go
@@ -52,11 +52,11 @@ func (s *TestSuite) TestOfflineTarget(t *testing.T) {
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Install and start target simulator
-	simulator := gnmiutils.CreateSimulatorWithName(t, offlineTargetName, false)
+	simulator := gnmiutils.CreateSimulatorWithName(ctx, t, offlineTargetName, false)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Wait for config to connect to the target
-	gnmiutils.WaitForTargetAvailable(t, topoapi.ID(simulator.Name()), time.Minute)
+	gnmiutils.WaitForTargetAvailable(ctx, t, topoapi.ID(simulator.Name()), time.Minute)
 	err := gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 

--- a/test/config/offlinetargettest.go
+++ b/test/config/offlinetargettest.go
@@ -45,11 +45,11 @@ func (s *TestSuite) TestOfflineTarget(t *testing.T) {
 	createOfflineTarget(t, offlineTargetName, "devicesim", "1.0.0", offlineTargetName+":11161")
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Sends a set request using onos-config NB
 	targetPath := gnmiutils.GetTargetPathWithValue(offlineTargetName, modPath, modValue, proto.StringVal)
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Install and start target simulator
 	simulator := gnmiutils.CreateSimulatorWithName(t, offlineTargetName, false)
@@ -60,7 +60,7 @@ func (s *TestSuite) TestOfflineTarget(t *testing.T) {
 	err := gnmiutils.WaitForConfigurationCompleteOrFail(t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, modValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, modValue, 0, "Query after set returned the wrong value")
 
 	// Check that the value was set properly on the target, wait for configuration gets completed
 	targetGnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)

--- a/test/config/offlinetargettest.go
+++ b/test/config/offlinetargettest.go
@@ -57,7 +57,7 @@ func (s *TestSuite) TestOfflineTarget(t *testing.T) {
 
 	// Wait for config to connect to the target
 	gnmiutils.WaitForTargetAvailable(t, topoapi.ID(simulator.Name()), time.Minute)
-	err := gnmiutils.WaitForConfigurationCompleteOrFail(t, configapi.ConfigurationID(simulator.Name()), time.Minute)
+	err := gnmiutils.WaitForConfigurationCompleteOrFail(ctx, t, configapi.ConfigurationID(simulator.Name()), time.Minute)
 	assert.NoError(t, err)
 
 	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, modValue, 0, "Query after set returned the wrong value")

--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -45,14 +45,14 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, devicePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly, both in onos-config and on the target
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
-	gnmiutils.CheckTargetValue(ctx, t, targetClient, devicePath, tzValue)
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, devicePath, gnmiutils.NoExtensions, tzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckTargetValue(ctx, t, targetClient, devicePath, gnmiutils.NoExtensions, tzValue)
 
 	// Remove the path we added
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, devicePath, gnmiutils.SyncExtension(t))
 
 	//  Make sure it got removed, both in onos-config and on the target
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, devicePath, "", 0,
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, devicePath, gnmiutils.NoExtensions, "", 0,
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
-	gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, devicePath)
+	gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, devicePath, gnmiutils.NoExtensions)
 }

--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -28,12 +28,12 @@ const (
 
 // TestSinglePath tests query/set/delete of a single GNMI path to a single device
 func (s *TestSuite) TestSinglePath(t *testing.T) {
-	// Create a simulated device
-	simulator := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
+
+	// Create a simulated device
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)

--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -36,23 +36,23 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	defer cancel()
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 	targetClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
 
 	// Set a value using gNMI client
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, devicePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, devicePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly, both in onos-config and on the target
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
 	gnmiutils.CheckTargetValue(ctx, t, targetClient, devicePath, tzValue)
 
 	// Remove the path we added
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, devicePath, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, devicePath, gnmiutils.SyncExtension(t))
 
 	//  Make sure it got removed, both in onos-config and on the target
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, devicePath, "", 0,
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, devicePath, "", 0,
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
 	gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, devicePath)
 }

--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -32,24 +32,27 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 	targetClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
 
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
 
 	// Set a value using gNMI client
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, devicePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, devicePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the value was set correctly, both in onos-config and on the target
-	gnmiutils.CheckGNMIValue(t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
-	gnmiutils.CheckTargetValue(t, targetClient, devicePath, tzValue)
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, devicePath, tzValue, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckTargetValue(ctx, t, targetClient, devicePath, tzValue)
 
 	// Remove the path we added
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, gnmiutils.NoPaths, devicePath, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, devicePath, gnmiutils.SyncExtension(t))
 
 	//  Make sure it got removed, both in onos-config and on the target
-	gnmiutils.CheckGNMIValue(t, gnmiClient, devicePath, "", 0,
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, devicePath, "", 0,
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
-	gnmiutils.CheckTargetValueDeleted(t, targetClient, devicePath)
+	gnmiutils.CheckTargetValueDeleted(ctx, t, targetClient, devicePath)
 }

--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -37,7 +37,7 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
-	targetClient := gnmiutils.GetTargetGNMIClientOrFail(t, simulator)
+	targetClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, simulator)
 
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
 

--- a/test/config/topotest.go
+++ b/test/config/topotest.go
@@ -74,11 +74,14 @@ func (s *TestSuite) checkTopo(t *testing.T, targetID topoapi.ID) {
 
 // TestTopoIntegration checks that the correct topology entities and relations are created
 func (s *TestSuite) TestTopoIntegration(t *testing.T) {
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Create simulated targets
 	targetID := "test-topo-integration-target-1"
-	simulator := gnmiutils.CreateSimulatorWithName(t, targetID, true)
+	simulator := gnmiutils.CreateSimulatorWithName(ctx, t, targetID, true)
 	assert.NotNil(t, simulator)
-	gnmiutils.WaitForTargetAvailable(t, topoapi.ID(targetID), 2*time.Minute)
+	gnmiutils.WaitForTargetAvailable(ctx, t, topoapi.ID(targetID), 2*time.Minute)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 	s.checkTopo(t, topoapi.ID(targetID))
 }

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -70,7 +70,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	// Set initial values
 	targetPathsForInit := gnmiutils.GetTargetPathsWithValues(targets, paths, initialValues)
 	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForInit, gnmiutils.NoPaths, gnmiutils.NoExtensions)
-	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, initialValues, 0, "Query after initial set returned the wrong value")
+	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, initialValues, 0, "Query after initial set returned the wrong value")
 
 	// Create a change that can be rolled back
 	targetPathsForSet := gnmiutils.GetTargetPathsWithValues(targets, paths, values)
@@ -78,16 +78,16 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 
 	// Check that the values were set correctly
 	expectedValues := []string{value1, value2}
-	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, expectedValues, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, expectedValues, 0, "Query after set returned the wrong value")
 
 	// Check that the values are set on the targets
 	target1GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, target1)
 	target2GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, target2)
 
-	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], value1)
-	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[1:2], value2)
-	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[2:3], value1)
-	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[3:4], value2)
+	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], gnmiutils.NoExtensions, value1)
+	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[1:2], gnmiutils.NoExtensions, value2)
+	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[2:3], gnmiutils.NoExtensions, value1)
+	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[3:4], gnmiutils.NoExtensions, value2)
 
 	// Now rollback the change
 	adminClient, err := gnmiutils.NewAdminServiceClient(ctx)
@@ -100,11 +100,11 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 
 	// Check that the values were really rolled back in onos-config
 	expectedValuesAfterRollback := []string{initValue1, initValue2}
-	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, expectedValuesAfterRollback, 0, "Query after rollback returned the wrong value")
+	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, expectedValuesAfterRollback, 0, "Query after rollback returned the wrong value")
 
 	// Check that the values were rolled back on the targets
-	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], initValue1)
-	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[1:2], initValue2)
-	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[2:3], initValue1)
-	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[3:4], initValue2)
+	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], gnmiutils.NoExtensions, initValue1)
+	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[1:2], gnmiutils.NoExtensions, initValue2)
+	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[2:3], gnmiutils.NoExtensions, initValue1)
+	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[3:4], gnmiutils.NoExtensions, initValue2)
 }

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -90,7 +90,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	gnmiutils.CheckTargetValue(ctx, t, target2GnmiClient, targetPathsForGet[3:4], value2)
 
 	// Now rollback the change
-	adminClient, err := gnmiutils.NewAdminServiceClient()
+	adminClient, err := gnmiutils.NewAdminServiceClient(ctx)
 	assert.NoError(t, err)
 	rollbackResponse, rollbackError := adminClient.RollbackTransaction(
 		context.Background(), &admin.RollbackRequest{Index: transactionIndex})

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -81,8 +81,8 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, expectedValues, 0, "Query after set returned the wrong value")
 
 	// Check that the values are set on the targets
-	target1GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, target1)
-	target2GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(t, target2)
+	target1GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, target1)
+	target2GnmiClient := gnmiutils.GetTargetGNMIClientOrFail(ctx, t, target2)
 
 	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[0:1], value1)
 	gnmiutils.CheckTargetValue(ctx, t, target1GnmiClient, targetPathsForGet[1:2], value2)

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -64,17 +64,17 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	targets[1] = target2.Name()
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 	targetPathsForGet := gnmiutils.GetTargetPaths(targets, paths)
 
 	// Set initial values
 	targetPathsForInit := gnmiutils.GetTargetPathsWithValues(targets, paths, initialValues)
-	_, _ = gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPathsForInit, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForInit, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, initialValues, 0, "Query after initial set returned the wrong value")
 
 	// Create a change that can be rolled back
 	targetPathsForSet := gnmiutils.GetTargetPathsWithValues(targets, paths, values)
-	_, transactionIndex := gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, targetPathsForSet, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	_, transactionIndex := gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForSet, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the values were set correctly
 	expectedValues := []string{value1, value2}

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -43,21 +43,21 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 		initialValues = []string{initValue1, initValue2}
 	)
 
-	// Get the configured targets from the environment.
-	target1 := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, target1)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
 
-	// Wait for config to connect to the targets
-	gnmiutils.WaitForTargetAvailable(t, topo.ID(target1.Name()), time.Minute)
+	// Get the configured targets from the environment.
+	target1 := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, target1)
 
-	target2 := gnmiutils.CreateSimulator(t)
+	// Wait for config to connect to the targets
+	gnmiutils.WaitForTargetAvailable(ctx, t, topo.ID(target1.Name()), time.Minute)
+
+	target2 := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, target2)
 
 	// Wait for config to connect to the targets
-	gnmiutils.WaitForTargetAvailable(t, topo.ID(target2.Name()), time.Minute)
+	gnmiutils.WaitForTargetAvailable(ctx, t, topo.ID(target2.Name()), time.Minute)
 
 	targets := make([]string, 2)
 	targets[0] = target1.Name()

--- a/test/config/treepathtest.go
+++ b/test/config/treepathtest.go
@@ -39,7 +39,7 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	defer cancel()
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	getPath := gnmiutils.GetTargetPath(simulator.Name(), newRootEnabledPath)
 
@@ -47,27 +47,27 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	setNamePath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: newRootConfigNamePath, PathDataValue: newRootName, PathDataType: proto.StringVal},
 	}
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Set values using gNMI client
 	setPath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: newRootDescriptionPath, PathDataValue: newDescription, PathDataType: proto.StringVal},
 		{TargetName: simulator.Name(), Path: newRootEnabledPath, PathDataValue: "false", PathDataType: proto.BoolVal},
 	}
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the name value was set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
 
 	// Check that the enabled value was set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
 
 	// Remove the root path we added
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, getPath, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, getPath, gnmiutils.SyncExtension(t))
 
 	//  Make sure child got removed
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
 
 	//  Make sure new root got removed
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, getPath, "", 0, "New root was not removed")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, getPath, "", 0, "New root was not removed")
 }

--- a/test/config/treepathtest.go
+++ b/test/config/treepathtest.go
@@ -31,12 +31,12 @@ const (
 
 // TestTreePath tests create/set/delete of a tree of GNMI paths to a single device
 func (s *TestSuite) TestTreePath(t *testing.T) {
-	// Make a simulated device
-	simulator := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
+
+	// Make a simulated device
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)

--- a/test/config/treepathtest.go
+++ b/test/config/treepathtest.go
@@ -57,17 +57,17 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the name value was set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, gnmiutils.NoExtensions, newRootName, 0, "Query name after set returned the wrong value")
 
 	// Check that the enabled value was set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, getPath, gnmiutils.NoExtensions, "false", 0, "Query enabled after set returned the wrong value")
 
 	// Remove the root path we added
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, getPath, gnmiutils.SyncExtension(t))
 
 	//  Make sure child got removed
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, gnmiutils.NoExtensions, newRootName, 0, "New child was not removed")
 
 	//  Make sure new root got removed
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, getPath, "", 0, "New root was not removed")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, getPath, gnmiutils.NoExtensions, "", 0, "New root was not removed")
 }

--- a/test/config/treepathtest.go
+++ b/test/config/treepathtest.go
@@ -35,8 +35,11 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 
 	getPath := gnmiutils.GetTargetPath(simulator.Name(), newRootEnabledPath)
 
@@ -44,27 +47,27 @@ func (s *TestSuite) TestTreePath(t *testing.T) {
 	setNamePath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: newRootConfigNamePath, PathDataValue: newRootName, PathDataType: proto.StringVal},
 	}
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 	// Set values using gNMI client
 	setPath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: newRootDescriptionPath, PathDataValue: newDescription, PathDataType: proto.StringVal},
 		{TargetName: simulator.Name(), Path: newRootEnabledPath, PathDataValue: "false", PathDataType: proto.BoolVal},
 	}
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, setPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Check that the name value was set correctly
-	gnmiutils.CheckGNMIValue(t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, setNamePath, newRootName, 0, "Query name after set returned the wrong value")
 
 	// Check that the enabled value was set correctly
-	gnmiutils.CheckGNMIValue(t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, getPath, "false", 0, "Query enabled after set returned the wrong value")
 
 	// Remove the root path we added
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, gnmiutils.NoPaths, getPath, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, getPath, gnmiutils.SyncExtension(t))
 
 	//  Make sure child got removed
-	gnmiutils.CheckGNMIValue(t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, setNamePath, newRootName, 0, "New child was not removed")
 
 	//  Make sure new root got removed
-	gnmiutils.CheckGNMIValue(t, gnmiClient, getPath, "", 0, "New root was not removed")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, getPath, "", 0, "New root was not removed")
 }

--- a/test/config/updatedeletetest.go
+++ b/test/config/updatedeletetest.go
@@ -47,7 +47,7 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	}
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, udtestNameValue, 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, gnmiutils.NoExtensions, udtestNameValue, 0, "Query name after set returned the wrong value")
 
 	// Set initial values for Enabled and Description using gNMI client
 	setInitialValuesPath := []proto.TargetPath{
@@ -66,8 +66,8 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, updateEnabledPath, deleteDescriptionPath, gnmiutils.SyncExtension(t))
 
 	// Check that the Enabled value is set correctly
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, updateEnabledPath, gnmiutils.NoExtensions, "false", 0, "Query name after set returned the wrong value")
 
 	//  Make sure Description got removed
-	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, gnmiutils.GetTargetPath(simulator.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, gnmiutils.GetTargetPath(simulator.Name(), udtestDescriptionPath), gnmiutils.NoExtensions, "", 0, "New child was not removed")
 }

--- a/test/config/updatedeletetest.go
+++ b/test/config/updatedeletetest.go
@@ -31,12 +31,12 @@ const (
 
 // TestUpdateDelete tests update and delete paths in a single GNMI request
 func (s *TestSuite) TestUpdateDelete(t *testing.T) {
-	// Get the first configured simulator from the environment.
-	simulator := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
+
+	// Get the first configured simulator from the environment.
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)

--- a/test/config/updatedeletetest.go
+++ b/test/config/updatedeletetest.go
@@ -35,23 +35,26 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Create interface tree using gNMI client
 	setNamePath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: udtestNamePath, PathDataValue: udtestNameValue, PathDataType: proto.StringVal},
 	}
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
-	gnmiutils.CheckGNMIValue(t, gnmiClient, setNamePath, udtestNameValue, 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, setNamePath, udtestNameValue, 0, "Query name after set returned the wrong value")
 
 	// Set initial values for Enabled and Description using gNMI client
 	setInitialValuesPath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: udtestEnabledPath, PathDataValue: "true", PathDataType: proto.BoolVal},
 		{TargetName: simulator.Name(), Path: udtestDescriptionPath, PathDataValue: udtestDescriptionValue, PathDataType: proto.StringVal},
 	}
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, setInitialValuesPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setInitialValuesPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Update Enabled, delete Description using gNMI client
 	updateEnabledPath := []proto.TargetPath{
@@ -60,11 +63,11 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	deleteDescriptionPath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: udtestDescriptionPath},
 	}
-	gnmiutils.SetGNMIValueOrFail(t, gnmiClient, updateEnabledPath, deleteDescriptionPath, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, updateEnabledPath, deleteDescriptionPath, gnmiutils.SyncExtension(t))
 
 	// Check that the Enabled value is set correctly
-	gnmiutils.CheckGNMIValue(t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
 
 	//  Make sure Description got removed
-	gnmiutils.CheckGNMIValue(t, gnmiClient, gnmiutils.GetTargetPath(simulator.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
+	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, gnmiutils.GetTargetPath(simulator.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
 }

--- a/test/config/updatedeletetest.go
+++ b/test/config/updatedeletetest.go
@@ -39,22 +39,22 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	defer cancel()
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Create interface tree using gNMI client
 	setNamePath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: udtestNamePath, PathDataValue: udtestNameValue, PathDataType: proto.StringVal},
 	}
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, setNamePath, udtestNameValue, 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, setNamePath, udtestNameValue, 0, "Query name after set returned the wrong value")
 
 	// Set initial values for Enabled and Description using gNMI client
 	setInitialValuesPath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: udtestEnabledPath, PathDataValue: "true", PathDataType: proto.BoolVal},
 		{TargetName: simulator.Name(), Path: udtestDescriptionPath, PathDataValue: udtestDescriptionValue, PathDataType: proto.StringVal},
 	}
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setInitialValuesPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setInitialValuesPath, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 
 	// Update Enabled, delete Description using gNMI client
 	updateEnabledPath := []proto.TargetPath{
@@ -63,11 +63,11 @@ func (s *TestSuite) TestUpdateDelete(t *testing.T) {
 	deleteDescriptionPath := []proto.TargetPath{
 		{TargetName: simulator.Name(), Path: udtestDescriptionPath},
 	}
-	gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, updateEnabledPath, deleteDescriptionPath, gnmiutils.SyncExtension(t))
+	gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, updateEnabledPath, deleteDescriptionPath, gnmiutils.SyncExtension(t))
 
 	// Check that the Enabled value is set correctly
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, updateEnabledPath, "false", 0, "Query name after set returned the wrong value")
 
 	//  Make sure Description got removed
-	gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, gnmiutils.GetTargetPath(simulator.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
+	gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, gnmiutils.GetTargetPath(simulator.Name(), udtestDescriptionPath), "", 0, "New child was not removed")
 }

--- a/test/rbac/badtokentest.go
+++ b/test/rbac/badtokentest.go
@@ -115,7 +115,7 @@ func (s *TestSuite) TestBadTokens(t *testing.T) {
 				gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 				// Try to fetch a value from the GNMI client
-				_, _, err = gnmiutils.GetGNMIValue(ctx, gnmiClient, devicePath, gpb.Encoding_PROTO)
+				_, _, err = gnmiutils.GetGNMIValue(ctx, gnmiClient, devicePath, gnmiutils.NoExtensions, gpb.Encoding_PROTO)
 
 				if testCase.expectedGetError != "" {
 					// An error is expected

--- a/test/rbac/badtokentest.go
+++ b/test/rbac/badtokentest.go
@@ -110,7 +110,7 @@ func (s *TestSuite) TestBadTokens(t *testing.T) {
 
 				// Make a GNMI client to use for requests
 				ctx := rbac.GetBearerContext(context.Background(), testCase.token)
-				gnmiClient := gnmiutuils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutuils.NoRetry)
+				gnmiClient := gnmiutuils.GetGNMIClientOrFail(ctx, t, gnmiutuils.NoRetry)
 
 				// Try to fetch a value from the GNMI client
 				_, _, err = gnmiutuils.GetGNMIValue(ctx, gnmiClient, devicePath, gpb.Encoding_PROTO)

--- a/test/rbac/badtokentest.go
+++ b/test/rbac/badtokentest.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"testing"
 
-	gnmiutuils "github.com/onosproject/onos-config/test/utils/gnmi"
+	gnmiutils "github.com/onosproject/onos-config/test/utils/gnmi"
 	"github.com/onosproject/onos-config/test/utils/proto"
 	"github.com/onosproject/onos-config/test/utils/rbac"
 )
@@ -89,10 +89,12 @@ func (s *TestSuite) TestBadTokens(t *testing.T) {
 	}
 
 	// Create a simulated target
-	simulator := gnmiutuils.CreateSimulator(t)
-	defer gnmiutuils.DeleteSimulator(t, simulator)
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
-	devicePath := gnmiutuils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
+	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
 
 	// Run the test cases
 	for testCaseIndex := range testCases {
@@ -110,10 +112,10 @@ func (s *TestSuite) TestBadTokens(t *testing.T) {
 
 				// Make a GNMI client to use for requests
 				ctx := rbac.GetBearerContext(context.Background(), testCase.token)
-				gnmiClient := gnmiutuils.GetGNMIClientOrFail(ctx, t, gnmiutuils.NoRetry)
+				gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 				// Try to fetch a value from the GNMI client
-				_, _, err = gnmiutuils.GetGNMIValue(ctx, gnmiClient, devicePath, gpb.Encoding_PROTO)
+				_, _, err = gnmiutils.GetGNMIValue(ctx, gnmiClient, devicePath, gpb.Encoding_PROTO)
 
 				if testCase.expectedGetError != "" {
 					// An error is expected

--- a/test/rbac/gettest.go
+++ b/test/rbac/gettest.go
@@ -200,7 +200,10 @@ func (s *TestSuite) TestGetOperations(t *testing.T) {
 	}
 
 	// Create a simulated device
-	simulator := gnmiutils.CreateSimulator(t)
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
+	simulator := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	setUpInterfaces(t, simulator.Name(), s.keycloakPassword)

--- a/test/rbac/gettest.go
+++ b/test/rbac/gettest.go
@@ -48,7 +48,7 @@ func setUpInterfaces(t *testing.T, target string, password string) {
 
 	// Make a GNMI client to use for requests
 	ctx := rbac.GetBearerContext(context.Background(), token)
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)
 
 	var interfaceNames = [...]string{starbucksInterface, acmeInterface, otherInterface}
 
@@ -61,14 +61,14 @@ func setUpInterfaces(t *testing.T, target string, password string) {
 		setNamePath := []proto.TargetPath{
 			{TargetName: target, Path: namePath, PathDataValue: interfaceName, PathDataType: proto.StringVal},
 		}
-		gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+		gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setNamePath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 
 		// Set initial values for Enabled and Description using gNMI client
 		setInitialValuesPath := []proto.TargetPath{
 			{TargetName: target, Path: enabledPath, PathDataValue: "true", PathDataType: proto.BoolVal},
 			{TargetName: target, Path: descriptionPath, PathDataValue: descriptionLeafValue, PathDataType: proto.StringVal},
 		}
-		gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, setInitialValuesPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+		gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, setInitialValuesPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 	}
 }
 
@@ -214,7 +214,7 @@ func (s *TestSuite) TestGetOperations(t *testing.T) {
 
 				// Make a GNMI client to use for requests
 				ctx := rbac.GetBearerContext(context.Background(), token)
-				gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
+				gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)
 				assert.NotNil(t, gnmiClient)
 
 				descriptionPath := getLeafPath(testCase.interfaceName, descriptionLeafName)

--- a/test/rbac/gettest.go
+++ b/test/rbac/gettest.go
@@ -228,7 +228,7 @@ func (s *TestSuite) TestGetOperations(t *testing.T) {
 				}
 
 				// Check that the value can be read via get
-				values, _, err := gnmiutils.GetGNMIValue(ctx, gnmiClient, targetPath, gpb.Encoding_PROTO)
+				values, _, err := gnmiutils.GetGNMIValue(ctx, gnmiClient, targetPath, gnmiutils.NoExtensions, gpb.Encoding_PROTO)
 				assert.NoError(t, err)
 				value := ""
 				if len(values) != 0 {

--- a/test/rbac/notokentest.go
+++ b/test/rbac/notokentest.go
@@ -34,8 +34,11 @@ func (s *TestSuite) TestNoToken(t *testing.T) {
 	simulator := gnmiutils.CreateSimulator(t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientOrFail(t)
+	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Try to fetch a value from the GNMI client
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)

--- a/test/rbac/notokentest.go
+++ b/test/rbac/notokentest.go
@@ -42,7 +42,7 @@ func (s *TestSuite) TestNoToken(t *testing.T) {
 
 	// Try to fetch a value from the GNMI client
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)
-	_, _, err := gnmiutils.GetGNMIValue(context.Background(), gnmiClient, devicePath, gpb.Encoding_PROTO)
+	_, _, err := gnmiutils.GetGNMIValue(context.Background(), gnmiClient, devicePath, gnmiutils.NoExtensions, gpb.Encoding_PROTO)
 
 	// An error indicating an unauthenticated request is expected
 	assert.Error(t, err)

--- a/test/rbac/notokentest.go
+++ b/test/rbac/notokentest.go
@@ -30,12 +30,12 @@ func (s *TestSuite) TestNoToken(t *testing.T) {
 		tzValue = "Europe/Dublin"
 		tzPath  = "/system/clock/config/timezone-name"
 	)
-	// Create a simulated device
-	simulator := gnmiutils.CreateSimulator(t)
-	defer gnmiutils.DeleteSimulator(t, simulator)
-
 	ctx, cancel := gnmiutils.MakeContext()
 	defer cancel()
+
+	// Create a simulated device
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	// Make a GNMI client to use for requests
 	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)

--- a/test/rbac/notokentest.go
+++ b/test/rbac/notokentest.go
@@ -38,7 +38,7 @@ func (s *TestSuite) TestNoToken(t *testing.T) {
 	defer cancel()
 
 	// Make a GNMI client to use for requests
-	gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.NoRetry)
+	gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
 
 	// Try to fetch a value from the GNMI client
 	devicePath := gnmiutils.GetTargetPathWithValue(simulator.Name(), tzPath, tzValue, proto.StringVal)

--- a/test/rbac/settest.go
+++ b/test/rbac/settest.go
@@ -56,7 +56,10 @@ func (s *TestSuite) TestSetOperations(t *testing.T) {
 	}
 
 	// Create a simulated target
-	simulator := gnmiutils.CreateSimulator(t)
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
+	simulator := gnmiutils.CreateSimulator(ctx, t)
 	defer gnmiutils.DeleteSimulator(t, simulator)
 
 	for testCaseIndex := range testCases {

--- a/test/rbac/settest.go
+++ b/test/rbac/settest.go
@@ -70,7 +70,7 @@ func (s *TestSuite) TestSetOperations(t *testing.T) {
 
 				// Make a GNMI client to use for requests
 				ctx := rbac.GetBearerContext(context.Background(), token)
-				gnmiClient := gnmiutils.GetGNMIClientWithContextOrFail(ctx, t, gnmiutils.WithRetry)
+				gnmiClient := gnmiutils.GetGNMIClientOrFail(ctx, t, gnmiutils.WithRetry)
 				assert.NotNil(t, gnmiClient)
 
 				// Get path for the test value
@@ -78,17 +78,17 @@ func (s *TestSuite) TestSetOperations(t *testing.T) {
 				assert.NotNil(t, targetPath)
 
 				// Set a value using gNMI client
-				_, _, err = gnmiutils.SetGNMIValueWithContext(ctx, t, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+				_, _, err = gnmiutils.SetGNMIValue(ctx, gnmiClient, targetPath, gnmiutils.NoPaths, gnmiutils.NoExtensions)
 				if testCase.expectedError != "" {
 					assert.Contains(t, err.Error(), testCase.expectedError)
 					return
 				}
 
 				// Check that the value was set correctly
-				gnmiutils.CheckGNMIValueWithContext(ctx, t, gnmiClient, targetPath, tzValue, 0, "Query after set returned the wrong value")
+				gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, tzValue, 0, "Query after set returned the wrong value")
 
 				// Remove the path we added
-				gnmiutils.SetGNMIValueWithContextOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.NoExtensions)
+				gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.NoExtensions)
 			},
 		)
 	}

--- a/test/rbac/settest.go
+++ b/test/rbac/settest.go
@@ -88,7 +88,7 @@ func (s *TestSuite) TestSetOperations(t *testing.T) {
 				}
 
 				// Check that the value was set correctly
-				gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, tzValue, 0, "Query after set returned the wrong value")
+				gnmiutils.CheckGNMIValue(ctx, t, gnmiClient, targetPath, gnmiutils.NoExtensions, tzValue, 0, "Query after set returned the wrong value")
 
 				// Remove the path we added
 				gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, gnmiutils.NoPaths, targetPath, gnmiutils.NoExtensions)

--- a/test/utils/gnmi/clients.go
+++ b/test/utils/gnmi/clients.go
@@ -1,0 +1,165 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gnmi
+
+import (
+	"context"
+	gclient "github.com/openconfig/gnmi/client/gnmi"
+	"testing"
+	"time"
+
+	toposdk "github.com/onosproject/onos-ric-sdk-go/pkg/topo"
+
+	"github.com/onosproject/onos-lib-go/pkg/errors"
+
+	"github.com/onosproject/helmit/pkg/helm"
+	"github.com/onosproject/helmit/pkg/kubernetes"
+	v1 "github.com/onosproject/helmit/pkg/kubernetes/core/v1"
+	"github.com/onosproject/onos-api/go/onos/config/admin"
+	"github.com/onosproject/onos-lib-go/pkg/grpc/retry"
+	gnmiclient "github.com/openconfig/gnmi/client"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// RetryOption specifies if a client should retry request errors
+type RetryOption int
+
+const (
+	// NoRetry do not attempt to retry
+	NoRetry RetryOption = iota
+
+	// WithRetry adds a retry option to the client
+	WithRetry
+)
+
+func getService(ctx context.Context, release *helm.HelmRelease, serviceName string) (*v1.Service, error) {
+	releaseClient := kubernetes.NewForReleaseOrDie(release)
+	service, err := releaseClient.CoreV1().Services().Get(ctx, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}
+
+func connectComponent(ctx context.Context, releaseName string, deploymentName string) (*grpc.ClientConn, error) {
+	release := helm.Chart(releaseName).Release(releaseName)
+	return connectService(ctx, release, deploymentName)
+}
+
+func connectService(ctx context.Context, release *helm.HelmRelease, deploymentName string) (*grpc.ClientConn, error) {
+	service, err := getService(ctx, release, deploymentName)
+	if err != nil {
+		return nil, err
+	}
+	tlsConfig, err := getClientCredentials()
+	if err != nil {
+		return nil, err
+	}
+	return grpc.Dial(service.Ports()[0].Address(true), grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)))
+}
+
+// NewTopoClient creates a topology client
+func NewTopoClient() (toposdk.Client, error) {
+	return toposdk.NewClient()
+}
+
+// NewAdminServiceClient :
+func NewAdminServiceClient(ctx context.Context) (admin.ConfigAdminServiceClient, error) {
+	conn, err := connectComponent(ctx, "onos-umbrella", "onos-config")
+	if err != nil {
+		return nil, err
+	}
+	return admin.NewConfigAdminServiceClient(conn), nil
+}
+
+// NewTransactionServiceClient :
+func NewTransactionServiceClient(ctx context.Context) (admin.TransactionServiceClient, error) {
+	conn, err := connectComponent(ctx, "onos-umbrella", "onos-config")
+	if err != nil {
+		return nil, err
+	}
+	return admin.NewTransactionServiceClient(conn), nil
+}
+
+// NewConfigurationServiceClient returns configuration store client
+func NewConfigurationServiceClient(ctx context.Context) (admin.ConfigurationServiceClient, error) {
+	conn, err := connectComponent(ctx, "onos-umbrella", "onos-config")
+	if err != nil {
+		return nil, err
+	}
+	return admin.NewConfigurationServiceClient(conn), nil
+}
+
+// GetTargetGNMIClientOrFail creates a GNMI client to a target. If there is an error, the test is failed
+func GetTargetGNMIClientOrFail(ctx context.Context, t *testing.T, simulator *helm.HelmRelease) gnmiclient.Impl {
+	t.Helper()
+	simulatorClient := kubernetes.NewForReleaseOrDie(simulator)
+	services, err := simulatorClient.CoreV1().Services().List(context.Background())
+	assert.NoError(t, err)
+	service := services[0]
+	dest := gnmiclient.Destination{
+		Addrs:   []string{service.Ports()[0].Address(true)},
+		Target:  service.Name,
+		Timeout: 10 * time.Second,
+	}
+	client, err := gclient.New(ctx, dest)
+	assert.NoError(t, err)
+	assert.True(t, client != nil, "Fetching target client returned nil")
+	return client
+}
+
+// GetOnosConfigDestination :
+func GetOnosConfigDestination(ctx context.Context) (gnmiclient.Destination, error) {
+	creds, err := getClientCredentials()
+	if err != nil {
+		return gnmiclient.Destination{}, err
+	}
+	configRelease := helm.Release("onos-umbrella")
+	configClient := kubernetes.NewForReleaseOrDie(configRelease)
+
+	configService, err := configClient.CoreV1().Services().Get(ctx, "onos-config")
+	if err != nil || configService == nil {
+		return gnmiclient.Destination{}, errors.NewNotFound("can't find service for onos-config")
+	}
+
+	return gnmiclient.Destination{
+		Addrs:   []string{configService.Ports()[0].Address(true)},
+		Target:  configService.Name,
+		TLS:     creds,
+		Timeout: 10 * time.Second,
+	}, nil
+}
+
+// GetGNMIClientOrFail makes a GNMI client to use for requests. If creating the client fails, the test is failed.
+func GetGNMIClientOrFail(ctx context.Context, t *testing.T, retryOption RetryOption) gnmiclient.Impl {
+	t.Helper()
+	dest, err := GetOnosConfigDestination(ctx)
+	assert.NoError(t, err)
+	opts := make([]grpc.DialOption, 0)
+	opts = append(opts, grpc.WithTransportCredentials(credentials.NewTLS(dest.TLS)))
+	if retryOption == WithRetry {
+		opts = append(opts, grpc.WithUnaryInterceptor(retry.RetryingUnaryClientInterceptor()))
+	}
+
+	conn, err := grpc.DialContext(ctx, dest.Addrs[0], opts...)
+	assert.NoError(t, err)
+	client, err := gclient.NewFromConn(ctx, conn, dest)
+	assert.NoError(t, err)
+	return client
+}

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -561,8 +561,8 @@ func GetOnosConfigDestination() (gnmiclient.Destination, error) {
 	}, nil
 }
 
-// GetGNMIClientWithContextOrFail makes a GNMI client to use for requests. If creating the client fails, the test is failed.
-func GetGNMIClientWithContextOrFail(ctx context.Context, t *testing.T, retryOption RetryOption) gnmiclient.Impl {
+// GetGNMIClientOrFail makes a GNMI client to use for requests. If creating the client fails, the test is failed.
+func GetGNMIClientOrFail(ctx context.Context, t *testing.T, retryOption RetryOption) gnmiclient.Impl {
 	t.Helper()
 	gCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -584,8 +584,8 @@ func GetGNMIClientWithContextOrFail(ctx context.Context, t *testing.T, retryOpti
 	return client
 }
 
-// CheckGNMIValueWithContext makes sure a value has been assigned properly by querying the onos-config northbound API
-func CheckGNMIValueWithContext(ctx context.Context, t *testing.T, gnmiClient gnmiclient.Impl, paths []protoutils.TargetPath, expectedValue string, expectedExtensions int, failMessage string) {
+// CheckGNMIValue makes sure a value has been assigned properly by querying the onos-config northbound API
+func CheckGNMIValue(ctx context.Context, t *testing.T, gnmiClient gnmiclient.Impl, paths []protoutils.TargetPath, expectedValue string, expectedExtensions int, failMessage string) {
 	t.Helper()
 	value, extensions, err := GetGNMIValue(ctx, gnmiClient, paths, gpb.Encoding_PROTO)
 	assert.NoError(t, err, "Get operation returned an unexpected error")
@@ -604,8 +604,8 @@ func CheckGNMIValues(ctx context.Context, t *testing.T, gnmiClient gnmiclient.Im
 	}
 }
 
-// SetGNMIValueWithContextOrFail does a GNMI set operation to the given client, and fails the test if there is an error
-func SetGNMIValueWithContextOrFail(ctx context.Context, t *testing.T, gnmiClient gnmiclient.Impl,
+// SetGNMIValueOrFail does a GNMI set operation to the given client, and fails the test if there is an error
+func SetGNMIValueOrFail(ctx context.Context, t *testing.T, gnmiClient gnmiclient.Impl,
 	updatePaths []protoutils.TargetPath, deletePaths []protoutils.TargetPath,
 	extensions []*gnmi_ext.Extension) (configapi.TransactionID, v2.Index) {
 	t.Helper()

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -269,6 +269,7 @@ func WaitForTargetUnavailable(ctx context.Context, t *testing.T, objectID topo.I
 
 		if event.Type == topo.EventType_REMOVED || event.Type == topo.EventType_NONE {
 			cl, err := NewTopoClient()
+			assert.NoError(t, err)
 			_, err = cl.Get(ctx, event.Object.ID)
 			if errors.IsNotFound(err) {
 				t.Logf("Target %s is unavailable", objectID)

--- a/test/utils/gnmi/utils.go
+++ b/test/utils/gnmi/utils.go
@@ -522,14 +522,12 @@ func CheckTargetValueDeleted(ctx context.Context, t *testing.T, targetGnmiClient
 }
 
 // GetTargetGNMIClientOrFail creates a GNMI client to a target. If there is an error, the test is failed
-func GetTargetGNMIClientOrFail(t *testing.T, simulator *helm.HelmRelease) gnmiclient.Impl {
+func GetTargetGNMIClientOrFail(ctx context.Context, t *testing.T, simulator *helm.HelmRelease) gnmiclient.Impl {
 	t.Helper()
 	simulatorClient := kubernetes.NewForReleaseOrDie(simulator)
 	services, err := simulatorClient.CoreV1().Services().List(context.Background())
 	assert.NoError(t, err)
 	service := services[0]
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	dest := gnmiclient.Destination{
 		Addrs:   []string{service.Ports()[0].Address(true)},
 		Target:  service.Name,


### PR DESCRIPTION
- Added extensions parameter to Get() related functions
- Client creation functions are in a separate file
- utility functions no longer create their own contexts
- callers to utility functions specify the context that should be used
