### PR TITLE
Store mastership term/master in Configuration store

### DIFF
--- a/pkg/controller/mastership/controller.go
+++ b/pkg/controller/mastership/controller.go
@@ -6,7 +6,9 @@ package mastership
 
 import (
 	"context"
+	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
 	"github.com/onosproject/onos-config/pkg/controller/utils"
+	"github.com/onosproject/onos-config/pkg/store/configuration"
 	"math/rand"
 	"time"
 
@@ -24,21 +26,25 @@ const defaultTimeout = 30 * time.Second
 var log = logging.GetLogger("controller", "mastership")
 
 // NewController returns a new mastership controller
-func NewController(topo topo.Store) *controller.Controller {
+func NewController(topo topo.Store, configurations configuration.Store) *controller.Controller {
 	c := controller.NewController("mastership")
 	c.Watch(&TopoWatcher{
 		topo: topo,
 	})
-
+	c.Watch(&ConfigurationStoreWatcher{
+		configurations: configurations,
+	})
 	c.Reconcile(&Reconciler{
-		topo: topo,
+		topo:           topo,
+		configurations: configurations,
 	})
 	return c
 }
 
 // Reconciler is mastership reconciler
 type Reconciler struct {
-	topo topo.Store
+	topo           topo.Store
+	configurations configuration.Store
 }
 
 // Reconcile reconciles the mastership state for a gnmi target
@@ -54,6 +60,24 @@ func (r *Reconciler) Reconcile(id controller.ID) (controller.Result, error) {
 			return controller.Result{}, nil
 		}
 		log.Warnf("Failed to reconcile mastership election for the gNMI target with ID %s: %s", targetEntity.ID, err)
+		return controller.Result{}, err
+	}
+
+	configurable := &topoapi.Configurable{}
+	if err = targetEntity.GetAspect(configurable); err != nil {
+		log.Warnf("Failed to reconcile mastership election for target with ID %s: %s", targetEntity.ID, err)
+		return controller.Result{}, err
+	}
+
+	configID := configuration.NewID(
+		configapi.TargetID(targetEntity.ID),
+		configapi.TargetType(configurable.Type),
+		configapi.TargetVersion(configurable.Version))
+	config, err := r.configurations.Get(ctx, configID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return controller.Result{}, nil
+		}
 		return controller.Result{}, err
 	}
 
@@ -76,15 +100,13 @@ func (r *Reconciler) Reconcile(id controller.ID) (controller.Result, error) {
 		}
 	}
 
-	mastership := &topoapi.MastershipState{}
-	_ = targetEntity.GetAspect(mastership)
-	if _, ok := targetRelations[topoapi.ID(mastership.NodeId)]; !ok {
+	if _, ok := targetRelations[topoapi.ID(config.Status.Mastership.Master)]; !ok {
 		if len(targetRelations) == 0 {
-			if mastership.NodeId == "" {
+			if config.Status.Mastership.Master == "" {
 				return controller.Result{}, nil
 			}
-			log.Infof("Master in term %d resigned for the gNMI target '%s'", mastership.Term, targetEntity.GetID())
-			mastership.NodeId = ""
+			log.Infof("Master in term %d resigned for the gNMI target '%s'", config.Status.Mastership.Term, targetEntity.GetID())
+			config.Status.Mastership.Master = ""
 		} else {
 			// Select a random master to assign to the gnmi target
 			relations := make([]topoapi.Object, 0, len(targetRelations))
@@ -94,22 +116,16 @@ func (r *Reconciler) Reconcile(id controller.ID) (controller.Result, error) {
 			relation := relations[rand.Intn(len(relations))]
 
 			// Increment the mastership term and assign the selected master
-			mastership.Term++
-			mastership.NodeId = string(relation.ID)
-			log.Infof("Elected new master '%s' in term %d for the gNMI target '%s'", mastership.NodeId, mastership.Term, targetEntity.GetID())
+			config.Status.Mastership.Term++
+			config.Status.Mastership.Master = string(relation.ID)
+			log.Infof("Elected new master '%s' in term %d for the gNMI target '%s'", config.Status.Mastership.Master, config.Status.Mastership.Term, targetEntity.GetID())
 		}
 
-		err = targetEntity.SetAspect(mastership)
-		if err != nil {
-			log.Warnf("Updating MastershipState for gNMI target '%s' failed: %v", targetEntity.GetID(), err)
-			return controller.Result{}, err
-		}
-
-		// Update the gNMI target entity
-		err = r.topo.Update(ctx, targetEntity)
+		// Update the Configuration status
+		err = r.configurations.UpdateStatus(ctx, config)
 		if err != nil {
 			if !errors.IsNotFound(err) && !errors.IsConflict(err) {
-				log.Warnf("Updating MastershipState for gNMI target '%s' failed: %v", targetEntity.GetID(), err)
+				log.Warnf("Updating mastership for gNMI target '%s' failed: %v", targetEntity.GetID(), err)
 				return controller.Result{}, err
 			}
 			return controller.Result{}, nil

--- a/pkg/controller/mastership/watcher.go
+++ b/pkg/controller/mastership/watcher.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	configapi "github.com/onosproject/onos-api/go/onos/config/v2"
 	"github.com/onosproject/onos-config/pkg/store/configuration"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
 	"sync"
 
 	"github.com/onosproject/onos-config/pkg/store/topo"
@@ -44,29 +45,64 @@ func (w *TopoWatcher) Start(ch chan<- controller.ID) error {
 	w.cancel = cancel
 
 	go func() {
+		defer close(ch)
 		for event := range eventCh {
 			log.Debugf("Received topo event '%s'", event.Object.ID)
-			if relation, ok := event.Object.Obj.(*topoapi.Object_Relation); ok &&
-				relation.Relation.KindID == topoapi.CONTROLS {
-				srcEntity, err := w.topo.Get(ctx, relation.Relation.SrcEntityID)
+			switch e := event.Object.Obj.(type) {
+			// If the event is a relation change and the source is ONOS_CONFIG kind, enqueue the target
+			// Configuration to be reconciled.
+			case *topoapi.Object_Relation:
+				// Get the source entity
+				srcEntity, err := w.topo.Get(ctx, e.Relation.SrcEntityID)
 				if err != nil {
-					log.Warn(err)
-				} else if srcEntity.GetEntity().KindID == topoapi.ONOS_CONFIG {
-					ch <- controller.NewID(relation.Relation.TgtEntityID)
+					if !errors.IsNotFound(err) {
+						log.Warn(err)
+					}
+					continue
 				}
 
-			}
-			if _, ok := event.Object.Obj.(*topoapi.Object_Entity); ok {
-				// If the entity object has configurable aspect then the controller
-				// can make a connection to it
-				err = event.Object.GetAspect(&topoapi.Configurable{})
-				if err == nil {
-					ch <- controller.NewID(event.Object.ID)
+				// Check that the source is ONOS_CONFIG kind
+				if srcEntity.GetEntity().KindID != topoapi.ONOS_CONFIG {
+					continue
 				}
-			}
 
+				// Get the target entity
+				tgtEntity, err := w.topo.Get(ctx, e.Relation.TgtEntityID)
+				if err != nil {
+					if !errors.IsNotFound(err) {
+						log.Warn(err)
+					}
+					continue
+				}
+
+				// Check that the target has the Configurable aspect
+				configurable := &topoapi.Configurable{}
+				if err := tgtEntity.GetAspect(configurable); err != nil {
+					continue
+				}
+
+				// Enqueue the associated Configuration for reconciliation
+				ch <- controller.NewID(configuration.NewID(
+					configapi.TargetID(tgtEntity.ID),
+					configapi.TargetType(configurable.Type),
+					configapi.TargetVersion(configurable.Version)))
+
+			// If the event is an entity change and the entity has a Configurable aspect, enqueue the
+			// associated Configuration for reconciliation.
+			case *topoapi.Object_Entity:
+				// Check that the entity has the Configurable aspect
+				configurable := &topoapi.Configurable{}
+				if err := event.Object.GetAspect(configurable); err != nil {
+					continue
+				}
+
+				// Enqueue the associated Configuration for reconciliation
+				ch <- controller.NewID(configuration.NewID(
+					configapi.TargetID(event.Object.ID),
+					configapi.TargetType(configurable.Type),
+					configapi.TargetVersion(configurable.Version)))
+			}
 		}
-		close(ch)
 	}()
 
 	return nil
@@ -108,7 +144,7 @@ func (w *ConfigurationStoreWatcher) Start(ch chan<- controller.ID) error {
 	w.cancel = cancel
 	go func() {
 		for event := range eventCh {
-			ch <- controller.NewID(topoapi.ID(event.Configuration.TargetID))
+			ch <- controller.NewID(event.Configuration.ID)
 		}
 	}()
 	return nil

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -134,8 +134,8 @@ func (m *Manager) startTargetController(topo topo.Store, conns sb.ConnManager) e
 }
 
 // startMastershipController starts mastership controller
-func (m *Manager) startMastershipController(topo topo.Store) error {
-	mastershipController := mastershipcontroller.NewController(topo)
+func (m *Manager) startMastershipController(topo topo.Store, configurations configuration.Store) error {
+	mastershipController := mastershipcontroller.NewController(topo, configurations)
 	return mastershipController.Start()
 }
 
@@ -222,7 +222,7 @@ func (m *Manager) Start() error {
 		return err
 	}
 
-	err = m.startMastershipController(topoStore)
+	err = m.startMastershipController(topoStore, configurations)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses #1626 by moving the persistence of the mastership term to the `Configuration` store. State in the `Configuration` store is never deleted and thus cannot be lost e.g. after µONOS is uninstalled and reinstalled.