### PR TITLE
[SDRAN-1521] WIP Testing ExtractPaths method

### DIFF
--- a/pkg/utils/path/path.go
+++ b/pkg/utils/path/path.go
@@ -52,11 +52,29 @@ type ReadOnlyAttrib struct {
 	AttrName    string
 }
 
+func (ro ReadOnlyAttrib) String() string {
+	// TODO add all fields
+	return fmt.Sprintf("[IsAKey: %t, ValueType: %s, TypeOpts: %d, Description: %s]", ro.IsAKey, ro.ValueType, ro.TypeOpts, ro.Description)
+}
+
 // ReadOnlySubPathMap abstracts the read only subpath
 type ReadOnlySubPathMap map[string]ReadOnlyAttrib
 
+
+
 // ReadOnlyPathMap abstracts the read only path
 type ReadOnlyPathMap map[string]ReadOnlySubPathMap
+
+func (ro ReadOnlyPathMap) PrettyString() string {
+	str := ""
+	for k, subPaths := range ro {
+		str += fmt.Sprintf("%s\n", k)
+		for k1, v := range subPaths {
+			str += fmt.Sprintf("\t%s: %s\n", k1, v)
+		}
+	}
+	return str
+}
 
 var rOnIndex = regexp.MustCompile(MatchOnIndex)
 var rIndexAllowedChars = regexp.MustCompile(IndexAllowedChars)
@@ -105,6 +123,15 @@ type ReadWritePathElem struct {
 
 // ReadWritePathMap is a map of ReadWrite paths their metadata
 type ReadWritePathMap map[string]ReadWritePathElem
+
+func (rw ReadWritePathMap) PrettyString() string {
+	str := ""
+	for k, v := range rw {
+		str += fmt.Sprintf("%s\n", k)
+		str += fmt.Sprintf("\t%s\n", v)
+	}
+	return str
+}
 
 // JustPaths extracts keys from a read write path map
 // expandSubPaths is not relevant for RW paths

--- a/pkg/utils/path/path_test.go
+++ b/pkg/utils/path/path_test.go
@@ -1,0 +1,188 @@
+package path
+
+import (
+	"fmt"
+	"github.com/openconfig/goyang/pkg/yang"
+	"gotest.tools/assert"
+	"testing"
+)
+
+// test the most basic scenario with one RO and one RW path, no recursion
+func TestExtractPathsSimpleCase(t *testing.T) {
+	var (
+		roLeaf = &yang.Entry{
+			Name:   "roLeaf",
+			Config: yang.TSFalse,
+			Type: &yang.YangType{
+				Name: "string",
+				Kind: yang.Ystring,
+			},
+		}
+		rwLeaf = &yang.Entry{
+			Name:   "rwLeaf",
+			Config: yang.TSTrue,
+			Type: &yang.YangType{
+				Name: "string",
+				Kind: yang.Ystring,
+			},
+			Default: "default",
+		}
+		simpleEntry = &yang.Entry{
+			Name:   "device",
+			Kind:   yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			Annotation: map[string]interface{}{
+				"isFakeRoot": true,
+				"schemapath": "/",
+				"structname": "Device",
+			},
+		}
+	)
+
+	// populate the yang tree
+	roLeaf.Parent = simpleEntry
+	rwLeaf.Parent = simpleEntry
+	simpleEntry.Dir = map[string]*yang.Entry{
+		"roLeaf": roLeaf,
+		"rwLeaf": rwLeaf,
+	}
+
+	ro, rw := ExtractPaths(simpleEntry, yang.TSUnset, "", "")
+	fmt.Println(ro.PrettyString(), rw.PrettyString())
+	assert.Equal(t, len(ro), 1)
+	assert.Equal(t, len(rw), 1)
+
+	assert.Equal(t, ro["/roLeaf"]["/"].AttrName, "roLeaf")
+	assert.Equal(t, rw["/rwLeaf"].Default, "default")
+	assert.Equal(t, rw["/rwLeaf"].ReadOnlyAttrib.AttrName, "rwLeaf")
+}
+
+// test recursion with no RO paths
+func TestExtractPathsNested(t *testing.T) {
+	var (
+		testDeviceEntry = &yang.Entry{
+			Name:   "device",
+			Kind:   yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			Annotation: map[string]interface{}{
+				"isFakeRoot": true,
+				"schemapath": "/",
+				"structname": "Device",
+			},
+			// Dir: cont1a
+		}
+		cont1a = &yang.Entry{
+			Name: "cont1a",
+			Kind: yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			// Dir: list2a
+		}
+		list2a = &yang.Entry{
+			Name: "list2a",
+			Kind: yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			ListAttr: &yang.ListAttr{
+				MinElements: 0,
+				MaxElements: 4,
+				OrderedBy:   nil,
+			},
+			Key: "name",
+			// Dir: name
+		}
+		name = &yang.Entry{
+			Name: "name",
+			Kind: yang.LeafEntry,
+			Config: yang.TSUnset,
+			Type: &yang.YangType{
+				Name: "string",
+				Kind: yang.Ystring,
+			},
+		}
+	)
+
+	name.Parent = list2a
+
+	list2a.Parent = cont1a
+	list2a.Dir = map[string]*yang.Entry{
+		"name": name,
+	}
+
+	cont1a.Parent = testDeviceEntry
+	cont1a.Dir = map[string]*yang.Entry{
+		"list2a": list2a,
+	}
+
+	testDeviceEntry.Dir = map[string]*yang.Entry{
+		"cont1a": cont1a,
+	}
+
+	ro, rw := ExtractPaths(testDeviceEntry, yang.TSUnset, "", "")
+	fmt.Println(ro.PrettyString(), rw.PrettyString())
+	assert.Equal(t, len(ro), 0)
+	assert.Equal(t, len(rw), 1)
+}
+
+// test recursion with RO paths
+func TestExtractPathsNestedRO(t *testing.T) {
+	var (
+		testDeviceEntry = &yang.Entry{
+			Name:   "device",
+			Kind:   yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			Annotation: map[string]interface{}{
+				"isFakeRoot": true,
+				"schemapath": "/",
+				"structname": "Device",
+			},
+			// Dir: cont1a
+		}
+		cont1a = &yang.Entry{
+			Name: "cont1a",
+			Kind: yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			// Dir: list2a
+		}
+		list2a = &yang.Entry{
+			Name: "list2a",
+			Kind: yang.DirectoryEntry,
+			Config: yang.TSUnset,
+			ListAttr: &yang.ListAttr{
+				MinElements: 0,
+				MaxElements: 4,
+				OrderedBy:   nil,
+			},
+			Key: "name",
+			// Dir: name
+		}
+		name = &yang.Entry{
+			Name: "name",
+			Kind: yang.LeafEntry,
+			Config: yang.TSFalse,
+			Type: &yang.YangType{
+				Name: "string",
+				Kind: yang.Ystring,
+			},
+		}
+	)
+
+	name.Parent = list2a
+
+	list2a.Parent = cont1a
+	list2a.Dir = map[string]*yang.Entry{
+		"name": name,
+	}
+
+	cont1a.Parent = testDeviceEntry
+	cont1a.Dir = map[string]*yang.Entry{
+		"list2a": list2a,
+	}
+
+	testDeviceEntry.Dir = map[string]*yang.Entry{
+		"cont1a": cont1a,
+	}
+
+	ro, rw := ExtractPaths(testDeviceEntry, yang.TSUnset, "", "")
+	fmt.Println(ro.PrettyString())
+	assert.Equal(t, len(ro), 1)
+	assert.Equal(t, len(rw), 0)
+}


### PR DESCRIPTION
Starting to look at the `ExtractPaths` method.

There is something that does not adds up in a basic test I added: `TestExtractPathsNested`
```
// read-only paths
/cont1a/list2a[name=*]
	/name: [IsAKey: false, ValueType: STRING, TypeOpts: [], Description: ]
	
// read-write paths
 /cont1a/list2a[name=*]/name
	[IsAKey: true, ValueType: STRING, TypeOpts: [], Description: ]
```

It seems strange to me that the same path is both `read-only` and `read-write`. My understanding is that it should be a `rw` path, is that correct @SeanCondon ?