### PR TITLE
Get state variables (passthrough) by specefiying the data type in the GetRequest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/onosproject/onos-lib-go v0.8.1
 	github.com/onosproject/onos-ric-sdk-go v0.8.2
 	github.com/onosproject/onos-test v0.6.6
-	github.com/onosproject/onos-topo v0.9.1
+	github.com/onosproject/onos-topo v0.9.3
 	github.com/openconfig/gnmi v0.0.0-20200617225440-d2b4e6a45802
 	github.com/openconfig/goyang v0.3.1
 	github.com/openconfig/ygot v0.12.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/onosproject/config-models/modelplugin/testdevice-2.0.0 v0.8.8
 	github.com/onosproject/helmit v0.6.19
-	github.com/onosproject/onos-api/go v0.8.53
+	github.com/onosproject/onos-api/go v0.8.54
 	github.com/onosproject/onos-lib-go v0.8.1
 	github.com/onosproject/onos-ric-sdk-go v0.8.2
 	github.com/onosproject/onos-test v0.6.6

--- a/go.sum
+++ b/go.sum
@@ -984,6 +984,8 @@ github.com/onosproject/onos-api/go v0.8.52 h1:smJINdaFPvW5zsU6FzLJX+pP8HJNIvFLW+
 github.com/onosproject/onos-api/go v0.8.52/go.mod h1:0hdMkFFN2AyKLHMiJVP3ZE61QgSYfNXHiI4BJ/Ry7UI=
 github.com/onosproject/onos-api/go v0.8.53 h1:knZLv1UVqTMYBW3vU6mVxufhKYhW2HORrshe/gc8GrI=
 github.com/onosproject/onos-api/go v0.8.53/go.mod h1:0hdMkFFN2AyKLHMiJVP3ZE61QgSYfNXHiI4BJ/Ry7UI=
+github.com/onosproject/onos-api/go v0.8.54 h1:nciPh50jArJQo9jUKUD3qBRgEdaEzlylWvset68+PL4=
+github.com/onosproject/onos-api/go v0.8.54/go.mod h1:0hdMkFFN2AyKLHMiJVP3ZE61QgSYfNXHiI4BJ/Ry7UI=
 github.com/onosproject/onos-lib-go v0.8.1 h1:debi/WjARXRmYNRtnMPVj3q1MuTl9kPFmrbRf0NGCQU=
 github.com/onosproject/onos-lib-go v0.8.1/go.mod h1:1klcUPfLoXPVu4fzM/sYi1V3Pggm2NRbY2fTzG2W1HY=
 github.com/onosproject/onos-proxy v0.1.0/go.mod h1:Julz7LLRkjnwIvioNEI1CjpujpxoA33vOdWSs0/wY9I=

--- a/go.sum
+++ b/go.sum
@@ -996,6 +996,8 @@ github.com/onosproject/onos-test v0.6.6 h1:KguLCDkhN3+/8YE8VjkuTW5g6GTq5fTRb5rIj
 github.com/onosproject/onos-test v0.6.6/go.mod h1:rC8K2TvTewH2EAh1rYZV38Qwwtpziw4p7wkLubPw7hI=
 github.com/onosproject/onos-topo v0.9.1 h1:FC6GhcRkTZs1ihoCAwrCBi8YPytO6nyTCeesXnMgkxw=
 github.com/onosproject/onos-topo v0.9.1/go.mod h1:oBYdHgKCxc1qG6ZQ5N4g7qak8qUOnje0HAstuPdaw5o=
+github.com/onosproject/onos-topo v0.9.3 h1:U2AxCaB8W7/R/nAyBJSvlyN6sA8/r3Udo0Xz9nZuYgY=
+github.com/onosproject/onos-topo v0.9.3/go.mod h1:vnr3mO5KtoC5kcQ9tS9qpgK7Ab9ZgZLHO3CR94gzgko=
 github.com/onsi/ginkgo v0.0.0-20151202141238-7f8ab55aaf3b/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -87,7 +87,7 @@ func (m *Manager) startNorthboundServer(
 	transactionsStore transaction.Store,
 	proposalsStore proposal.Store,
 	configurationsStore configuration.Store,
-	pluginRegistry pluginregistry.PluginRegistry) error {
+	pluginRegistry pluginregistry.PluginRegistry, conns sb.ConnManager) error {
 	authorization := false
 	if oidcURL := os.Getenv(OIDCServerURL); oidcURL != "" {
 		authorization = true
@@ -108,7 +108,7 @@ func (m *Manager) startNorthboundServer(
 	s.AddService(logging.Service{})
 
 	adminService := admin.NewService(transactionsStore, configurationsStore, pluginRegistry)
-	gnmi := gnminb.NewService(topo, transactionsStore, proposalsStore, configurationsStore, pluginRegistry)
+	gnmi := gnminb.NewService(topo, transactionsStore, proposalsStore, configurationsStore, pluginRegistry, conns)
 	s.AddService(adminService)
 	s.AddService(gnmi)
 
@@ -237,7 +237,7 @@ func (m *Manager) Start() error {
 		return err
 	}
 
-	err = m.startNorthboundServer(topoStore, transactions, proposals, configurations, m.pluginRegistry)
+	err = m.startNorthboundServer(topoStore, transactions, proposals, configurations, m.pluginRegistry, conns)
 	if err != nil {
 		return err
 	}

--- a/pkg/northbound/gnmi/v2/extensions.go
+++ b/pkg/northbound/gnmi/v2/extensions.go
@@ -18,12 +18,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
 	"github.com/onosproject/onos-lib-go/pkg/errors"
-	"github.com/onosproject/onos-lib-go/pkg/logging"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 )
-
-var log = logging.GetLogger("northbound", "gnmi")
 
 // extractExtension extract the value of an extension from a list given an extension ID
 // if extType is passed we assume the content of the extension is a proto that needs to be Unmarshalled,

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -74,15 +74,11 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		return resp, nil
 	}
 
-	if req.Type == gnmi.GetRequest_ALL {
-		return nil, errors.NewNotSupported("request data type %s not supported", gnmi.GetRequest_ALL.String())
-	}
-
-	return s.processConfigRequest(ctx, req, groups, transactionStrategy)
+	return s.processRequest(ctx, req, groups, transactionStrategy)
 
 }
 
-func (s *Server) processConfigRequest(ctx context.Context, req *gnmi.GetRequest, groups []string, transactionStrategy configapi.TransactionStrategy) (*gnmi.GetResponse, error) {
+func (s *Server) processRequest(ctx context.Context, req *gnmi.GetRequest, groups []string, transactionStrategy configapi.TransactionStrategy) (*gnmi.GetResponse, error) {
 	notifications := make([]*gnmi.Notification, 0)
 	prefix := req.GetPrefix()
 	targets := make(map[configapi.TargetID]*targetInfo)

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -104,7 +104,6 @@ func (s *Server) processRequest(ctx context.Context, req *gnmi.GetRequest, group
 				targetID:     targetID,
 				path:         path,
 				pathAsString: pathAsString,
-				readOnly:     false,
 			}
 			err := s.addTarget(ctx, targetID, targets, pathInfo)
 			if err != nil {

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -74,7 +74,11 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 		return resp, nil
 	}
 
-	return s.processRequest(ctx, req, groups, transactionStrategy)
+	resp, err := s.processRequest(ctx, req, groups, transactionStrategy)
+	if err != nil {
+		return nil, errors.Status(err).Err()
+	}
+	return resp, nil
 
 }
 

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -225,12 +225,10 @@ func (s *Server) processStateOrOperationalRequest(ctx context.Context, req *gnmi
 
 		conn, err := s.conns.GetByTarget(ctx, topoapi.ID(targetID))
 		if err != nil {
-			log.Warn("Test here 0", err)
 			return nil, errors.Status(err).Err()
 		}
 		resp, err := conn.Get(ctx, roGetReq)
 		if err != nil {
-			log.Warn("Test here 1", err)
 			return nil, errors.Status(err).Err()
 		}
 		notifications = append(notifications, resp.Notification...)
@@ -255,13 +253,12 @@ func (s *Server) addTarget(ctx context.Context, targetID configapi.TargetID, tar
 		plugin:        modelPlugin,
 	}
 
-	if !pathInfo.readOnly {
-		targetConfig, err := s.configurations.Get(ctx, configuration.NewID(targetInfo.targetID))
-		if err != nil {
-			return err
-		}
-		targetInfo.configuration = targetConfig
+	targetConfig, err := s.configurations.Get(ctx, configuration.NewID(targetInfo.targetID))
+	if err != nil {
+		return err
 	}
+	targetInfo.configuration = targetConfig
+
 	targets[targetID] = targetInfo
 	return nil
 }

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -132,7 +132,7 @@ func (s *Server) processRequest(ctx context.Context, req *gnmi.GetRequest, group
 			}
 		}
 
-		updates, err := s.getUpdate(ctx, targets[targetID], prefix, nil, req.GetEncoding(), groups)
+		updates, err := s.getUpdate(ctx, targets[targetID], prefix, &pathInfo{}, req.GetEncoding(), groups)
 		if err != nil {
 			return nil, errors.Status(err).Err()
 		}
@@ -257,7 +257,6 @@ func (s *Server) addTarget(ctx context.Context, targetID configapi.TargetID, tar
 		return err
 	}
 	targetInfo.configuration = targetConfig
-
 	targets[targetID] = targetInfo
 	return nil
 }

--- a/pkg/northbound/gnmi/v2/get.go
+++ b/pkg/northbound/gnmi/v2/get.go
@@ -83,6 +83,7 @@ func (s *Server) Get(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetRespon
 }
 
 func (s *Server) processRequest(ctx context.Context, req *gnmi.GetRequest, groups []string, transactionStrategy configapi.TransactionStrategy) (*gnmi.GetResponse, error) {
+	log.Debugf("Processing get request %+v", req)
 	notifications := make([]*gnmi.Notification, 0)
 	prefix := req.GetPrefix()
 	targets := make(map[configapi.TargetID]*targetInfo)
@@ -185,10 +186,11 @@ func (s *Server) processRequest(ctx context.Context, req *gnmi.GetRequest, group
 		wg.Wait()
 	}
 
-	response := gnmi.GetResponse{
+	response := &gnmi.GetResponse{
 		Notification: notifications,
 	}
-	return &response, nil
+	log.Debugf("Returning Get response for request: %+v", response, req)
+	return response, nil
 }
 
 func (s *Server) processStateOrOperationalRequest(ctx context.Context, req *gnmi.GetRequest) (*gnmi.GetResponse, error) {

--- a/pkg/northbound/gnmi/v2/get_utils.go
+++ b/pkg/northbound/gnmi/v2/get_utils.go
@@ -15,8 +15,9 @@
 package gnmi
 
 import (
-	"fmt"
 	"regexp"
+
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 
 	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
 
@@ -83,7 +84,7 @@ func createUpdate(prefix *gnmi.Path, path *gnmi.Path, configValues []*configapi.
 		}
 		return updates, nil
 	default:
-		return nil, fmt.Errorf("unsupported encoding %v", encoding)
+		return nil, errors.NewInvalid("unsupported encoding %v", encoding)
 	}
 }
 

--- a/pkg/northbound/gnmi/v2/service.go
+++ b/pkg/northbound/gnmi/v2/service.go
@@ -17,8 +17,9 @@ package gnmi
 
 import (
 	"context"
-	"github.com/onosproject/onos-config/pkg/store/proposal"
 	"sync"
+
+	"github.com/onosproject/onos-config/pkg/store/proposal"
 
 	"github.com/golang/protobuf/proto"
 	protobuf "github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -32,6 +33,7 @@ import (
 	"github.com/onosproject/onos-config/pkg/store/topo"
 	"github.com/onosproject/onos-config/pkg/store/transaction"
 
+	sb "github.com/onosproject/onos-config/pkg/southbound/gnmi"
 	"github.com/onosproject/onos-lib-go/pkg/northbound"
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc"
@@ -45,6 +47,7 @@ type Service struct {
 	transactions   transaction.Store
 	proposals      proposal.Store
 	configurations configuration.Store
+	conns          sb.ConnManager
 }
 
 // NewService allocates a Service struct with the given parameters
@@ -53,13 +56,14 @@ func NewService(
 	transactions transaction.Store,
 	proposals proposal.Store,
 	configurations configuration.Store,
-	pluginRegistry pluginregistry.PluginRegistry) Service {
+	pluginRegistry pluginregistry.PluginRegistry, conns sb.ConnManager) Service {
 	return Service{
 		pluginRegistry: pluginRegistry,
 		topo:           topo,
 		transactions:   transactions,
 		proposals:      proposals,
 		configurations: configurations,
+		conns:          conns,
 	}
 }
 
@@ -72,6 +76,7 @@ func (s Service) Register(r *grpc.Server) {
 			transactions:   s.transactions,
 			proposals:      s.proposals,
 			configurations: s.configurations,
+			conns:          s.conns,
 		})
 }
 
@@ -83,6 +88,7 @@ type Server struct {
 	transactions   transaction.Store
 	proposals      proposal.Store
 	configurations configuration.Store
+	conns          sb.ConnManager
 }
 
 // Capabilities implements gNMI Capabilities

--- a/pkg/northbound/gnmi/v2/service.go
+++ b/pkg/northbound/gnmi/v2/service.go
@@ -19,6 +19,8 @@ import (
 	"context"
 	"sync"
 
+	"github.com/onosproject/onos-lib-go/pkg/logging"
+
 	"github.com/onosproject/onos-config/pkg/store/proposal"
 
 	"github.com/golang/protobuf/proto"
@@ -38,6 +40,8 @@ import (
 	"github.com/openconfig/gnmi/proto/gnmi"
 	"google.golang.org/grpc"
 )
+
+var log = logging.GetLogger("northbound", "gnmi")
 
 // Service implements Service for GNMI
 type Service struct {

--- a/pkg/northbound/gnmi/v2/types.go
+++ b/pkg/northbound/gnmi/v2/types.go
@@ -34,5 +34,4 @@ type pathInfo struct {
 	targetID     configapi.TargetID
 	path         *gnmi.Path
 	pathAsString string
-	readOnly     bool
 }

--- a/pkg/southbound/gnmi/conn_manager.go
+++ b/pkg/southbound/gnmi/conn_manager.go
@@ -16,6 +16,9 @@ package gnmi
 
 import (
 	"context"
+	"math"
+	"sync"
+
 	"github.com/google/uuid"
 	topoapi "github.com/onosproject/onos-api/go/onos/topo"
 	"github.com/onosproject/onos-lib-go/pkg/errors"
@@ -24,13 +27,12 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
-	"math"
-	"sync"
 )
 
 // ConnManager gNMI connection manager
 type ConnManager interface {
 	Get(ctx context.Context, connID ConnID) (Conn, bool)
+	GetByTarget(ctx context.Context, targetID topoapi.ID) (Client, error)
 	Connect(ctx context.Context, target *topoapi.Object) error
 	Disconnect(ctx context.Context, targetID topoapi.ID) error
 	Watch(ctx context.Context, ch chan<- Conn) error
@@ -39,7 +41,7 @@ type ConnManager interface {
 // NewConnManager creates a new gNMI connection manager
 func NewConnManager() ConnManager {
 	mgr := &connManager{
-		targets:  make(map[topoapi.ID]*grpc.ClientConn),
+		targets:  make(map[topoapi.ID]*client),
 		conns:    make(map[ConnID]Conn),
 		watchers: make(map[uuid.UUID]chan<- Conn),
 		eventCh:  make(chan Conn),
@@ -49,12 +51,23 @@ func NewConnManager() ConnManager {
 }
 
 type connManager struct {
-	targets    map[topoapi.ID]*grpc.ClientConn
+	targets    map[topoapi.ID]*client
 	conns      map[ConnID]Conn
 	connsMu    sync.RWMutex
 	watchers   map[uuid.UUID]chan<- Conn
 	watchersMu sync.RWMutex
 	eventCh    chan Conn
+}
+
+func (m *connManager) GetByTarget(ctx context.Context, targetID topoapi.ID) (Client, error) {
+	m.connsMu.RLock()
+	defer m.connsMu.RUnlock()
+	for id, gnmiClient := range m.targets {
+		if id == targetID {
+			return gnmiClient, nil
+		}
+	}
+	return nil, errors.NewNotFound("connection for target %s not found", targetID)
 }
 
 func (m *connManager) Get(ctx context.Context, connID ConnID) (Conn, bool) {
@@ -66,7 +79,7 @@ func (m *connManager) Get(ctx context.Context, connID ConnID) (Conn, bool) {
 
 func (m *connManager) Connect(ctx context.Context, target *topoapi.Object) error {
 	m.connsMu.RLock()
-	clientConn, ok := m.targets[target.ID]
+	gnmiClient, ok := m.targets[target.ID]
 	m.connsMu.RUnlock()
 	if ok {
 		return errors.NewAlreadyExists("target '%s' already exists", target.ID)
@@ -75,7 +88,7 @@ func (m *connManager) Connect(ctx context.Context, target *topoapi.Object) error
 	m.connsMu.Lock()
 	defer m.connsMu.Unlock()
 
-	clientConn, ok = m.targets[target.ID]
+	gnmiClient, ok = m.targets[target.ID]
 	if ok {
 		return errors.NewAlreadyExists("target '%s' already exists", target.ID)
 	}
@@ -104,7 +117,8 @@ func (m *connManager) Connect(ctx context.Context, target *topoapi.Object) error
 		log.Warnf("Failed to connect to the gNMI target %s: %s", destination.Target, err)
 		return err
 	}
-	m.targets[target.ID] = clientConn
+
+	m.targets[target.ID] = gnmiClient
 
 	go func() {
 		var conn Conn

--- a/pkg/southbound/gnmi/conn_manager.go
+++ b/pkg/southbound/gnmi/conn_manager.go
@@ -67,7 +67,7 @@ func (m *connManager) GetByTarget(ctx context.Context, targetID topoapi.ID) (Cli
 			return gnmiClient, nil
 		}
 	}
-	return nil, errors.NewNotFound("connection for target %s not found", targetID)
+	return nil, errors.NewNotFound("gnmi client for target %s not found", targetID)
 }
 
 func (m *connManager) Get(ctx context.Context, connID ConnID) (Conn, bool) {

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -12,27 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package gnmi
+package node
 
 import (
-	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
-	"github.com/onosproject/onos-config/pkg/pluginregistry"
-	"github.com/openconfig/gnmi/proto/gnmi"
+	topoapi "github.com/onosproject/onos-api/go/onos/topo"
+	"github.com/onosproject/onos-lib-go/pkg/env"
+	"github.com/onosproject/onos-lib-go/pkg/uri"
 )
 
-type targetInfo struct {
-	targetID      configapi.TargetID
-	targetVersion configapi.TargetVersion
-	targetType    configapi.TargetType
-	plugin        pluginregistry.ModelPlugin
-	updates       configapi.TypedValueMap
-	removes       []string
-	configuration *configapi.Configuration
-}
-
-type pathInfo struct {
-	targetID     configapi.TargetID
-	path         *gnmi.Path
-	pathAsString string
-	readOnly     bool
+// GetOnosConfigID gets onos-config URI
+func GetOnosConfigID() topoapi.ID {
+	return topoapi.ID(uri.NewURI(
+		uri.WithScheme("gnmi"),
+		uri.WithOpaque(env.GetPodID())).String())
 }

--- a/test/config/getstatetest.go
+++ b/test/config/getstatetest.go
@@ -1,0 +1,57 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"testing"
+
+	gnmiutils "github.com/onosproject/onos-config/test/utils/gnmi"
+	"github.com/onosproject/onos-config/test/utils/proto"
+	protognmi "github.com/openconfig/gnmi/proto/gnmi"
+)
+
+const (
+	stateValue = "opennetworking.org"
+	statePath  = "/system/state/domain-name"
+)
+
+// TestGetState tests query/set/delete of a single GNMI path to a single device
+func (s *TestSuite) TestGetState(t *testing.T) {
+	ctx, cancel := gnmiutils.MakeContext()
+	defer cancel()
+
+	// Create a simulated device
+	simulator := gnmiutils.CreateSimulator(ctx, t)
+	defer gnmiutils.DeleteSimulator(t, simulator)
+
+	// Make a GNMI client to use for requests
+	gnmiClient := gnmiutils.NewOnosConfigGNMIClientOrFail(ctx, t, gnmiutils.NoRetry)
+
+	// Get the GNMI path
+	targetPaths := gnmiutils.GetTargetPathWithValue(simulator.Name(), statePath, stateValue, proto.StringVal)
+
+	// Set up requests
+	var onosConfigGetReq = &gnmiutils.GetRequest{
+		Ctx:      ctx,
+		Client:   gnmiClient,
+		Paths:    targetPaths,
+		Encoding: protognmi.Encoding_JSON,
+		DataType: protognmi.GetRequest_STATE,
+	}
+
+	// Check that the value was set correctly, both in onos-config and on the target
+	onosConfigGetReq.CheckValue(t, stateValue, 0, "Query after set returned the wrong value from onos-config")
+
+}

--- a/test/config/singlepathtest.go
+++ b/test/config/singlepathtest.go
@@ -15,9 +15,10 @@
 package config
 
 import (
+	"testing"
+
 	protognmi "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	gnmiutils "github.com/onosproject/onos-config/test/utils/gnmi"
 	"github.com/onosproject/onos-config/test/utils/proto"
@@ -50,7 +51,6 @@ func (s *TestSuite) TestSinglePath(t *testing.T) {
 		Client:   gnmiClient,
 		Paths:    targetPaths,
 		Encoding: protognmi.Encoding_PROTO,
-		DataType: protognmi.GetRequest_CONFIG,
 	}
 	var simulatorGetReq = &gnmiutils.GetRequest{
 		Ctx:      ctx,

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -69,7 +69,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 
 	// Set initial values
 	targetPathsForInit := gnmiutils.GetTargetPathsWithValues(targets, paths, initialValues)
-	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForInit, gnmiutils.NoPaths, gnmiutils.NoExtensions)
+	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForInit, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
 	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, initialValues, 0, "Query after initial set returned the wrong value")
 
 	// Create a change that can be rolled back

--- a/test/config/transactiontest.go
+++ b/test/config/transactiontest.go
@@ -70,7 +70,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 	// Set initial values
 	targetPathsForInit := gnmiutils.GetTargetPathsWithValues(targets, paths, initialValues)
 	_, _ = gnmiutils.SetGNMIValueOrFail(ctx, t, gnmiClient, targetPathsForInit, gnmiutils.NoPaths, gnmiutils.SyncExtension(t))
-	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, initialValues, 0, "Query after initial set returned the wrong value")
+	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.SyncExtension(t), initialValues, 0, "Query after initial set returned the wrong value")
 
 	// Create a change that can be rolled back
 	targetPathsForSet := gnmiutils.GetTargetPathsWithValues(targets, paths, values)
@@ -78,7 +78,7 @@ func (s *TestSuite) TestTransaction(t *testing.T) {
 
 	// Check that the values were set correctly
 	expectedValues := []string{value1, value2}
-	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.NoExtensions, expectedValues, 0, "Query after set returned the wrong value")
+	gnmiutils.CheckGNMIValues(ctx, t, gnmiClient, targetPathsForGet, gnmiutils.SyncExtension(t), expectedValues, 0, "Query after set returned the wrong value")
 
 	// Check that the values are set on the targets
 	target1GnmiClient := gnmiutils.NewSimulatorGNMIClientOrFail(ctx, t, target1)

--- a/test/utils/gnmi/requests.go
+++ b/test/utils/gnmi/requests.go
@@ -18,6 +18,9 @@ package gnmi
 import (
 	"context"
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/onosproject/onos-api/go/onos/config/v2"
 	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
@@ -27,8 +30,6 @@ import (
 	protognmi "github.com/openconfig/gnmi/proto/gnmi"
 	"github.com/openconfig/gnmi/proto/gnmi_ext"
 	"github.com/stretchr/testify/assert"
-	"strings"
-	"testing"
 )
 
 // GetRequest represents a GNMI Get request
@@ -54,6 +55,7 @@ func (req *GetRequest) Get() ([]protoutils.TargetPath, []*gnmi_ext.Extension, er
 	}
 	gnmiGetRequest.Encoding = req.Encoding
 	gnmiGetRequest.Extension = req.Extensions
+	gnmiGetRequest.Type = req.DataType
 	response, err := req.Client.(*gclient.Client).Get(req.Ctx, gnmiGetRequest)
 	if err != nil || response == nil {
 		return nil, nil, err


### PR DESCRIPTION
This PR implements the following cases which is required for Aether. The user should specify the data type for STATE or OPERATIONAL data types and the request gets processed by forming a Get request _for all of the paths in the request that are associated with each target_ to be sent down to each target. The responses from all of the targets will be processed to form and return one GetResponse  to the user. 

according to the gnmi spec:

The types of data currently defined are:

    CONFIG - specified to be data that the target considers to be read/write. If the data schema is described in YANG, this corresponds to the "config true" set of leaves on the target. (the default behavior is this even if the user doesn't set it at the moment)
    STATE - specified to be the read-only data on the target. If the data schema is described in YANG, STATE data is the "config false" set of leaves on the target. 
    OPERATIONAL - specified to be the read-only data on the target that is related to software processes operating on the device, or external interactions of the device.
ALL:  All data elements. (I think it should be the default value of enum)


If the type field is not specified, the target MUST return CONFIG, STATE and OPERATIONAL data fields in the tree resulting from the client's query. (not supported yet completly). 
  To support this, we need a function to be added in the plugin to determine a path is read only or not then distinguish the   read only paths from RW paths in the request, then process the read only paths by sending the GetRequests to the target  and RW paths by reading them from the configuration store to form a GetResponse and return it to the user.  


