### PR TITLE
Avoid skipping  the prefix in SB + fix linter issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,7 @@ issues:
     - Error return value of `.*Flush` is not checked
     - Error return value of `.*Write` is not checked
     - Error return value of `.*Stop` is not checked
+    - "package-comments: should have a package comment"
   exclude-rules:
     - path: pkg/northbound/gnmi/set.go
       linters:

--- a/cmd/onos-config/onos-config.go
+++ b/cmd/onos-config/onos-config.go
@@ -20,7 +20,6 @@ Arguments
 
 -certPath <the location of a client certificate>
 
-
 See ../../docs/run.md for how to run the application.
 */
 package main

--- a/pkg/southbound/gnmi/client.go
+++ b/pkg/southbound/gnmi/client.go
@@ -35,7 +35,7 @@ type client struct {
 }
 
 // Subscribe calls gNMI subscription bacc
-//sed on a given query
+// sed on a given query
 func (c *client) Subscribe(ctx context.Context, q baseClient.Query) error {
 	err := c.client.Subscribe(ctx, q)
 	go c.run(ctx)

--- a/pkg/utils/gnmiPathUtils.go
+++ b/pkg/utils/gnmiPathUtils.go
@@ -141,11 +141,6 @@ func SplitPath(path string) []string {
 	for len(path) > 0 {
 		i := nextTokenIndex(path)
 		part := path[:i]
-		partsNs := strings.Split(part, ":")
-		if len(partsNs) == 2 {
-			// We have to discard the namespace as gNMI doesn't handle it
-			part = partsNs[1]
-		}
 		result = append(result, part)
 		path = path[i:]
 		if len(path) > 0 && path[0] == '/' {

--- a/pkg/utils/gnmiPathUtils_test.go
+++ b/pkg/utils/gnmiPathUtils_test.go
@@ -120,7 +120,7 @@ func Test_ParseNamespace(t *testing.T) {
 	assert.NoError(t, err, "Path with NS returns error")
 	assert.NotNil(t, parsed, "path with NS returns nil")
 
-	checkElement(t, parsed, 0, "a", "x", "y")
+	checkElement(t, parsed, 0, "ns:a", "x", "y")
 }
 
 func Test_StrPath(t *testing.T) {


### PR DESCRIPTION
since having prefix is optionally added to the plugin that can be controlled at runtime, we don't need to discard prefix in util function (I should see what would be effect of this change). If the path in the change has prefix should be included in the SB request otherwise it won't. @SeanCondon  what do you think? 