### PR TITLE
Add model based test engine

### DIFF
--- a/internal/controller/model/state.go
+++ b/internal/controller/model/state.go
@@ -79,6 +79,7 @@ const (
 // TransactionStatus indicates the status of a transaction within a phase
 type TransactionStatus string
 
+// UnmarshalJSON  implements the Unmarshaler interface
 func (s *TransactionStatus) UnmarshalJSON(data []byte) error {
 	var value string
 	if err := json.Unmarshal(data, &value); err != nil {
@@ -108,6 +109,7 @@ const (
 // Transactions is a mapping of transaction indexes to transactions
 type Transactions map[Index]Transaction
 
+// UnmarshalJSON  implements the Unmarshaler interface
 func (t *Transactions) UnmarshalJSON(data []byte) error {
 	var list []Transaction
 	if err := json.Unmarshal(data, &list); err == nil {
@@ -154,6 +156,7 @@ type TransactionPhase struct {
 // Values is a change/rollback values map
 type Values map[string]string
 
+// UnmarshalJSON  implements the Unmarshaler interface
 func (s *Values) UnmarshalJSON(data []byte) error {
 	var list []any
 	if err := json.Unmarshal(data, &list); err != nil {
@@ -173,6 +176,7 @@ func (s *Values) UnmarshalJSON(data []byte) error {
 // Value is a change/rollback value
 type Value string
 
+// UnmarshalJSON  implements the Unmarshaler interface
 func (s *Value) UnmarshalJSON(data []byte) error {
 	var value string
 	if err := json.Unmarshal(data, &value); err != nil {

--- a/internal/controller/model/state.go
+++ b/internal/controller/model/state.go
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"encoding/json"
+)
+
+const nilString = "<nil>"
+
+type Index uint64
+
+type Ordinal uint64
+
+type Revision uint64
+
+type Term uint64
+
+type NodeID string
+
+type ConnID int
+
+type Conns map[NodeID]Conn
+
+type Conn struct {
+	ID        ConnID `json:"id"`
+	Connected bool   `json:"connected"`
+}
+
+type Target struct {
+	ID      int    `json:"id"`
+	Values  Values `json:"values"`
+	Running bool   `json:"running"`
+}
+
+type EventType string
+
+const (
+	CommitEvent EventType = "Commit"
+	ApplyEvent  EventType = "Apply"
+)
+
+type TransactionEvent struct {
+	Index  Index              `json:"index"`
+	Phase  TransactionPhaseID `json:"phase"`
+	Event  EventType          `json:"event"`
+	Status TransactionState   `json:"status"`
+}
+
+type TransactionPhaseID string
+
+const (
+	TransactionPhaseChange   TransactionPhaseID = "Change"
+	TransactionPhaseRollback TransactionPhaseID = "Rollback"
+)
+
+type TransactionState string
+
+func (s *TransactionState) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	if value != nilString {
+		*s = TransactionState(value)
+	}
+	return nil
+}
+
+const (
+	TransactionPending    TransactionState = "Pending"
+	TransactionInProgress TransactionState = "InProgress"
+	TransactionComplete   TransactionState = "Complete"
+	TransactionAborted    TransactionState = "Aborted"
+	TransactionCanceled   TransactionState = "Canceled"
+	TransactionFailed     TransactionState = "Failed"
+)
+
+type Transactions map[Index]Transaction
+
+func (t *Transactions) UnmarshalJSON(data []byte) error {
+	var list []Transaction
+	if err := json.Unmarshal(data, &list); err == nil {
+		transactions := make(Transactions)
+		for _, transaction := range list {
+			transactions[transaction.Index] = transaction
+		}
+		*t = transactions
+		return nil
+	}
+	obj := make(map[Index]Transaction)
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	transactions := make(Transactions)
+	for _, transaction := range obj {
+		transactions[transaction.Index] = transaction
+	}
+	*t = transactions
+	return nil
+}
+
+type Transaction struct {
+	Index    Index              `json:"index"`
+	Phase    TransactionPhaseID `json:"phase"`
+	Change   TransactionPhase   `json:"change"`
+	Rollback TransactionPhase   `json:"rollback"`
+}
+
+type TransactionPhase struct {
+	Index   Index             `json:"index"`
+	Ordinal Ordinal           `json:"ordinal"`
+	Values  Values            `json:"values"`
+	Commit  *TransactionState `json:"commit"`
+	Apply   *TransactionState `json:"apply"`
+}
+
+type Values map[string]string
+
+func (s *Values) UnmarshalJSON(data []byte) error {
+	var list []any
+	if err := json.Unmarshal(data, &list); err != nil {
+		values := make(map[string]string)
+		if err := json.Unmarshal(data, &values); err != nil {
+			return err
+		}
+		state := make(Values)
+		for key, value := range values {
+			state[key] = value
+		}
+		*s = state
+	}
+	return nil
+}
+
+type Value string
+
+func (s *Value) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	if value != nilString {
+		*s = Value(value)
+	}
+	return nil
+}
+
+type Configuration struct {
+	State     ConfigurationState     `json:"state"`
+	Term      Term                   `json:"term"`
+	Committed ConfigurationCommitted `json:"committed"`
+	Applied   ConfigurationApplied   `json:"applied"`
+}
+
+type ConfigurationCommitted struct {
+	Index    Index    `json:"index"`
+	Change   Index    `json:"change"`
+	Ordinal  Ordinal  `json:"ordinal"`
+	Revision Revision `json:"revision"`
+	Target   Index    `json:"target"`
+	Term     Term     `json:"term"`
+	Values   Values   `json:"values"`
+}
+
+type ConfigurationApplied struct {
+	Index    Index    `json:"index"`
+	Ordinal  Ordinal  `json:"ordinal"`
+	Revision Revision `json:"revision"`
+	Target   Index    `json:"target"`
+	Values   Values   `json:"values"`
+}
+
+type ConfigurationState string
+
+const (
+	ConfigurationPending  ConfigurationState = "Pending"
+	ConfigurationComplete ConfigurationState = "Complete"
+)
+
+type Mastership struct {
+	Term   Term   `json:"term"`
+	Master NodeID `json:"master"`
+}

--- a/internal/controller/model/test.go
+++ b/internal/controller/model/test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package model
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"github.com/onosproject/onos-lib-go/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"os"
+	"testing"
+)
+
+// RunTests runs the tests in the given model-based test case file
+// The parameters S and C define the test state and test context structs respectively.
+// For each test in the file, the given function f will be called with the TestCase
+// populated with the initial state, transitions, and the context in which those
+// transitions occurred.
+func RunTests[S, C any](t *testing.T, path string, f func(*testing.T, TestCase[S, C])) {
+	t.Helper()
+
+	file, err := os.Open(path)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	reader, err := NewTestReader[S, C](file)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	i := 0
+	for {
+		i++
+		testCase, err := reader.Next()
+		if err == io.EOF {
+			break
+		}
+		if !assert.NoError(t, err) {
+			break
+		}
+		testName := fmt.Sprintf("%s%d", t.Name(), i)
+		ok := t.Run(testName, func(t *testing.T) {
+			f(t, testCase)
+		})
+		if !ok {
+			break
+		}
+	}
+}
+
+// TestCase is a model-based test case containing the state and changes expected in a single step of the model.
+type TestCase[S, C any] struct {
+	Context     C `json:"context"`
+	State       S `json:"state"`
+	Transitions S `json:"transitions"`
+}
+
+// NewTestReader creates a new TestReader that reads the given Reader.
+func NewTestReader[S, C any](file io.Reader) (*TestReader[S, C], error) {
+	gzfile, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+
+	tarfile := tar.NewReader(gzfile)
+
+	header, err := tarfile.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	switch header.Typeflag {
+	case tar.TypeReg:
+		scanner := bufio.NewScanner(tarfile)
+		return &TestReader[S, C]{
+			scanner: scanner,
+			hashes:  make(map[string]bool),
+		}, nil
+	default:
+		return nil, errors.NewInternal("malformed test file")
+	}
+}
+
+// TestReader reads and deduplicates TestCases from an input file.
+type TestReader[S, C any] struct {
+	scanner *bufio.Scanner
+	hashes  map[string]bool
+}
+
+// Next gets the next TestCase in the file.
+// If the test case is a duplicate of a test case that was already read from the file, the reader
+// will continue reading until it either finds a unique test case or reaches the end of the file.
+func (r *TestReader[S, C]) Next() (TestCase[S, C], error) {
+	for {
+		testCase, ok, err := r.read()
+		if err != nil {
+			return testCase, err
+		} else if ok {
+			return testCase, nil
+		}
+	}
+}
+
+func (r *TestReader[S, C]) unique(bytes []byte) bool {
+	hash := md5.Sum(bytes)
+	key := hex.EncodeToString(hash[:])
+	_, ok := r.hashes[key]
+	if !ok {
+		r.hashes[key] = true
+		return true
+	}
+	return false
+}
+
+func (r *TestReader[S, C]) read() (TestCase[S, C], bool, error) {
+	var testCase TestCase[S, C]
+	if !r.scanner.Scan() {
+		return testCase, false, io.EOF
+	}
+	bytes := r.scanner.Bytes()
+	if !r.unique(bytes) {
+		return testCase, false, nil
+	}
+	if err := json.Unmarshal(bytes, &testCase); err != nil {
+		return testCase, false, err
+	}
+	return testCase, true, nil
+}


### PR DESCRIPTION
This PR adds the engine for running unit tests generated by the TLC model. Tests are run by defining a test state and context struct and then calling `RunTests`. Once #1656 is merged, I will submit an additional PR adding the tests to the controllers.