### PR TITLE
Add caching and watch multiplexing in Transaction store

### DIFF
--- a/pkg/store/transaction/store.go
+++ b/pkg/store/transaction/store.go
@@ -15,6 +15,8 @@
 package transaction
 
 import (
+	"github.com/google/uuid"
+	"sync"
 	"time"
 
 	"github.com/atomix/atomix-go-client/pkg/atomix"
@@ -42,12 +44,6 @@ type Store interface {
 	// GetByIndex gets a transaction by index
 	GetByIndex(ctx context.Context, index configapi.Index) (*configapi.Transaction, error)
 
-	// GetPrev gets the previous network change by index
-	GetPrev(ctx context.Context, index configapi.Index) (*configapi.Transaction, error)
-
-	// GetNext gets the next transaction by index
-	GetNext(ctx context.Context, index configapi.Index) (*configapi.Transaction, error)
-
 	// Create creates a new transaction
 	Create(ctx context.Context, transaction *configapi.Transaction) error
 
@@ -56,9 +52,6 @@ type Store interface {
 
 	// UpdateStatus updates the status of an existing transaction
 	UpdateStatus(ctx context.Context, transaction *configapi.Transaction) error
-
-	// Delete deletes a transaction
-	Delete(ctx context.Context, transaction *configapi.Transaction) error
 
 	// List lists transactions
 	List(ctx context.Context) ([]*configapi.Transaction, error)
@@ -76,22 +69,35 @@ func NewAtomixStore(client atomix.Client) (Store, error) {
 	if err != nil {
 		return nil, errors.FromAtomix(err)
 	}
-	return &transactionStore{
+	store := &transactionStore{
 		transactions: transactions,
-	}, nil
+		cacheIDs:     make(map[configapi.TransactionID]*cacheEntry),
+		cacheIndexes: make(map[configapi.Index]*cacheEntry),
+		watchers:     make(map[uuid.UUID]chan<- configapi.TransactionEvent),
+		eventCh:      make(chan configapi.TransactionEvent, 1000),
+	}
+	if err := store.open(context.Background()); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+type watchOptions struct {
+	transactionID configapi.TransactionID
+	replay        bool
 }
 
 // WatchOption is a configuration option for Watch calls
 type WatchOption interface {
-	apply([]indexedmap.WatchOption) []indexedmap.WatchOption
+	apply(*watchOptions)
 }
 
 // watchReplyOption is an option to replay events on watch
 type watchReplayOption struct {
 }
 
-func (o watchReplayOption) apply(opts []indexedmap.WatchOption) []indexedmap.WatchOption {
-	return append(opts, indexedmap.WithReplay())
+func (o watchReplayOption) apply(options *watchOptions) {
+	options.replay = true
 }
 
 // WithReplay returns a WatchOption that replays past changes
@@ -103,10 +109,8 @@ type watchIDOption struct {
 	id configapi.TransactionID
 }
 
-func (o watchIDOption) apply(opts []indexedmap.WatchOption) []indexedmap.WatchOption {
-	return append(opts, indexedmap.WithFilter(indexedmap.Filter{
-		Key: string(o.id),
-	}))
+func (o watchIDOption) apply(options *watchOptions) {
+	options.transactionID = o.id
 }
 
 // WithTransactionID returns a Watch option that watches for transactions based on a  given transaction ID
@@ -114,50 +118,171 @@ func WithTransactionID(id configapi.TransactionID) WatchOption {
 	return watchIDOption{id: id}
 }
 
+type cacheEntry struct {
+	*configapi.Transaction
+	prev *cacheEntry
+	next *cacheEntry
+}
+
 type transactionStore struct {
 	transactions indexedmap.IndexedMap
+	cacheIDs     map[configapi.TransactionID]*cacheEntry
+	cacheIndexes map[configapi.Index]*cacheEntry
+	firstEntry   *cacheEntry
+	cacheMu      sync.RWMutex
+	watchers     map[uuid.UUID]chan<- configapi.TransactionEvent
+	watchersMu   sync.RWMutex
+	eventCh      chan configapi.TransactionEvent
+}
+
+func (s *transactionStore) open(ctx context.Context) error {
+	ch := make(chan indexedmap.Event)
+	if err := s.transactions.Watch(ctx, ch, indexedmap.WithReplay()); err != nil {
+		return err
+	}
+	go func() {
+		for event := range ch {
+			transaction := &configapi.Transaction{}
+			if err := decodeTransaction(&event.Entry, transaction); err != nil {
+				log.Error(err)
+				continue
+			}
+			s.updateCache(transaction)
+		}
+	}()
+	go s.processEvents()
+	return nil
+}
+
+func (s *transactionStore) publishEvent(event configapi.TransactionEvent) {
+	s.eventCh <- event
+}
+
+func (s *transactionStore) processEvents() {
+	for event := range s.eventCh {
+		s.watchersMu.RLock()
+		for _, watcher := range s.watchers {
+			watcher <- event
+		}
+		s.watchersMu.RUnlock()
+	}
+}
+
+func (s *transactionStore) updateCache(transaction *configapi.Transaction) {
+	// Use a double-checked lock when updating the cache.
+	// First, check for a more recent version of the transaction already in the cache.
+	s.cacheMu.RLock()
+	entry, ok := s.cacheIDs[transaction.ID]
+	s.cacheMu.RUnlock()
+	if ok && entry.Version >= transaction.Version {
+		*transaction = *entry.Transaction
+		return
+	}
+
+	// The cache needs to be updated. Acquire a write lock and check once again
+	// for a more recent version of the transaction.
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+	entry, ok = s.cacheIDs[transaction.ID]
+	if !ok {
+		entry = &cacheEntry{
+			Transaction: transaction,
+		}
+		s.cacheIDs[entry.ID] = entry
+		s.cacheIndexes[entry.Index] = entry
+		if s.firstEntry == nil || entry.Index < s.firstEntry.Index {
+			s.firstEntry = entry
+		}
+		if prevEntry, ok := s.cacheIndexes[transaction.Index-1]; ok {
+			entry.prev = prevEntry
+			prevEntry.next = entry
+		}
+		if nextEntry, ok := s.cacheIndexes[transaction.Index+1]; ok {
+			entry.next = nextEntry
+			nextEntry.prev = entry
+		}
+		s.publishEvent(configapi.TransactionEvent{
+			Type:        configapi.TransactionEvent_CREATED,
+			Transaction: *transaction,
+		})
+		return
+	}
+
+	// If the cached entry version is greater than the update version, skip the update.
+	if entry.Version >= transaction.Version {
+		*transaction = *entry.Transaction
+		return
+	}
+
+	// Add the transaction to the ID and index caches and publish an event.
+	entry.Transaction = transaction
+	s.publishEvent(configapi.TransactionEvent{
+		Type:        configapi.TransactionEvent_UPDATED,
+		Transaction: *transaction,
+	})
 }
 
 // Get gets a transaction
 func (s *transactionStore) Get(ctx context.Context, id configapi.TransactionID) (*configapi.Transaction, error) {
+	// Check the ID cache for the latest version of the transaction.
+	s.cacheMu.RLock()
+	cached, ok := s.cacheIDs[id]
+	s.cacheMu.RUnlock()
+	if ok {
+		return cached.Transaction, nil
+	}
+
+	// If the transaction is not already in the cache, get it from the underlying primitive.
 	entry, err := s.transactions.Get(ctx, string(id))
 	if err != nil {
 		return nil, errors.FromAtomix(err)
 	}
-	return decodeTransaction(*entry)
+
+	// Decode the transaction bytes.
+	transaction := &configapi.Transaction{}
+	if err := decodeTransaction(entry, transaction); err != nil {
+		return nil, errors.NewInvalid("transaction decoding failed: %v", err)
+	}
+
+	// Update the cache before returning the transaction.
+	s.updateCache(transaction)
+	return transaction, nil
 }
 
 // GetByIndex gets a transaction by index
 func (s *transactionStore) GetByIndex(ctx context.Context, index configapi.Index) (*configapi.Transaction, error) {
+	// Check the index cache for the latest version of the transaction.
+	s.cacheMu.RLock()
+	cached, ok := s.cacheIndexes[index]
+	s.cacheMu.RUnlock()
+	if ok {
+		return cached.Transaction, nil
+	}
+
+	// If the transaction is not already in the cache, get it from the underlying primitive.
 	entry, err := s.transactions.GetIndex(ctx, indexedmap.Index(index))
 	if err != nil {
 		return nil, errors.FromAtomix(err)
 	}
-	return decodeTransaction(*entry)
-}
 
-// GetPrev gets the previous network change by index
-func (s *transactionStore) GetPrev(ctx context.Context, index configapi.Index) (*configapi.Transaction, error) {
-	entry, err := s.transactions.PrevEntry(ctx, indexedmap.Index(index))
-	if err != nil {
-		return nil, errors.FromAtomix(err)
+	// Decode the transaction bytes.
+	transaction := &configapi.Transaction{}
+	if err := decodeTransaction(entry, transaction); err != nil {
+		return nil, errors.NewInvalid("transaction decoding failed: %v", err)
 	}
-	return decodeTransaction(*entry)
-}
 
-// GetNext gets the next transaction by index
-func (s *transactionStore) GetNext(ctx context.Context, index configapi.Index) (*configapi.Transaction, error) {
-	entry, err := s.transactions.NextEntry(ctx, indexedmap.Index(index))
-	if err != nil {
-		return nil, errors.FromAtomix(err)
-	}
-	return decodeTransaction(*entry)
+	// Update the cache before returning the transaction.
+	s.updateCache(transaction)
+	return transaction, nil
 }
 
 // Create creates a new transaction
 func (s *transactionStore) Create(ctx context.Context, transaction *configapi.Transaction) error {
 	if transaction.ID == "" {
 		transaction.ID = newTransactionID()
+	}
+	if transaction.Version != 0 {
+		return errors.NewInvalid("not a new object")
 	}
 	if transaction.Revision != 0 {
 		return errors.NewInvalid("not a new object")
@@ -166,18 +291,25 @@ func (s *transactionStore) Create(ctx context.Context, transaction *configapi.Tr
 	transaction.Created = time.Now()
 	transaction.Updated = time.Now()
 
+	// Encode the transaction bytes.
 	bytes, err := proto.Marshal(transaction)
 	if err != nil {
 		return errors.NewInvalid("transaction encoding failed: %v", err)
 	}
 
+	// Append a new entry to the transaction log.
 	entry, err := s.transactions.Append(ctx, string(transaction.ID), bytes)
 	if err != nil {
 		return errors.FromAtomix(err)
 	}
 
-	transaction.Index = configapi.Index(entry.Index)
-	transaction.Version = uint64(entry.Revision)
+	// Decode the transaction from the returned entry bytes.
+	if err := decodeTransaction(entry, transaction); err != nil {
+		return errors.NewInvalid("transaction decoding failed: %v", err)
+	}
+
+	// Update the cache.
+	s.updateCache(transaction)
 	return nil
 }
 
@@ -192,17 +324,25 @@ func (s *transactionStore) Update(ctx context.Context, transaction *configapi.Tr
 	transaction.Revision++
 	transaction.Updated = time.Now()
 
+	// Encode the transaction bytes.
 	bytes, err := proto.Marshal(transaction)
 	if err != nil {
 		return errors.NewInvalid("change encoding failed: %v", err)
 	}
 
+	// Update the entry in the transaction log.
 	entry, err := s.transactions.Set(ctx, indexedmap.Index(transaction.Index), string(transaction.ID), bytes, indexedmap.IfMatch(meta.NewRevision(meta.Revision(transaction.Version))))
 	if err != nil {
 		return errors.FromAtomix(err)
 	}
 
-	transaction.Version = uint64(entry.Revision)
+	// Decode the transaction from the returned entry bytes.
+	if err := decodeTransaction(entry, transaction); err != nil {
+		return errors.NewInvalid("transaction decoding failed: %v", err)
+	}
+
+	// Update the cache.
+	s.updateCache(transaction)
 	return nil
 }
 
@@ -216,48 +356,25 @@ func (s *transactionStore) UpdateStatus(ctx context.Context, transaction *config
 	}
 	transaction.Updated = time.Now()
 
+	// Encode the transaction bytes.
 	bytes, err := proto.Marshal(transaction)
 	if err != nil {
 		return errors.NewInvalid("change encoding failed: %v", err)
 	}
 
+	// Update the entry in the transaction log.
 	entry, err := s.transactions.Set(ctx, indexedmap.Index(transaction.Index), string(transaction.ID), bytes, indexedmap.IfMatch(meta.NewRevision(meta.Revision(transaction.Version))))
 	if err != nil {
 		return errors.FromAtomix(err)
 	}
 
-	transaction.Version = uint64(entry.Revision)
-	return nil
-}
-
-// Delete deletes a transaction
-func (s *transactionStore) Delete(ctx context.Context, transaction *configapi.Transaction) error {
-	if transaction.Version == 0 {
-		return errors.NewInvalid("transaction must contain a version on delete")
+	// Decode the transaction from the returned entry bytes.
+	if err := decodeTransaction(entry, transaction); err != nil {
+		return errors.NewInvalid("transaction decoding failed: %v", err)
 	}
 
-	if transaction.Deleted == nil {
-		log.Debugf("Updating transaction %s", transaction.ID)
-		t := time.Now()
-		transaction.Deleted = &t
-		bytes, err := proto.Marshal(transaction)
-		if err != nil {
-			return errors.NewInvalid("transaction encoding failed: %v", err)
-		}
-		entry, err := s.transactions.Set(ctx, indexedmap.Index(transaction.Index), string(transaction.ID), bytes, indexedmap.IfMatch(meta.NewRevision(meta.Revision(transaction.Version))))
-		if err != nil {
-			return errors.FromAtomix(err)
-		}
-		transaction.Version = uint64(entry.Revision)
-	} else {
-		log.Debugf("Deleting transaction %s", transaction.ID)
-		_, err := s.transactions.RemoveIndex(ctx, indexedmap.Index(transaction.Index), indexedmap.IfMatch(meta.NewRevision(meta.Revision(transaction.Version))))
-		if err != nil {
-			log.Warnf("Failed to delete transaction %s: %s", transaction.ID, err)
-			return errors.FromAtomix(err)
-		}
-		transaction.Version = 0
-	}
+	// Update the cache.
+	s.updateCache(transaction)
 	return nil
 }
 
@@ -269,9 +386,11 @@ func (s *transactionStore) List(ctx context.Context) ([]*configapi.Transaction, 
 	}
 
 	transactions := make([]*configapi.Transaction, 0)
-
 	for entry := range indexMapCh {
-		if transaction, err := decodeTransaction(entry); err == nil {
+		transaction := &configapi.Transaction{}
+		if err := decodeTransaction(&entry, transaction); err != nil {
+			log.Error(err)
+		} else {
 			transactions = append(transactions, transaction)
 		}
 	}
@@ -280,39 +399,64 @@ func (s *transactionStore) List(ctx context.Context) ([]*configapi.Transaction, 
 
 // Watch watches the transaction store  for changes
 func (s *transactionStore) Watch(ctx context.Context, ch chan<- configapi.TransactionEvent, opts ...WatchOption) error {
-	watchOpts := make([]indexedmap.WatchOption, 0)
+	var options watchOptions
 	for _, opt := range opts {
-		watchOpts = opt.apply(watchOpts)
+		opt.apply(&options)
 	}
 
-	indexMapCh := make(chan indexedmap.Event)
-	if err := s.transactions.Watch(ctx, indexMapCh, watchOpts...); err != nil {
-		return errors.FromAtomix(err)
+	watchCh := make(chan configapi.TransactionEvent, 10)
+	id := uuid.New()
+	s.watchersMu.Lock()
+	s.watchers[id] = watchCh
+	s.watchersMu.Unlock()
+
+	var replay []configapi.TransactionEvent
+	if options.replay {
+		if options.transactionID == "" {
+			s.cacheMu.RLock()
+			replay = make([]configapi.TransactionEvent, 0, len(s.cacheIDs))
+			entry := s.firstEntry
+			for entry != nil {
+				replay = append(replay, configapi.TransactionEvent{
+					Type:        configapi.TransactionEvent_REPLAYED,
+					Transaction: *entry.Transaction,
+				})
+				entry = entry.next
+			}
+			s.cacheMu.RUnlock()
+		} else {
+			s.cacheMu.RLock()
+			entry, ok := s.cacheIDs[options.transactionID]
+			if ok {
+				replay = []configapi.TransactionEvent{
+					{
+						Type:        configapi.TransactionEvent_REPLAYED,
+						Transaction: *entry.Transaction,
+					},
+				}
+			}
+			s.cacheMu.RUnlock()
+		}
 	}
 
 	go func() {
 		defer close(ch)
-		for event := range indexMapCh {
-			if transaction, err := decodeTransaction(event.Entry); err == nil {
-				var eventType configapi.TransactionEvent_EventType
-				switch event.Type {
-				case indexedmap.EventReplay:
-					eventType = configapi.TransactionEvent_REPLAYED
-				case indexedmap.EventInsert:
-					eventType = configapi.TransactionEvent_CREATED
-				case indexedmap.EventRemove:
-					eventType = configapi.TransactionEvent_DELETED
-				case indexedmap.EventUpdate:
-					eventType = configapi.TransactionEvent_UPDATED
-				default:
-					eventType = configapi.TransactionEvent_UPDATED
-				}
-				ch <- configapi.TransactionEvent{
-					Type:        eventType,
-					Transaction: *transaction,
-				}
+		for _, event := range replay {
+			ch <- event
+		}
+		for event := range watchCh {
+			if options.transactionID == "" || event.Transaction.ID == options.transactionID {
+				ch <- event
 			}
 		}
+	}()
+
+	go func() {
+		<-ctx.Done()
+		s.watchersMu.Lock()
+		delete(s.watchers, id)
+		s.watchersMu.Unlock()
+		close(watchCh)
 	}()
 	return nil
 }
@@ -326,15 +470,14 @@ func (s *transactionStore) Close(ctx context.Context) error {
 	return nil
 }
 
-func decodeTransaction(entry indexedmap.Entry) (*configapi.Transaction, error) {
-	transaction := &configapi.Transaction{}
+func decodeTransaction(entry *indexedmap.Entry, transaction *configapi.Transaction) error {
 	if err := proto.Unmarshal(entry.Value, transaction); err != nil {
-		return nil, errors.NewInvalid("transaction decoding failed: %v", err)
+		return err
 	}
 	transaction.ID = configapi.TransactionID(entry.Key)
 	transaction.Index = configapi.Index(entry.Index)
 	transaction.Version = uint64(entry.Revision)
-	return transaction, nil
+	return nil
 }
 
 // newTransactionID creates a new transaction ID

--- a/pkg/store/transaction/store_test.go
+++ b/pkg/store/transaction/store_test.go
@@ -146,6 +146,9 @@ func TestTransactionStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, revision, transaction2.Revision)
 
+	transactionEvent = nextTransaction(t, eventCh)
+	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
+
 	event := nextEvent(t, transactionCh)
 	assert.Equal(t, transaction2.ID, event.Transaction.ID)
 	assert.Equal(t, transaction2.Revision, event.Transaction.Revision)
@@ -164,6 +167,9 @@ func TestTransactionStore(t *testing.T) {
 	err = store1.Update(context.TODO(), transaction2)
 	assert.NoError(t, err)
 	assert.NotEqual(t, revision, transaction2.Revision)
+
+	transactionEvent = nextTransaction(t, eventCh)
+	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
 
 	event = nextEvent(t, transactionCh)
 	assert.Equal(t, transaction2.ID, event.Transaction.ID)
@@ -191,11 +197,6 @@ func TestTransactionStore(t *testing.T) {
 	err = store2.Update(context.TODO(), transaction12)
 	assert.Error(t, err)
 
-	// Verify events were received again
-	transactionEvent = nextTransaction(t, eventCh)
-	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
-	transactionEvent = nextTransaction(t, eventCh)
-	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
 	transactionEvent = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.TransactionID("transaction-1"), transactionEvent.ID)
 

--- a/pkg/store/transaction/store_test.go
+++ b/pkg/store/transaction/store_test.go
@@ -19,8 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onosproject/onos-lib-go/pkg/errors"
-
 	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
 
 	"github.com/atomix/atomix-go-client/pkg/atomix/test"
@@ -52,8 +50,8 @@ func TestTransactionStore(t *testing.T) {
 	target1 := configapi.TargetID("target-1")
 	target2 := configapi.TargetID("target-2")
 
-	ch := make(chan configapi.TransactionEvent)
-	err = store2.Watch(context.Background(), ch)
+	eventCh := make(chan configapi.TransactionEvent)
+	err = store2.Watch(context.Background(), eventCh)
 	assert.NoError(t, err)
 
 	transaction1 := &configapi.Transaction{
@@ -132,9 +130,9 @@ func TestTransactionStore(t *testing.T) {
 	assert.NotEqual(t, configapi.Revision(0), transaction2.Revision)
 
 	// Verify events were received for the transactions
-	transactionEvent := nextEvent(t, ch)
+	transactionEvent := nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.TransactionID("transaction-1"), transactionEvent.ID)
-	transactionEvent = nextEvent(t, ch)
+	transactionEvent = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
 
 	// Watch events for a specific transaction
@@ -148,26 +146,9 @@ func TestTransactionStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, revision, transaction2.Revision)
 
-	event := <-transactionCh
+	event := nextEvent(t, transactionCh)
 	assert.Equal(t, transaction2.ID, event.Transaction.ID)
 	assert.Equal(t, transaction2.Revision, event.Transaction.Revision)
-
-	// Get previous and next transactions
-	transaction1, err = store2.Get(context.TODO(), "transaction-1")
-	assert.NoError(t, err)
-	assert.NotNil(t, transaction1)
-	transaction2, err = store2.GetNext(context.TODO(), transaction1.Index)
-	assert.NoError(t, err)
-	assert.NotNil(t, transaction2)
-	assert.Equal(t, configapi.Index(2), transaction2.Index)
-
-	transaction2, err = store2.Get(context.TODO(), "transaction-2")
-	assert.NoError(t, err)
-	assert.NotNil(t, transaction2)
-	transaction1, err = store2.GetPrev(context.TODO(), transaction2.Index)
-	assert.NoError(t, err)
-	assert.NotNil(t, transaction1)
-	assert.Equal(t, configapi.Index(1), transaction1.Index)
 
 	// Read and then update the transaction
 	transaction2, err = store2.Get(context.TODO(), "transaction-2")
@@ -184,7 +165,7 @@ func TestTransactionStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, revision, transaction2.Revision)
 
-	event = <-transactionCh
+	event = nextEvent(t, transactionCh)
 	assert.Equal(t, transaction2.ID, event.Transaction.ID)
 	assert.Equal(t, transaction2.Revision, event.Transaction.Revision)
 
@@ -211,11 +192,11 @@ func TestTransactionStore(t *testing.T) {
 	assert.Error(t, err)
 
 	// Verify events were received again
-	transactionEvent = nextEvent(t, ch)
+	transactionEvent = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
-	transactionEvent = nextEvent(t, ch)
+	transactionEvent = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.TransactionID("transaction-2"), transactionEvent.ID)
-	transactionEvent = nextEvent(t, ch)
+	transactionEvent = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.TransactionID("transaction-1"), transactionEvent.ID)
 
 	// List the transactions
@@ -223,27 +204,7 @@ func TestTransactionStore(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(transactions))
 
-	// Delete a transaction
-	err = store1.Delete(context.TODO(), transaction2)
-	assert.NoError(t, err)
-	transaction, err := store2.Get(context.TODO(), "transaction-2")
-	assert.NoError(t, err)
-	assert.NotNil(t, transaction.Deleted)
-	err = store1.Delete(context.TODO(), transaction2)
-	assert.NoError(t, err)
-	transaction, err = store2.Get(context.TODO(), "transaction-2")
-	assert.Error(t, err)
-	assert.True(t, errors.IsNotFound(err))
-	assert.Nil(t, transaction)
-
-	event = <-transactionCh
-	assert.Equal(t, transaction2.ID, event.Transaction.ID)
-	assert.Equal(t, configapi.TransactionEvent_UPDATED, event.Type)
-	event = <-transactionCh
-	assert.Equal(t, transaction2.ID, event.Transaction.ID)
-	assert.Equal(t, configapi.TransactionEvent_DELETED, event.Type)
-
-	transaction = &configapi.Transaction{
+	transaction := &configapi.Transaction{
 		ID: "transaction-3",
 		Details: &configapi.Transaction_Change{
 			Change: &configapi.ChangeTransaction{
@@ -289,24 +250,30 @@ func TestTransactionStore(t *testing.T) {
 	err = store1.Create(context.TODO(), transaction)
 	assert.NoError(t, err)
 
-	ch = make(chan configapi.TransactionEvent)
-	err = store1.Watch(context.TODO(), ch, WithReplay())
+	eventCh = make(chan configapi.TransactionEvent)
+	err = store1.Watch(context.TODO(), eventCh, WithReplay())
 	assert.NoError(t, err)
 
-	transaction = nextEvent(t, ch)
+	transaction = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.Index(1), transaction.Index)
-	transaction = nextEvent(t, ch)
+	transaction = nextTransaction(t, eventCh)
+	assert.Equal(t, configapi.Index(2), transaction.Index)
+	transaction = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.Index(3), transaction.Index)
-	transaction = nextEvent(t, ch)
+	transaction = nextTransaction(t, eventCh)
 	assert.Equal(t, configapi.Index(4), transaction.Index)
 }
 
-func nextEvent(t *testing.T, ch chan configapi.TransactionEvent) *configapi.Transaction {
+func nextEvent(t *testing.T, ch chan configapi.TransactionEvent) *configapi.TransactionEvent {
 	select {
-	case c := <-ch:
-		return &c.Transaction
+	case e := <-ch:
+		return &e
 	case <-time.After(5 * time.Second):
 		t.FailNow()
 	}
 	return nil
+}
+
+func nextTransaction(t *testing.T, ch chan configapi.TransactionEvent) *configapi.Transaction {
+	return &nextEvent(t, ch).Transaction
 }


### PR DESCRIPTION
This PR adds a cache and multiplexes `Watch`es in the `Transaction` store. The `Transaction` store is currently append-only, so the cache is only ever updated and entries are never removed from the cache. Because the transaction store depends on order, the cache is stored in both ordered and unordered (for random access) forms. The cache is updated on local updates, and events can be triggered to watches locally rather than waiting for a round trip to the Atomix store. This means that events may not be received for every state change, but the controllers and the northbound API depend only on the current state of the store and are not dependent on an accurate history of events from the store.